### PR TITLE
Fix cross-device dog account sync to use canonical remote snapshot

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -122,6 +122,15 @@ const normalizeSession = (row = {}) => {
 
 const normalizeSessions = (rows = []) => ensureArray(rows).map(normalizeSession);
 
+const hasRemoteSnapshotData = (remote) => {
+  if (!remote || typeof remote !== "object") return false;
+  if (remote.dog) return true;
+  if (Array.isArray(remote.sessions) && remote.sessions.length > 0) return true;
+  if (Array.isArray(remote.walks) && remote.walks.length > 0) return true;
+  if (Array.isArray(remote.patterns) && remote.patterns.length > 0) return true;
+  return false;
+};
+
 const syncFetch = async (dogId) => {
   const id = canonicalDogId(dogId);
   const dogFilter = `dog_id=ilike.${encodeURIComponent(id)}`;
@@ -1339,9 +1348,20 @@ export default function PawTimer() {
           return next;
         });
       }
-      setSessions(prev => { const m = normalizeSessions(mergeById(prev, remote.sessions)); save(sessKey(activeDogId), m); return m; });
-      setWalks   (prev => { const m = mergeById(prev, remote.walks);    save(walkKey(activeDogId), m); return m; });
-      setPatterns(prev => { const m = mergeById(prev, remote.patterns); save(patKey(activeDogId),  m); return m; });
+      const canonicalId = canonicalDogId(activeDogId);
+      const syncedSessions = normalizeSessions(ensureArray(remote.sessions));
+      const syncedWalks = ensureArray(remote.walks)
+        .filter((w) => w && w.id)
+        .sort((a, b) => new Date(a.date) - new Date(b.date));
+      const syncedPatterns = ensureArray(remote.patterns)
+        .filter((p) => p && p.id)
+        .sort((a, b) => new Date(a.date) - new Date(b.date));
+      setSessions(syncedSessions);
+      setWalks(syncedWalks);
+      setPatterns(syncedPatterns);
+      save(sessKey(canonicalId), syncedSessions);
+      save(walkKey(canonicalId), syncedWalks);
+      save(patKey(canonicalId), syncedPatterns);
       setSyncError("");
       setSyncStatus("ok");
     };
@@ -1436,7 +1456,7 @@ export default function PawTimer() {
     setScreen("app");
   };
 
-  const handleDogSelect = (id, isJoin = false) => {
+  const handleDogSelect = async (id, isJoin = false) => {
     const normalizedId = canonicalDogId(id);
     const existing = dogs.find(d => canonicalDogId(d.id) === normalizedId)
                   ?? ensureArray(load(DOGS_KEY, [])).find(d => canonicalDogId(d.id) === normalizedId);
@@ -1445,6 +1465,44 @@ export default function PawTimer() {
       return;
     }
     if (isJoin) {
+      if (SYNC_ENABLED) {
+        setSyncStatus("syncing");
+        const { result: remote, error } = await syncFetch(normalizedId);
+        if (remote && hasRemoteSnapshotData(remote)) {
+          const prefix = normalizedId.split("-")[0] || "DOG";
+          const joinedDog = remote.dog
+            ? { ...remote.dog, id: normalizedId, isJoined: true }
+            : {
+                id: normalizedId,
+                dogName: prefix,
+                leavesPerDay: 3,
+                currentMaxCalm: 60,
+                goalSeconds: 2400,
+                createdAt: new Date().toISOString(),
+                isJoined: true,
+              };
+          const updatedDogs = [...dogs.filter((d) => canonicalDogId(d.id) !== normalizedId), joinedDog];
+          const syncedSessions = normalizeSessions(ensureArray(remote.sessions));
+          const syncedWalks = ensureArray(remote.walks);
+          const syncedPatterns = ensureArray(remote.patterns);
+
+          save(DOGS_KEY, updatedDogs);
+          save(sessKey(normalizedId), syncedSessions);
+          save(walkKey(normalizedId), syncedWalks);
+          save(patKey(normalizedId), syncedPatterns);
+          setDogs(updatedDogs);
+          setSyncError("");
+          setSyncStatus("ok");
+          openDog(joinedDog);
+          showToast(`✅ Joined ${joinedDog.dogName || prefix} via synced account.`);
+          return;
+        }
+        if (error) {
+          setSyncStatus("err");
+          setSyncError(error);
+        }
+      }
+
       const prefix = id.split("-")[0] || "DOG";
       const suggestedLeaves = Math.min(8, Math.max(1, Math.round(prefix.length / 2) + 2));
       const confirmed = window.confirm(


### PR DESCRIPTION
### Motivation
- Users reported that opening the same dog ID on different devices produced divergent local accounts because local data could outlive and conflict with remote data. The intent is to make Supabase the source-of-truth so the same dog ID always resolves to a single shared account across devices. 
- Root cause: the periodic sync merged remote rows into existing local arrays (`mergeById`), which preserved stale/offline-only local rows and allowed separate local forks; joining by ID also created placeholders without checking Supabase first, causing split local accounts.

### Description
- Treated remote snapshot as canonical in the poller by replacing in-memory collections rather than merging, and persisted the exact snapshot to local storage keys; this ensures reloads and other devices see the same dataset (changed sync logic in `useEffect` poll for active dog). 
- Added `hasRemoteSnapshotData(remote)` helper to reliably detect whether a fetched Supabase snapshot contains meaningful remote data. 
- Made join-by-ID flow fetch Supabase before creating a placeholder and hydrate local `dogs`, `sessions`, `walks`, and `patterns` from the remote snapshot when present, opening the shared account immediately; only falls back to placeholder when no remote snapshot exists. 
- File changed: `src/App.jsx` — notable edits: added `hasRemoteSnapshotData`, replaced `mergeById(prev, remote.*)` merges with snapshot replacement + normalized sorting/persistence, and made `handleDogSelect` async to perform pre-join fetch and hydration.

### Testing
- Ran unit tests with `npm test` (Vitest) and all tests passed (`tests/protocol.test.js` — 10 tests passed). 
- Built the production bundle with `npm run build` and the build completed successfully. 
- Note: an earlier attempt using `npm test -- --runInBand` failed due to an invalid Vitest CLI flag, but the correct `npm test` run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ea00a3ac83329a063f1b6cd16e27)