### PR TITLE
Restore missing recommendation metrics to prevent runtime crash

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1511,6 +1511,19 @@ export default function PawTimer() {
   const calmRate7 = calcWindowCalmRate(7);
   const calmRate14 = calcWindowCalmRate(14);
 
+  const doseMultiplier = leaveProfile.confidenceScale;
+  const adjustedTarget = Math.max(
+    activeProto.startDurationSeconds,
+    Math.round(target * doseMultiplier)
+  );
+  const recommendationConfidence = (() => {
+    if (!sessions.length) return "building";
+    const recent = sessions.slice(-6);
+    const calmRate = recent.filter((s) => s.distressLevel === "none").length / recent.length;
+    const threshold = normalizedLeaves >= 7 ? 0.85 : normalizedLeaves >= 5 ? 0.75 : 0.65;
+    return calmRate >= threshold ? "high" : calmRate >= threshold - 0.15 ? "medium" : "low";
+  })();
+
   const calmDurations = sessions
     .filter((s) => s.distressLevel === "none" && Number.isFinite(s.actualDuration))
     .map((s) => s.actualDuration)


### PR DESCRIPTION
### Motivation
- The main app screen could crash to a blank screen because JSX still referenced derived values that had been removed, causing a runtime `ReferenceError` in the recommendation banner.  
- The intent is to restore the previous computed recommendation metrics so the UI can render without changing behavior or UX.

### Description
- Restored three derived values in `src/App.jsx`: `doseMultiplier`, `adjustedTarget`, and `recommendationConfidence`, computed from `leaveProfile`, `activeProto`, `target`, `normalizedLeaves`, and recent `sessions`.  
- Kept the logic consistent with prior behavior: `adjustedTarget` is `Math.round(target * doseMultiplier)` bounded by protocol start duration, and `recommendationConfidence` derives from recent calm-rate thresholds.  
- Change is minimal and localized to `src/App.jsx` to reconnect the recommendation banner to its data without other refactors.

### Testing
- Built the production bundle with `npm run build` (succeeded).  
- Ran unit tests with `npm test` (Vitest) and all tests passed.  
- Performed browser smoke checks via automated Playwright flows exercising onboarding → app load → start/end session → submit feedback → History and Settings navigation, and verified no runtime errors and expected UI elements rendered (smoke checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2cd9499588332b186783df2c6cbcc)