### PR TITLE
Fix dog-ID cross-device sync divergence and preserve shared account state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -122,15 +122,21 @@ const normalizeSession = (row = {}) => {
 
 const normalizeSessions = (rows = []) => ensureArray(rows).map(normalizeSession);
 
+const isMissingColumnError = (error = "") => /column .* does not exist/i.test(String(error));
+
 const syncFetch = async (dogId) => {
   const id = canonicalDogId(dogId);
   const dogFilter = `dog_id=ilike.${encodeURIComponent(id)}`;
-  const [dogRes, sessRes, walkRes, patRes] = await Promise.all([
+  const [dogRes, detailedSessRes, walkRes, patRes] = await Promise.all([
     sbReq(`dogs?id=ilike.${encodeURIComponent(id)}&select=id,settings&limit=5`),
-    sbReq(`sessions?${dogFilter}&select=id,date,planned_duration,actual_duration,distress_level,result&order=date.asc`),
+    sbReq(`sessions?${dogFilter}&select=id,date,planned_duration,actual_duration,distress_level,result,context,symptoms,recovery_seconds,pre_session,environment&order=date.asc`),
     sbReq(`walks?${dogFilter}&select=id,date,duration&order=date.asc`),
     sbReq(`patterns?${dogFilter}&select=id,date,type&order=date.asc`),
   ]);
+
+  const sessRes = detailedSessRes.ok || !isMissingColumnError(detailedSessRes.error)
+    ? detailedSessRes
+    : await sbReq(`sessions?${dogFilter}&select=id,date,planned_duration,actual_duration,distress_level,result&order=date.asc`);
 
   const errors = [
     !dogRes.ok ? `dogs: ${dogRes.error}` : null,
@@ -161,6 +167,11 @@ const syncFetch = async (dogId) => {
         actualDuration: r.actual_duration,
         distressLevel: r.distress_level,
         result: r.result,
+        context: r.context,
+        symptoms: r.symptoms,
+        recoverySeconds: r.recovery_seconds,
+        preSession: r.pre_session,
+        environment: r.environment,
       }))),
       walks: walkRows.map((r) => ({ id: r.id, date: r.date, duration: r.duration })),
       patterns: patRows.map((r) => ({ id: r.id, date: r.date, type: r.type })),
@@ -195,6 +206,11 @@ const syncPush = async (dogId, kind, data, dogSettings = null) => {
         actual_duration: data.actualDuration,
         distress_level: data.distressLevel,
         result: data.result,
+        context: data.context ?? {},
+        symptoms: data.symptoms ?? {},
+        recovery_seconds: Number.isFinite(data.recoverySeconds) ? data.recoverySeconds : null,
+        pre_session: data.preSession ?? {},
+        environment: data.environment ?? {},
       }
     : kind === "walk"
       ? {
@@ -210,11 +226,28 @@ const syncPush = async (dogId, kind, data, dogSettings = null) => {
           type: data.type,
         };
 
-  const res = await sbReq(table, {
+  let res = await sbReq(table, {
     method: "POST",
     body: JSON.stringify(row),
     prefer: "resolution=merge-duplicates,return=minimal",
   });
+
+  if (!res.ok && kind === "session" && isMissingColumnError(res.error)) {
+    const fallbackRow = {
+      id: String(data.id),
+      dog_id: id,
+      date: data.date,
+      planned_duration: data.plannedDuration,
+      actual_duration: data.actualDuration,
+      distress_level: data.distressLevel,
+      result: data.result,
+    };
+    res = await sbReq(table, {
+      method: "POST",
+      body: JSON.stringify(fallbackRow),
+      prefer: "resolution=merge-duplicates,return=minimal",
+    });
+  }
   return res.ok
     ? { ok: true, error: null }
     : { ok: false, error: `${kind} push failed: ${res.error}` };
@@ -1338,6 +1371,8 @@ export default function PawTimer() {
           save(DOGS_KEY, next);
           return next;
         });
+        setPatLabels(ensureObject(remote.dog.patLabels));
+        setDogPhoto(remote.dog.dogPhoto ?? null);
       }
       setSessions(prev => { const m = normalizeSessions(mergeById(prev, remote.sessions)); save(sessKey(activeDogId), m); return m; });
       setWalks   (prev => { const m = mergeById(prev, remote.walks);    save(walkKey(activeDogId), m); return m; });
@@ -1369,14 +1404,15 @@ export default function PawTimer() {
   useEffect(() => {
     if (!SYNC_ENABLED || !activeDogId) return;
     const dog = dogs.find((d) => canonicalDogId(d.id) === canonicalDogId(activeDogId));
-    if (!dog) return;
-    syncUpsertDog(dog).then(({ ok, error }) => {
+    const sharedDog = buildSharedDogPayload(dog);
+    if (!sharedDog) return;
+    syncUpsertDog(sharedDog).then(({ ok, error }) => {
       if (!ok) {
         setSyncStatus("err");
         setSyncError(error || "Unable to sync dog settings");
       }
     });
-  }, [activeDogId, dogs]);
+  }, [activeDogId, dogs, patLabels, dogPhoto]);
 
   // Coach mark: show on first ever app open (no sessions yet)
   useEffect(() => {
@@ -1486,10 +1522,20 @@ export default function PawTimer() {
     setPhase("rating");
   };
 
+  function buildSharedDogPayload(dog) {
+    if (!dog) return null;
+    return {
+      ...dog,
+      id: canonicalDogId(dog.id),
+      patLabels: ensureObject(patLabels),
+      dogPhoto: dogPhoto ?? null,
+    };
+  }
+
   const pushWithSyncStatus = async (kind, data) => {
     if (!SYNC_ENABLED || !activeDogId) return false;
     const currentDog = dogs.find((d) => canonicalDogId(d.id) === canonicalDogId(activeDogId));
-    const dogSettings = currentDog ? { ...currentDog, id: canonicalDogId(currentDog.id) } : null;
+    const dogSettings = buildSharedDogPayload(currentDog);
     setSyncStatus("syncing");
     const { ok, error } = await syncPush(canonicalDogId(activeDogId), kind, data, dogSettings);
     if (ok) {

--- a/supabase_setup.sql
+++ b/supabase_setup.sql
@@ -19,8 +19,19 @@ create table if not exists sessions (
   actual_duration  integer not null,  -- seconds
   distress_level   text not null check (distress_level in ('none', 'mild', 'strong')),
   result           text not null check (result in ('success', 'distress')),
+  context          jsonb not null default '{}'::jsonb,
+  symptoms         jsonb not null default '{}'::jsonb,
+  recovery_seconds integer,
+  pre_session      jsonb not null default '{}'::jsonb,
+  environment      jsonb not null default '{}'::jsonb,
   created_at       timestamptz default now()
 );
+
+alter table sessions add column if not exists context jsonb not null default '{}'::jsonb;
+alter table sessions add column if not exists symptoms jsonb not null default '{}'::jsonb;
+alter table sessions add column if not exists recovery_seconds integer;
+alter table sessions add column if not exists pre_session jsonb not null default '{}'::jsonb;
+alter table sessions add column if not exists environment jsonb not null default '{}'::jsonb;
 
 -- 3. Walks table — one row per "walked together" log
 create table if not exists walks (


### PR DESCRIPTION
### Motivation
- Users reported that opening the same Dog ID on different devices could show different account state because local-only fields diverged between devices. 
- Root cause: the cloud sync contract was partial—sessions were read/written with a minimal field set while richer session fields and dog-level metadata (`patLabels`, `dogPhoto`) lived only in device-local storage, causing per-device variants for the same Dog ID. 
- To make one Dog ID represent a single shared account the app must read/write the full session payload and include dog-level shared metadata, while remaining compatible with older DB schemas.

### Description
- Expanded remote fetch (`syncFetch`) to request the extended session columns (`context`, `symptoms`, `recovery_seconds`, `pre_session`, `environment`) and to normalize them into local sessions. (file: `src/App.jsx`).
- Added adaptive fallback when the extended columns are missing by detecting missing-column errors and retrying with the legacy/minimal session projection so older DBs do not break sync. (file: `src/App.jsx`).
- Expanded session push (`syncPush`) to include the full session payload and added a fallback write path that retries with the minimal schema if serverside columns are absent. (file: `src/App.jsx`).
- Included dog-shared metadata in dog settings upserts and reads: the app now upserts `patLabels` and `dogPhoto` into the shared `dogs.settings` and applies remote `patLabels`/`dogPhoto` into local state during polling. (file: `src/App.jsx`).
- Added a small helper `isMissingColumnError` and `buildSharedDogPayload` to centralize compatibility logic and dog-settings packaging. (file: `src/App.jsx`).
- Updated Supabase setup SQL to add the richer session columns and safe `ALTER TABLE ... IF NOT EXISTS` migration statements so existing projects can be upgraded in-place: `context jsonb`, `symptoms jsonb`, `recovery_seconds integer`, `pre_session jsonb`, and `environment jsonb`. (file: `supabase_setup.sql`).

### Testing
- Ran the unit test suite with `npm run test` and all tests passed (`tests/protocol.test.js`: 10 tests passed). 
- Built the production bundle with `npm run build` and the build completed successfully. 
- Verified the sync code-paths by code inspection and local execution: fetch now returns extended session objects and remote dog settings are applied to local state, and push falls back to the minimal schema when DB columns are missing.

Notes: to achieve exact parity of rich session fields across devices you should run the updated `supabase_setup.sql` in your Supabase project's SQL editor (the script includes safe `IF NOT EXISTS` alters); the app includes compatibility fallbacks so older schemas will continue to function but may not share extended session fields until migrated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ea00a3ac83329a063f1b6cd16e27)