### PR TITLE
Fix merge regression that broke production build

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -261,6 +261,8 @@ const sessionDetailBadges = (s) => {
   if (s.environment?.noiseEvent) badges.push("🔊 noise/event");
 
   return badges;
+};
+
 const getLeaveProfile = (leavesPerDay = 3) => {
   const normalizedLeaves = Math.max(1, Number(leavesPerDay) || 3);
   if (normalizedLeaves <= 2) return { key: "low", confidenceScale: 0.9, desc: "lower daily departure load" };


### PR DESCRIPTION
### Motivation
- A bad merge resolution left `sessionDetailBadges` without its closing `};` in `src/App.jsx`, which caused the subsequent `export default function PawTimer()` to be parsed out of the top-level scope and broke Vite production builds.

### Description
- Add the missing closing `};` to the `sessionDetailBadges` function in `src/App.jsx` to restore valid module-level syntax and allow the `export` to be top-level.

### Testing
- Ran `npm run build` and the build completes successfully (production bundle generated). 
- Ran `npm run test` (Vitest) and all tests passed (`tests/protocol.test.js` — 10 tests passing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c6ffbb8083328afdf12454218367)