### PR TITLE
Extract protocol logic, switch Supabase sync to normalized tables, and add tests/docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.DS_Store

--- a/PROJECT_REVIEW.md
+++ b/PROJECT_REVIEW.md
@@ -1,0 +1,30 @@
+# PawTimer Project Review (Updated)
+
+This file tracks the major issues found during review and their status.
+
+## ✅ Fixed in code
+
+1. **Supabase schema mismatch fixed**
+   - App sync now uses normalized Supabase tables (`sessions`, `walks`, `patterns`) instead of a non-existent `activities` table.
+
+2. **Remote delete behavior improved**
+   - Deleting single history items now deletes from the correct remote table.
+   - "Clear sessions" now also performs remote delete by `dog_id`.
+
+3. **Documentation drift reduced**
+   - README now documents optional Supabase sync and explicit GitHub/Vercel + Supabase setup steps.
+
+4. **Protocol logic extracted for testability**
+   - Core progression logic moved to `src/lib/protocol.js`.
+
+## ⚠️ Still recommended next
+
+1. **RLS hardening**
+   - Current policies intentionally allow broad anon access for easy partner sharing.
+   - For production privacy, move to stricter row-level policies (dog secret or authenticated users).
+
+2. **Component size refactor**
+   - `src/App.jsx` is still large and should be split by feature over time.
+
+3. **CI quality checks**
+   - Add CI workflow in GitHub Actions to run `npm run build` and tests on every PR.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ PawTimer guides you through a science-based separation anxiety training method:
 - 📈 **Smart progression engine** — increases time on success, holds on mild distress, reverts on strong distress
 - 📊 **Statistics** — total sessions, distress breakdown, best time, streak counter, progress chart
 - 💡 **Training tips** — evidence-based guidance personalised with your dog's name
-- 💾 **No backend needed** — all data saved in your browser's localStorage
+- 💾 **Works offline with localStorage**
+- ☁️ **Optional Supabase sync** — share one dog profile across devices using the same Dog ID
 
 ---
 
@@ -34,7 +35,7 @@ PawTimer guides you through a science-based separation anxiety training method:
 | Frontend | React (Vite) |
 | Charts | Recharts |
 | Styling | Plain CSS-in-JS |
-| Storage | localStorage |
+| Storage | localStorage + optional Supabase |
 | Deployment | Vercel / Netlify |
 
 ---
@@ -81,7 +82,35 @@ pawtimer/
 
 ---
 
-## Deploying for free
+## Deploying with GitHub + Vercel
+
+1. Create a GitHub repository and push this project.
+2. Import the repository into Vercel.
+3. Deploy once without environment variables (local-only mode works immediately).
+4. (Optional) Add Supabase environment variables in Vercel project settings:
+   - `VITE_SUPABASE_URL`
+   - `VITE_SUPABASE_ANON_KEY`
+5. Redeploy.
+
+---
+
+## Supabase setup (optional cloud sync)
+
+1. Create a new Supabase project.
+2. Open **SQL Editor** → run `supabase_setup.sql` from this repository.
+3. In Supabase project settings, copy:
+   - Project URL
+   - Anon public key
+4. Add both values as Vercel environment variables:
+   - `VITE_SUPABASE_URL`
+   - `VITE_SUPABASE_ANON_KEY`
+5. Redeploy your app.
+
+> The app still works without Supabase — cloud sync is optional.
+
+---
+
+## Deploying for free (alternative)
 
 ### Vercel (recommended)
 
@@ -129,8 +158,6 @@ This app is based on the gradual desensitisation method for separation anxiety:
 ## Future improvements
 
 - 🔔 Browser push notifications for daily reminders
-- 📱 PWA support (install on phone, works offline)
-- ☁️ Cloud sync across devices (via Supabase)
 - 📤 Export session history to CSV
 - 📷 Photo log per session
 - 🌙 Dark mode

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.43.0",
@@ -18,6 +19,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "vite": "^5.2.0",
     "vite-plugin-pwa": "^0.20.0",
-    "workbox-window": "^7.1.0"
+    "workbox-window": "^7.1.0",
+    "vitest": "^2.1.8"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { PROTOCOL, getNextDurationSeconds, suggestNext } from "./lib/protocol";
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid,
   Tooltip, ResponsiveContainer, ReferenceLine,
@@ -57,30 +58,68 @@ const mergeById = (a = [], b = []) => {
 };
 
 const syncFetch = async (dogId) => {
-  const rows = await sbReq(`activities?dog_id=eq.${encodeURIComponent(dogId)}&select=kind,data`);
-  if (!Array.isArray(rows)) return null;
+  const [sessRows, walkRows, patRows] = await Promise.all([
+    sbReq(`sessions?dog_id=eq.${encodeURIComponent(dogId)}&select=id,date,planned_duration,actual_duration,distress_level,result&order=date.asc`),
+    sbReq(`walks?dog_id=eq.${encodeURIComponent(dogId)}&select=id,date,duration&order=date.asc`),
+    sbReq(`patterns?dog_id=eq.${encodeURIComponent(dogId)}&select=id,date,type&order=date.asc`),
+  ]);
+  if (!Array.isArray(sessRows) || !Array.isArray(walkRows) || !Array.isArray(patRows)) return null;
   return {
-    sessions: rows.filter(r => r.kind === "session").map(r => r.data),
-    walks:    rows.filter(r => r.kind === "walk").map(r => r.data),
-    patterns: rows.filter(r => r.kind === "pattern").map(r => r.data),
+    sessions: sessRows.map((r) => ({
+      id: r.id,
+      date: r.date,
+      plannedDuration: r.planned_duration,
+      actualDuration: r.actual_duration,
+      distressLevel: r.distress_level,
+      result: r.result,
+    })),
+    walks: walkRows.map((r) => ({ id: r.id, date: r.date, duration: r.duration })),
+    patterns: patRows.map((r) => ({ id: r.id, date: r.date, type: r.type })),
   };
 };
 
 const syncPush = async (dogId, kind, data) => {
-  const result = await sbReq("activities", {
+  const table = kind === "session" ? "sessions" : kind === "walk" ? "walks" : "patterns";
+  const row = kind === "session"
+    ? {
+        id: String(data.id),
+        dog_id: dogId,
+        date: data.date,
+        planned_duration: data.plannedDuration,
+        actual_duration: data.actualDuration,
+        distress_level: data.distressLevel,
+        result: data.result,
+      }
+    : kind === "walk"
+      ? {
+          id: String(data.id),
+          dog_id: dogId,
+          date: data.date,
+          duration: data.duration,
+        }
+      : {
+          id: String(data.id),
+          dog_id: dogId,
+          date: data.date,
+          type: data.type,
+        };
+
+  const result = await sbReq(table, {
     method: "POST",
-    body: JSON.stringify({ id: String(data.id), dog_id: dogId, kind, data }),
+    body: JSON.stringify(row),
     prefer: "resolution=merge-duplicates",
   });
-  if (result === null) {
-    console.error("syncPush FAILED — kind:", kind, "id:", data.id);
-    return false;
-  }
-  console.log("syncPush OK — kind:", kind, "id:", data.id);
+  if (result === null) return false;
   return true;
 };
 
-const syncDelete = (id) => sbReq(`activities?id=eq.${String(id)}`, { method: "DELETE" });
+const syncDelete = (kind, id) => {
+  const table = kind === "session" ? "sessions" : kind === "walk" ? "walks" : "patterns";
+  return sbReq(`${table}?id=eq.${String(id)}`, { method: "DELETE" });
+};
+
+const syncDeleteSessionsForDog = (dogId) =>
+  sbReq(`sessions?dog_id=eq.${encodeURIComponent(dogId)}`, { method: "DELETE" });
 
 // ─── Dog ID: up to 6-letter prefix + 4-digit number (e.g. LUNA-4829) ─────────
 const generateId = (name) => {
@@ -102,85 +141,6 @@ const fmtDate = (iso) => {
   return `${date} · ${time}`;
 };
 const isToday = (iso) => new Date(iso).toDateString() === new Date().toDateString();
-
-// ═══════════════════════════════════════════════════════════════════════════════
-// PROTOCOL LOGIC — mirrors protocolConfig exactly
-// ═══════════════════════════════════════════════════════════════════════════════
-const PROTOCOL = {
-  sessionsPerDayDefault:                    1,
-  sessionsPerDayMax:                        5,
-  trainingDaysPerWeekDefault:               5,
-  restDaysPerWeekMin:                       1,
-  restDaysPerWeekRecommended:               2,
-  startDurationSeconds:                     30,
-  incrementPercentMin:                      10,
-  incrementPercentMax:                      20,
-  incrementPercentDefault:                  15,
-  microstepCeilingMinutes:                  40,
-  maxDailyAloneMinutes:                     30,
-  desensitizationBlocksPerDayRecommendedMin: 3,
-  desensitizationBlocksPerDayRecommendedMax: 5,
-  desensitizationBlocksPerDayMax:           12,
-  cuesPerBlockMin:                          2,
-  cuesPerBlockMax:                          5,
-  minPauseBetweenBlocksMinutes:             30,
-};
-
-/** Next duration after a SUCCESSFUL session. */
-function getNextDurationSeconds(lastSuccessfulDurationSec) {
-  if (!lastSuccessfulDurationSec || lastSuccessfulDurationSec <= 0)
-    return PROTOCOL.startDurationSeconds;
-  const lastMin = lastSuccessfulDurationSec / 60;
-  if (lastMin <= PROTOCOL.microstepCeilingMinutes) {
-    const next = Math.round(lastSuccessfulDurationSec * (1 + PROTOCOL.incrementPercentDefault / 100));
-    return next;
-  }
-  // Above 40-min ceiling → fixed +5-min steps
-  return Math.round((lastMin + 5) * 60);
-}
-
-/**
- * Given the full sessions array and the dog profile, return the next planned
- * duration in seconds.
- *
- * Rules (from protocol):
- *   • No history       → startDurationSeconds (or 80% of currentMaxCalm if set)
- *   • Last = "none"    → +incrementPercentDefault% (up to 40 min ceiling, then +5 min)
- *   • Last = "mild"    → hold (same plannedDuration)
- *   • Last = "strong"  → roll back to 1–2 successful sessions ago
- */
-function suggestNext(sessions, dog) {
-  const goalSec = dog?.goalSeconds ?? 7200;
-  if (!sessions.length) {
-    const start = dog?.currentMaxCalm
-      ? Math.round(dog.currentMaxCalm * 0.8)
-      : PROTOCOL.startDurationSeconds;
-    return Math.max(start, PROTOCOL.startDurationSeconds);
-  }
-
-  const last = sessions[sessions.length - 1];
-  const successful = sessions.filter(s => s.distressLevel === "none");
-
-  if (last.distressLevel === "none") {
-    // Only step up if the dog actually stayed for the full planned time
-    const completed = (last.actualDuration || 0) >= (last.plannedDuration || 0);
-    if (completed) {
-      const next = getNextDurationSeconds(last.plannedDuration);
-      return Math.min(next, goalSec);
-    }
-    // Ended early — hold at same duration
-    return last.plannedDuration;
-  }
-
-  if (last.distressLevel === "mild") {
-    return last.plannedDuration; // hold
-  }
-
-  // strong distress → rollback 1–2 successful steps
-  if (!successful.length) return PROTOCOL.startDurationSeconds;
-  const rollbackIdx = Math.max(successful.length - 2, 0);
-  return Math.max(successful[rollbackIdx].plannedDuration, PROTOCOL.startDurationSeconds);
-}
 
 /**
  * Returns daily session info. No hard limits — just advisory warnings.
@@ -1781,7 +1741,12 @@ export default function PawTimer() {
               {sessions.length > 0 && (
                 <button className="clear-btn" onClick={() => {
                   if (window.confirm("Clear all training sessions?")) {
-                    setSessions([]); setTarget(suggestNext([], dog)); showToast("Sessions cleared");
+                    setSessions([]);
+                    setTarget(suggestNext([], dog));
+                    syncDeleteSessionsForDog(activeDogId).then((ok) => {
+                      if (ok === null) showToast("⚠️ Sessions cleared locally — remote delete failed");
+                      else showToast("Sessions cleared");
+                    });
                   }
                 }}>Clear sessions</button>
               )}
@@ -1807,7 +1772,7 @@ export default function PawTimer() {
                       <div className="h-date">{fmtDate(s.date)}</div>
                     </div>
                     <span className={`h-badge badge-${lv}`}>{distressLabel(lv)}</span>
-                    <button className="h-del" onClick={() => { setSessions(prev => prev.filter(x => x.id !== s.id)); syncDelete(s.id); }} title="Delete">✕</button>
+                    <button className="h-del" onClick={() => { setSessions(prev => prev.filter(x => x.id !== s.id)); syncDelete("session", s.id); }} title="Delete">✕</button>
                   </div>
                 );
               }
@@ -1821,7 +1786,7 @@ export default function PawTimer() {
                       <div className="h-date">{fmtDate(w.date)}</div>
                     </div>
                     <span className="h-badge badge-walk">Walk</span>
-                    <button className="h-del" onClick={() => { setWalks(prev => prev.filter(x => x.id !== w.id)); syncDelete(w.id); }} title="Delete">✕</button>
+                    <button className="h-del" onClick={() => { setWalks(prev => prev.filter(x => x.id !== w.id)); syncDelete("walk", w.id); }} title="Delete">✕</button>
                   </div>
                 );
               }
@@ -1836,7 +1801,7 @@ export default function PawTimer() {
                       <div className="h-date">{fmtDate(p.date)}</div>
                     </div>
                     <span className="h-badge badge-pat">Pattern break</span>
-                    <button className="h-del" onClick={() => { setPatterns(prev => prev.filter(x => x.id !== p.id)); syncDelete(p.id); }} title="Delete">✕</button>
+                    <button className="h-del" onClick={() => { setPatterns(prev => prev.filter(x => x.id !== p.id)); syncDelete("pattern", p.id); }} title="Delete">✕</button>
                   </div>
                 );
               }

--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -1,0 +1,57 @@
+export const PROTOCOL = {
+  sessionsPerDayDefault:                    1,
+  sessionsPerDayMax:                        5,
+  trainingDaysPerWeekDefault:               5,
+  restDaysPerWeekMin:                       1,
+  restDaysPerWeekRecommended:               2,
+  startDurationSeconds:                     30,
+  incrementPercentMin:                      10,
+  incrementPercentMax:                      20,
+  incrementPercentDefault:                  15,
+  microstepCeilingMinutes:                  40,
+  maxDailyAloneMinutes:                     30,
+  desensitizationBlocksPerDayRecommendedMin: 3,
+  desensitizationBlocksPerDayRecommendedMax: 5,
+  desensitizationBlocksPerDayMax:           12,
+  cuesPerBlockMin:                          2,
+  cuesPerBlockMax:                          5,
+  minPauseBetweenBlocksMinutes:             30,
+};
+
+export function getNextDurationSeconds(lastSuccessfulDurationSec) {
+  if (!lastSuccessfulDurationSec || lastSuccessfulDurationSec <= 0)
+    return PROTOCOL.startDurationSeconds;
+  const lastMin = lastSuccessfulDurationSec / 60;
+  if (lastMin <= PROTOCOL.microstepCeilingMinutes) {
+    return Math.round(lastSuccessfulDurationSec * (1 + PROTOCOL.incrementPercentDefault / 100));
+  }
+  return Math.round((lastMin + 5) * 60);
+}
+
+export function suggestNext(sessions, dog) {
+  const goalSec = dog?.goalSeconds ?? 7200;
+  if (!sessions.length) {
+    const start = dog?.currentMaxCalm
+      ? Math.round(dog.currentMaxCalm * 0.8)
+      : PROTOCOL.startDurationSeconds;
+    return Math.max(start, PROTOCOL.startDurationSeconds);
+  }
+
+  const last = sessions[sessions.length - 1];
+  const successful = sessions.filter((s) => s.distressLevel === "none");
+
+  if (last.distressLevel === "none") {
+    const completed = (last.actualDuration || 0) >= (last.plannedDuration || 0);
+    if (completed) {
+      const next = getNextDurationSeconds(last.plannedDuration);
+      return Math.min(next, goalSec);
+    }
+    return last.plannedDuration;
+  }
+
+  if (last.distressLevel === "mild") return last.plannedDuration;
+
+  if (!successful.length) return PROTOCOL.startDurationSeconds;
+  const rollbackIdx = Math.max(successful.length - 2, 0);
+  return Math.max(successful[rollbackIdx].plannedDuration, PROTOCOL.startDurationSeconds);
+}

--- a/supabase_setup.sql
+++ b/supabase_setup.sql
@@ -27,12 +27,23 @@ create table if not exists walks (
   id         text primary key,        -- e.g. "walk-LUNA-4829-1712345678000"
   dog_id     text not null references dogs(id) on delete cascade,
   date       timestamptz not null,
+  duration   integer not null default 0, -- seconds
+  created_at timestamptz default now()
+);
+
+-- 4. Pattern-break table — one row per desensitization cue log
+create table if not exists patterns (
+  id         text primary key,
+  dog_id     text not null references dogs(id) on delete cascade,
+  date       timestamptz not null,
+  type       text not null check (type in ('keys', 'shoes', 'jacket')),
   created_at timestamptz default now()
 );
 
 -- Indexes for fast lookups by dog
 create index if not exists sessions_dog_id_idx on sessions(dog_id);
 create index if not exists walks_dog_id_idx    on walks(dog_id);
+create index if not exists patterns_dog_id_idx on patterns(dog_id);
 
 -- ============================================================
 -- Row Level Security (RLS)
@@ -44,8 +55,10 @@ create index if not exists walks_dog_id_idx    on walks(dog_id);
 alter table dogs     enable row level security;
 alter table sessions enable row level security;
 alter table walks    enable row level security;
+alter table patterns enable row level security;
 
 -- Allow all operations via the anon key (public, ID-gated access)
 create policy "Public dog access"      on dogs     for all using (true) with check (true);
 create policy "Public session access"  on sessions for all using (true) with check (true);
 create policy "Public walk access"     on walks    for all using (true) with check (true);
+create policy "Public pattern access"  on patterns for all using (true) with check (true);

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { getNextDurationSeconds, suggestNext, PROTOCOL } from "../src/lib/protocol";
+
+describe("getNextDurationSeconds", () => {
+  it("returns start duration for invalid input", () => {
+    expect(getNextDurationSeconds(0)).toBe(PROTOCOL.startDurationSeconds);
+  });
+
+  it("uses percentage step-up under microstep ceiling", () => {
+    expect(getNextDurationSeconds(60)).toBe(69);
+  });
+
+  it("uses +5 minute step above microstep ceiling", () => {
+    expect(getNextDurationSeconds(41 * 60)).toBe(46 * 60);
+  });
+});
+
+describe("suggestNext", () => {
+  it("starts at 80% of current calm when no sessions", () => {
+    expect(suggestNext([], { currentMaxCalm: 120 })).toBe(96);
+  });
+
+  it("holds if successful session ended early", () => {
+    const sessions = [{ distressLevel: "none", actualDuration: 30, plannedDuration: 60 }];
+    expect(suggestNext(sessions, {})).toBe(60);
+  });
+
+  it("rolls back after strong distress", () => {
+    const sessions = [
+      { distressLevel: "none", plannedDuration: 60, actualDuration: 60 },
+      { distressLevel: "none", plannedDuration: 69, actualDuration: 69 },
+      { distressLevel: "strong", plannedDuration: 80, actualDuration: 20 },
+    ];
+    expect(suggestNext(sessions, {})).toBe(60);
+  });
+});


### PR DESCRIPTION
### Motivation

- Make the core progression logic testable and reusable by moving it out of the main component. 
- Replace the previous single `activities` sync model with proper normalized Supabase tables (`sessions`, `walks`, `patterns`) to match the DB schema. 
- Improve developer experience with basic project hygiene, documentation, and automated unit tests for the protocol.

### Description

- Extracted protocol configuration and functions into `src/lib/protocol.js` and updated `src/App.jsx` to import `PROTOCOL`, `getNextDurationSeconds`, and `suggestNext`. 
- Reworked Supabase sync functions in `src/App.jsx` to `GET` from and `POST` to the normalized tables `sessions`, `walks`, and `patterns`, added `syncDelete(kind, id)` and `syncDeleteSessionsForDog(dogId)` helpers, and wired remote deletes into UI actions (single-item deletes and "Clear sessions").
- Added schema and RLS setup SQL in `supabase_setup.sql` (tables, indexes, and permissive public policies) and added `patterns` table support. 
- Added project files: `.gitignore`, `PROJECT_REVIEW.md`, updated `README.md` with optional Supabase setup and deployment instructions, and added `tests/protocol.test.js` plus `vitest` as a dev dependency and a `test` script in `package.json`.

### Testing

- Added unit tests in `tests/protocol.test.js` covering `getNextDurationSeconds` and `suggestNext`. 
- Ran the test suite with `npm run test` (Vitest) and all tests passed. 
- No other automated CI or build checks were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1966762088332b300fb1e9682ba15)