### PR TITLE
Add context-aware next-session recommendation (suggestNextWithContext)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { PROTOCOL, getNextDurationSeconds, suggestNext } from "./lib/protocol";
+import { PROTOCOL, getNextDurationSeconds, suggestNext, suggestNextWithContext } from "./lib/protocol";
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid,
   Tooltip, ResponsiveContainer, ReferenceLine,
@@ -1229,7 +1229,7 @@ export default function PawTimer() {
     syncPush(activeDogId, "session", session).then(ok => {
       if (!ok) showToast("⚠️ Sync failed — check console");
     });
-    const next = suggestNext(updated, dog);
+    const next = suggestNextWithContext(updated, walks, patterns, dog) ?? suggestNext(updated, dog);
     setTarget(next);
     setPhase("idle"); setElapsed(0); setFinalElapsed(0); setSessionCompleted(false);
     const n = (dog?.dogName ?? "dog").toUpperCase();

--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -55,3 +55,127 @@ export function suggestNext(sessions, dog) {
   const rollbackIdx = Math.max(successful.length - 2, 0);
   return Math.max(successful[rollbackIdx].plannedDuration, PROTOCOL.startDurationSeconds);
 }
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const startOfDay = (value) => {
+  const d = new Date(value);
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
+const toDayKey = (value) => startOfDay(value).toISOString().slice(0, 10);
+
+const inLastDays = (iso, days, now = new Date()) => {
+  const time = new Date(iso).getTime();
+  if (!Number.isFinite(time)) return false;
+  const floor = startOfDay(now).getTime() - (days - 1) * DAY_MS;
+  return time >= floor;
+};
+
+const clamp01 = (v) => Math.max(0, Math.min(1, v));
+
+const getRecentSessions = (sessions, count = 7) => sessions.slice(-count);
+
+const getLastStableCalmDuration = (sessions) => {
+  const reverse = [...sessions].reverse();
+  const completedCalm = reverse.find(
+    (s) => s?.distressLevel === "none" && (s.actualDuration || 0) >= (s.plannedDuration || 0),
+  );
+  if (completedCalm?.plannedDuration) return completedCalm.plannedDuration;
+  const calm = reverse.find((s) => s?.distressLevel === "none");
+  if (calm?.plannedDuration) return calm.plannedDuration;
+  return PROTOCOL.startDurationSeconds;
+};
+
+export function suggestNextWithContext(sessions = [], walks = [], patterns = [], dog = {}) {
+  if (!Array.isArray(sessions) || sessions.length === 0) return suggestNext([], dog);
+
+  const goalSec = dog?.goalSeconds ?? 7200;
+  const now = new Date();
+  const last = sessions[sessions.length - 1];
+  const lastPlanned = Math.max(last?.plannedDuration || 0, PROTOCOL.startDurationSeconds);
+
+  const recent7Day = sessions.filter((s) => inLastDays(s.date, 7, now));
+  const calmRatio7d = recent7Day.length
+    ? recent7Day.filter((s) => s.distressLevel === "none").length / recent7Day.length
+    : 0.5;
+
+  const recentSessions = getRecentSessions(sessions, 7);
+  const completionRatio = recentSessions.length
+    ? recentSessions.reduce((sum, s) => {
+      const planned = s?.plannedDuration || 0;
+      if (planned <= 0) return sum;
+      return sum + clamp01((s?.actualDuration || 0) / planned);
+    }, 0) / recentSessions.length
+    : 0.5;
+
+  const last3 = getRecentSessions(sessions, 3);
+  const strongDistressPenalty = last3.some((s) => s.distressLevel === "strong") ? 1 : 0;
+
+  const patternsByDay = new Map();
+  patterns.forEach((p) => {
+    const key = toDayKey(p.date);
+    patternsByDay.set(key, (patternsByDay.get(key) || 0) + 1);
+  });
+
+  const walksByDay = new Map();
+  walks.forEach((w) => {
+    const key = toDayKey(w.date);
+    walksByDay.set(key, (walksByDay.get(key) || 0) + 1);
+  });
+
+  const dayAdherence = (offset) => {
+    const day = new Date(startOfDay(now).getTime() - offset * DAY_MS);
+    const key = toDayKey(day);
+    const done = patternsByDay.get(key) || 0;
+    const walkCount = walksByDay.get(key) || 0;
+    const needed = Math.max(PROTOCOL.desensitizationBlocksPerDayRecommendedMin, walkCount);
+    return clamp01(done / Math.max(needed, 1));
+  };
+
+  const todayAdherence = dayAdherence(0);
+  const rolling3Adherence = (dayAdherence(0) + dayAdherence(1) + dayAdherence(2)) / 3;
+
+  const sessionsByDay = new Map();
+  const aloneByDay = new Map();
+  sessions.forEach((s) => {
+    const key = toDayKey(s.date);
+    sessionsByDay.set(key, (sessionsByDay.get(key) || 0) + 1);
+    aloneByDay.set(key, (aloneByDay.get(key) || 0) + (s.actualDuration || 0));
+  });
+
+  const overloadLimitCount = dog?.sessionsPerDayMax || PROTOCOL.sessionsPerDayMax;
+  const overloadLimitSec = (dog?.maxDailyAloneMinutes || PROTOCOL.maxDailyAloneMinutes) * 60;
+  const todayKey = toDayKey(now);
+  const overloadToday =
+    (sessionsByDay.get(todayKey) || 0) > overloadLimitCount
+    || (aloneByDay.get(todayKey) || 0) > overloadLimitSec;
+
+  const recentOverload = [0, 1, 2].some((offset) => {
+    const day = new Date(startOfDay(now).getTime() - offset * DAY_MS);
+    const key = toDayKey(day);
+    return (sessionsByDay.get(key) || 0) > overloadLimitCount
+      || (aloneByDay.get(key) || 0) > overloadLimitSec;
+  });
+  const overloadPenalty = overloadToday ? 1 : recentOverload ? 0.5 : 0;
+
+  const confidence = clamp01(
+    calmRatio7d * 0.3
+    + completionRatio * 0.25
+    + todayAdherence * 0.15
+    + rolling3Adherence * 0.15
+    + (1 - strongDistressPenalty) * 0.1
+    + (1 - overloadPenalty) * 0.05,
+  );
+
+  if (confidence >= 0.72) {
+    return Math.min(getNextDurationSeconds(lastPlanned), goalSec);
+  }
+
+  if (confidence >= 0.45) {
+    return Math.min(lastPlanned, goalSec);
+  }
+
+  return Math.min(Math.max(getLastStableCalmDuration(sessions), PROTOCOL.startDurationSeconds), goalSec);
+}

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { getNextDurationSeconds, suggestNext, PROTOCOL } from "../src/lib/protocol";
+import {
+  getNextDurationSeconds,
+  suggestNext,
+  suggestNextWithContext,
+  PROTOCOL,
+} from "../src/lib/protocol";
 
 describe("getNextDurationSeconds", () => {
   it("returns start duration for invalid input", () => {
@@ -32,5 +37,57 @@ describe("suggestNext", () => {
       { distressLevel: "strong", plannedDuration: 80, actualDuration: 20 },
     ];
     expect(suggestNext(sessions, {})).toBe(60);
+  });
+});
+
+describe("suggestNextWithContext", () => {
+  it("falls back to suggestNext when session history is empty", () => {
+    expect(suggestNextWithContext([], [], [], { currentMaxCalm: 120 })).toBe(96);
+  });
+
+  it("steps up for high confidence", () => {
+    const now = new Date();
+    const sessions = Array.from({ length: 6 }).map((_, idx) => ({
+      date: new Date(now.getTime() - (5 - idx) * 86400000).toISOString(),
+      distressLevel: "none",
+      plannedDuration: 60,
+      actualDuration: 60,
+    }));
+    sessions.push({
+      date: now.toISOString(),
+      distressLevel: "none",
+      plannedDuration: 69,
+      actualDuration: 69,
+    });
+
+    const patterns = Array.from({ length: 3 }).flatMap((_, idx) => {
+      const date = new Date(now.getTime() - idx * 86400000).toISOString();
+      return [{ date, type: "keys" }, { date, type: "shoes" }, { date, type: "jacket" }];
+    });
+
+    expect(suggestNextWithContext(sessions, [], patterns, { goalSeconds: 3600 })).toBe(79);
+  });
+
+  it("holds for medium confidence", () => {
+    const now = new Date();
+    const sessions = [
+      { date: new Date(now.getTime() - 86400000).toISOString(), distressLevel: "none", plannedDuration: 60, actualDuration: 60 },
+      { date: now.toISOString(), distressLevel: "mild", plannedDuration: 69, actualDuration: 55 },
+    ];
+
+    expect(suggestNextWithContext(sessions, [], [], {})).toBe(69);
+  });
+
+  it("rolls back to last stable calm duration for low confidence", () => {
+    const now = new Date();
+    const sessions = [
+      { date: new Date(now.getTime() - 4 * 86400000).toISOString(), distressLevel: "none", plannedDuration: 60, actualDuration: 60 },
+      { date: new Date(now.getTime() - 3 * 86400000).toISOString(), distressLevel: "strong", plannedDuration: 69, actualDuration: 20 },
+      { date: new Date(now.getTime() - 2 * 86400000).toISOString(), distressLevel: "strong", plannedDuration: 69, actualDuration: 10 },
+      { date: new Date(now.getTime() - 86400000).toISOString(), distressLevel: "mild", plannedDuration: 69, actualDuration: 30 },
+      { date: now.toISOString(), distressLevel: "strong", plannedDuration: 80, actualDuration: 10 },
+    ];
+
+    expect(suggestNextWithContext(sessions, [], [], {})).toBe(60);
   });
 });


### PR DESCRIPTION
### Motivation
- Improve the automatic next-session target by using recent context (sessions, walks, pattern breaks and dog settings) instead of only the last session.

### Description
- Added `suggestNextWithContext(sessions, walks, patterns, dog)` in `src/lib/protocol.js` that computes a confidence score from recent signals and maps bands to actions (step up / hold / rollback). 
- Confidence is derived from: last 7-day calm ratio, recent completion ratio (actual/planned), strong-distress recency (last 3 sessions penalty), pattern-break adherence (today + rolling 3-day), and daily overload flags (sessions/day or alone-time/day) with configurable protocol/dog limits.
- High confidence uses existing progression (`getNextDurationSeconds`), medium holds the current planned duration, and low rolls back to the last stable fully-calm duration; `suggestNext` remains unchanged and is retained as a fallback.
- Wired the new function into the `recordResult` flow in `src/App.jsx` (calls `suggestNextWithContext(updated, walks, patterns, dog) ?? suggestNext(updated, dog)`), and updated imports accordingly; added/updated unit tests in `tests/protocol.test.js`.

### Testing
- Ran unit tests with `npm test` (Vitest): `tests/protocol.test.js` now contains 10 tests and all passed.
- Built production bundle with `npm run build`: build completed successfully (Vite production build).
- Modified files: `src/lib/protocol.js`, `src/App.jsx`, and `tests/protocol.test.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2bda5e17c8332859c348f947e192d)