### PR TITLE
Make walk durations editable; add metric explainers; fix Stats layout and center Train text

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -845,6 +845,7 @@ const styles = `
   .metric-help-card { width:min(100%, 420px); background:var(--surf); border-radius:var(--radius); padding:18px 16px; box-shadow:var(--shadow-lg); }
   .metric-help-title { font-size:20px; color:var(--brown); font-weight:700; margin-bottom:8px; }
   .metric-help-body { font-size:14px; color:var(--text-muted); line-height:1.6; font-weight:400; }
+  .metric-help-detail { margin-top:10px; font-size:12px; color:var(--text-muted); font-weight:500; }
   .metric-help-close { margin-top:14px; width:100%; border:none; border-radius:10px; background:var(--brown); color:var(--bg); padding:11px; font-size:14px; font-weight:600; cursor:pointer; }
 
   .train-coverage { text-align:center; }
@@ -1729,18 +1730,22 @@ export default function PawTimer() {
     stability: {
       title: "Stability",
       body: "How consistent calm-session durations are. Higher stability means your calm sessions are predictable; big swings suggest your dog may still need more repetition at easier levels.",
+      detail: `Median calm · SD ${durationVariability != null ? fmt(durationVariability) : "—"} · ${stabilityTone.label}`,
     },
     momentum: {
       title: "Momentum",
       body: "Your short-term trend. It compares calm-session rate over the last 7 days against the last 14 days to show whether progress is improving, holding, or slipping.",
+      detail: `7d calm · 14d ${calmRate14 != null ? `${calmRate14}%` : "—"} · ${momentumTone.label}`,
     },
     relapseRisk: {
       title: "Relapse risk",
       body: "A quick warning signal based on strong-distress sessions in your most recent attempts. More strong distress in the recent window means a higher chance of setbacks and a need to slow down.",
+      detail: `${recentStrongCount}/${relapseWindow} recent sessions strong distress · ${relapseTone.label}`,
     },
     adherence: {
       title: "Adherence",
       body: "How well daily pattern breaks keep pace with real departures (walks together). Better adherence means cues are practiced enough to support training progress.",
+      detail: `Pattern breaks vs walks by day · ${adherenceTone.label}`,
     },
   };
 
@@ -1777,6 +1782,9 @@ export default function PawTimer() {
           <div className="metric-help-card" onClick={(e) => e.stopPropagation()}>
             <div className="metric-help-title" id="metric-help-title">{metricExplainers[metricHelp]?.title}</div>
             <div className="metric-help-body">{metricExplainers[metricHelp]?.body}</div>
+            {metricExplainers[metricHelp]?.detail && (
+              <div className="metric-help-detail">{metricExplainers[metricHelp]?.detail}</div>
+            )}
             <button className="metric-help-close" onClick={() => setMetricHelp(null)} type="button">Got it</button>
           </div>
         </div>
@@ -2299,28 +2307,24 @@ export default function PawTimer() {
                   <div className="insight-value" style={{ color: stabilityTone.color }}>
                     {calmMedian != null ? fmt(calmMedian) : "—"}
                   </div>
-                  <div className="insight-sub">Median calm · SD {durationVariability != null ? fmt(durationVariability) : "—"} · {stabilityTone.label}</div>
                 </button>
                 <button className="insight-card insight-card-btn" style={{ borderLeftColor: momentumTone.color }} onClick={() => openMetricHelp("momentum")} type="button">
                   <div className="insight-title">Momentum</div>
                   <div className="insight-value" style={{ color: momentumTone.color }}>
                     {calmRate7 != null ? `${calmRate7}%` : "—"}
                   </div>
-                  <div className="insight-sub">7d calm · 14d {calmRate14 != null ? `${calmRate14}%` : "—"} · {momentumTone.label}</div>
                 </button>
                 <button className="insight-card insight-card-btn" style={{ borderLeftColor: relapseTone.color }} onClick={() => openMetricHelp("relapseRisk")} type="button">
                   <div className="insight-title">Relapse risk</div>
                   <div className="insight-value" style={{ color: relapseTone.color }}>
                     {relapseRisk ? "High" : "Low"}
                   </div>
-                  <div className="insight-sub">{recentStrongCount}/{relapseWindow} recent sessions strong distress · {relapseTone.label}</div>
                 </button>
                 <button className="insight-card insight-card-btn" style={{ borderLeftColor: adherenceTone.color }} onClick={() => openMetricHelp("adherence")} type="button">
                   <div className="insight-title">Adherence</div>
                   <div className="insight-value" style={{ color: adherenceTone.color }}>
                     {adherenceByDay != null ? `${adherenceByDay}%` : "—"}
                   </div>
-                  <div className="insight-sub">Pattern breaks vs walks by day · {adherenceTone.label}</div>
                 </button>
               </div>
             )}


### PR DESCRIPTION
### Motivation
- Allow users to directly correct walk durations from the Activity Log so logged walks can be accurate.  
- Make key Statistics metrics (`Stability`, `Momentum`, `Relapse Risk`, `Adherence`) self-explanatory to reduce confusion.  
- Remove the large empty area in the Statistics view and improve visual balance, and center-align the Train tab helper text for better alignment.

### Description
- Added parsing helper `parseDurationInput` and an `editWalkDuration` handler that prompts for `seconds` or `mm:ss`, validates input, updates local state, and calls `pushWithSyncStatus("walk", ...)` to sync changes.  
- Exposed an edit action (✎) in each walk row (`Activity Log`) and added compact action styling (`.h-actions`, `.h-edit`) so users can edit or delete a walk in place.  
- Implemented tappable metric cards (converted to buttons) with explanatory content stored in `metricExplainers`, a modal UI (`metricHelp`) and persisted seen-state in localStorage under the key `pawtimer_metric_help_seen_v1`.  
- Auto-opens the first unseen metric explanation when the user visits the Stats tab with data, and allows reopening by tapping any metric card.  
- Fixed the empty gap in the Stats grid by making the `Next target` stat span two columns (`.stat-card-span2`) and added `train-coverage` CSS to center the Train helper text.  
- All UI and behaviour changes are implemented in `src/App.jsx` and associated inline styles within the same file.

### Testing
- Ran unit tests with `npm test` (Vitest) and all tests passed.  
- Built the production bundle with `npm run build` (Vite) and the build completed successfully.  
- Attempted an end-to-end screenshot flow with Playwright to validate the modal and centered text, but the headless browser crashed in this environment (SIGSEGV), so no screenshot artifacts were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2fac417bc83328480241e32c24693)