### PR TITLE
Update first-session coach text to 'leave the apartment'

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1388,7 +1388,7 @@ export default function PawTimer() {
           <div className="coach-tip" style={{ bottom:220 }}>
             <div className="coach-tip-arrow"/>
             <div className="coach-title" id="coach-title">This is {name}'s first session 🐾</div>
-            <div className="coach-body">Tap <strong>Start Session</strong> when you're ready to leave the room. The app will track the time and ask how {name.toLowerCase().replace(/\b\w/g,c=>c.toUpperCase())} did when you return.</div>
+            <div className="coach-body">Tap <strong>Start Session</strong> when you're ready to leave the apartment. The app will track the time and ask how {name.toLowerCase().replace(/\b\w/g,c=>c.toUpperCase())} did when you return.</div>
             <button className="coach-btn" onClick={() => { setShowCoach(false); save("pawtimer_coach_seen", true); }}>Got it — let's start</button>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Clarify the first-session coach tip to instruct users to `leave the apartment` rather than `leave the room`.

### Description
- Updated the coach message in `src/App.jsx` to replace the phrase "leave the room" with "leave the apartment" in the first-session tip.

### Testing
- Ran `npm test` (Vitest); all tests passed (1 file, 6 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2b99da7f08332b6aafce0e9a38aea)