### PR TITLE
Enforce 30s minimum and fix stale-session ordering in recommendation engine

### DIFF
--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -5,7 +5,7 @@ export const PROTOCOL = {
   restDaysPerWeekMin: 1,
   restDaysPerWeekRecommended: 2,
   startDurationSeconds: 30,
-  minDurationSeconds: 15,
+  minDurationSeconds: 30,
   goalDurationDefaultSeconds: 7200,
   stabilizationDistressThreshold: 2,
   stabilizationWindow: 6,
@@ -106,6 +106,17 @@ function getLatestSessions(sessions, count) {
   return sessions.slice(-count);
 }
 
+function sortByDateAsc(sessions = []) {
+  return [...sessions].sort((a, b) => {
+    const timeA = toTimestamp(a?.date);
+    const timeB = toTimestamp(b?.date);
+    if (timeA == null && timeB == null) return 0;
+    if (timeA == null) return -1;
+    if (timeB == null) return 1;
+    return timeA - timeB;
+  });
+}
+
 function countStreak(items, predicate) {
   let streak = 0;
   for (let i = items.length - 1; i >= 0; i -= 1) {
@@ -184,8 +195,7 @@ function classifyWindow(sessions = []) {
 }
 
 function computeSafeAloneTime(sessions = []) {
-  const calm = sessions
-    .map(toRichSession)
+  const calm = getLatestSessions(sortByDateAsc(sessions).map(toRichSession), PROTOCOL.confidenceSessionWindow)
     .filter((s) => s.belowThreshold);
   if (!calm.length) return PROTOCOL.startDurationSeconds;
 
@@ -288,7 +298,7 @@ function buildCueStats(cueSessions = []) {
 }
 
 export function calculateTrainingStats(sessions = [], options = {}) {
-  const richSessions = sessions.map(toRichSession);
+  const richSessions = sortByDateAsc(sessions).map(toRichSession);
   const realAbsences = richSessions.filter((s) => s.departureType === "real_life");
   const trainingSessions = richSessions.filter((s) => s.departureType !== "real_life");
   const safeAloneTime = computeSafeAloneTime(trainingSessions);
@@ -349,7 +359,7 @@ function chooseRecommendationType(last, stats, recent) {
 }
 
 export function buildRecommendation(sessions = [], options = {}) {
-  const rich = sessions.map(toRichSession);
+  const rich = sortByDateAsc(sessions).map(toRichSession);
   const training = rich.filter((s) => s.departureType !== "real_life");
   const recent = getLatestSessions(training, PROTOCOL.calmWindow);
   const last = training[training.length - 1] || null;

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -84,6 +84,27 @@ describe("recommendation engine", () => {
     expect(["repeat_current_duration", "insert_easy_sessions", "departure_cues_first"]).toContain(rec.recommendationType);
   });
 
+  it("never recommends below 30 seconds even with legacy 15s history", () => {
+    const sessions = [
+      { date: daysAgo(3), plannedDuration: 15, actualDuration: 15, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(2), plannedDuration: 15, actualDuration: 15, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(1), plannedDuration: 50, actualDuration: 50, distressLevel: "none", belowThreshold: true },
+    ];
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recommendedDuration).toBeGreaterThanOrEqual(30);
+  });
+
+  it("uses latest session data even when input order is stale", () => {
+    const sessions = [
+      { date: daysAgo(0), plannedDuration: 50, actualDuration: 50, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(2), plannedDuration: 15, actualDuration: 15, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(1), plannedDuration: 15, actualDuration: 15, distressLevel: "none", belowThreshold: true },
+    ];
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recommendedDuration).toBeGreaterThanOrEqual(30);
+    expect(rec.recommendationType).not.toBe("stabilization_block");
+  });
+
   it("rolls back and enters stabilization mode after repeated active distress", () => {
     const sessions = [
       { date: daysAgo(4), plannedDuration: 60, actualDuration: 20, distressLevel: "active", belowThreshold: false },


### PR DESCRIPTION
### Motivation
- Users observed the next recommended session falling to `15s` after a calm `50s` session, which violates the intended minimum and suggests stale/legacy data or ordering issues were pulling the recommendation down. 
- Investigation showed the protocol minimum floor was `15` and safe-alone time aggregation could be influenced by older legacy sessions when session arrays were not chronologically sorted.

### Description
- Raised the hard minimum from `15` to `30` by updating `PROTOCOL.minDurationSeconds` to `30` in `src/lib/protocol.js`. 
- Added `sortByDateAsc` and applied chronological sorting before mapping sessions to rich form in `calculateTrainingStats` and `buildRecommendation` to ensure the latest sessions are used. 
- Limited `computeSafeAloneTime` to the most recent `PROTOCOL.confidenceSessionWindow` calm sessions after sorting so old legacy short sessions cannot dominate the weighted safe-alone calculation. 
- Added regression tests to `tests/protocol.test.js` that assert recommendations never drop below `30s` and that the engine uses the latest session data even when input order is stale.

### Testing
- Ran the test suite with `npm test` (Vitest) and all tests passed: 1 test file, 14 tests succeeded. 
- The new regression tests in `tests/protocol.test.js` executed and confirmed the recommendation floor and ordering behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b48858977083328b75d518949f38af)