### PR TITLE
Remove dark mode and keep app in light mode only

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ This app is based on the gradual desensitisation method for separation anxiety:
 - 🔔 Browser push notifications for daily reminders
 - 📤 Export session history to CSV
 - 📷 Photo log per session
-- 🌙 Dark mode
 
 ---
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -244,29 +244,6 @@ const styles = `
     --radius-sm: 12px;
   }
 
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --bg:          #1c1916;
-      --surf:        #262220;
-      --surf-soft:   #1e2b22;
-      --border:      #3a3028;
-      --green:       #5a9e72;
-      --green-light: #3a6e50;
-      --green-dark:  #6bbf8a;
-      --brown:       #e8ddd0;
-      --brown-mid:   #c8b8a8;
-      --brown-muted: #9a8878;
-      --amber:       #e8984a;
-      --amber-light: #f0b865;
-      --red:         #e05a4a;
-      --orange:      #f08832;
-      --text:        #e8ddd0;
-      --text-muted:  #a89888;
-      --shadow:    0 4px 24px rgba(0,0,0,0.30);
-      --shadow-lg: 0 8px 40px rgba(0,0,0,0.40);
-    }
-  }
-
   html { overflow-x: hidden; width: 100%; max-width: 100vw; }
   html, body {
     height: 100%;


### PR DESCRIPTION
### Motivation
- Remove the app's night/dark styling so the UI always uses the single light theme and avoids diverging palettes.

### Description
- Deleted the `@media (prefers-color-scheme: dark)` CSS override in `src/App.jsx` so the `:root` light palette is the sole theme, and removed the Dark mode item from `README.md`; changed files: `src/App.jsx`, `README.md`.

### Testing
- Ran `npm run build` which completed successfully, started the dev server with `npm run dev` to validate the UI, and captured a light-mode screenshot to confirm the app renders in the light theme.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a746b1a88332aff6f7b29c45f863)