### PR TITLE
Fix Supabase sync so walk/activity logs appear across devices

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -79,6 +79,13 @@ const syncFetch = async (dogId) => {
 };
 
 const syncPush = async (dogId, kind, data) => {
+  const dogReady = await sbReq("dogs", {
+    method: "POST",
+    body: JSON.stringify({ id: dogId, settings: {} }),
+    prefer: "resolution=merge-duplicates",
+  });
+  if (dogReady === null) return false;
+
   const table = kind === "session" ? "sessions" : kind === "walk" ? "walks" : "patterns";
   const row = kind === "session"
     ? {


### PR DESCRIPTION
### Motivation
- Users reported that walks logged on one device did not appear on another for the same dog ID because remote inserts could fail silently. 
- Root cause: `sessions`, `walks`, and `patterns` rows reference `dogs(id)` and would be rejected if the remote dog row did not exist.

### Description
- Updated `syncPush` to ensure a `dogs` row exists before inserting activity by performing an upsert-like `POST` to the `dogs` table with `prefer: "resolution=merge-duplicates"`.
- Added an early failure return (`return false`) when the dog upsert fails so callers can detect sync errors instead of proceeding.
- Change applied in `src/App.jsx` (ensures `dogs` row creation/upsert prior to writing to `sessions`, `walks`, or `patterns`).
- Preserves existing localStorage-only behavior when Supabase env vars are not configured.

### Testing
- Ran unit tests with `npm test` which completed successfully (`6 tests` passed).
- Built production bundle with `npm run build` which completed successfully (no errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a5cd56c88332a31762e7ddf03714)