### PR TITLE
Weight recent calm sessions and enable initial 20% step-up before first stress event

### DIFF
--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -195,13 +195,34 @@ function classifyWindow(sessions = []) {
 }
 
 function computeSafeAloneTime(sessions = []) {
-  const calm = getLatestSessions(sortByDateAsc(sessions).map(toRichSession), PROTOCOL.confidenceSessionWindow)
-    .filter((s) => s.belowThreshold);
+  const sorted = sortByDateAsc(sessions).map(toRichSession);
+  const nowTime = Date.now();
+  const calm = getLatestSessions(sorted, PROTOCOL.confidenceSessionWindow)
+    .filter((s) => s.belowThreshold)
+    .map((s) => {
+      const ageDays = Math.max(0, (nowTime - (toTimestamp(s.date) ?? nowTime)) / DAY_MS);
+      let recencyWeight = 0.1;
+      if (ageDays <= 1) recencyWeight = 1;
+      else if (ageDays <= 3) recencyWeight = 0.7;
+      else if (ageDays <= 7) recencyWeight = 0.4;
+
+      return {
+        ...s,
+        recencyWeight,
+      };
+    });
   if (!calm.length) return PROTOCOL.startDurationSeconds;
 
-  const weighted = calm.reduce((sum, s) => sum + (s.actualDuration * s.confidence), 0);
-  const weight = calm.reduce((sum, s) => sum + s.confidence, 0);
-  return Math.max(PROTOCOL.minDurationSeconds, Math.round(weighted / Math.max(weight, 1)));
+  const weighted = calm.reduce((sum, s) => sum + (s.actualDuration * s.confidence * s.recencyWeight), 0);
+  const weight = calm.reduce((sum, s) => sum + (s.confidence * s.recencyWeight), 0);
+  return Math.max(PROTOCOL.minDurationSeconds, Math.round(weighted / Math.max(weight, 0.01)));
+}
+
+function hasPriorStressEvent(sessions = []) {
+  return sessions.some((session) => {
+    const level = normalizeDistressLevel(session?.distressLevel);
+    return level !== DISTRESS_LEVELS.NONE;
+  });
 }
 
 function computeStability(sessions = []) {
@@ -336,10 +357,11 @@ export function calculateTrainingStats(sessions = [], options = {}) {
   };
 }
 
-function getStepMultiplier(stats, latestSessions = []) {
+function getStepMultiplier(stats, latestSessions = [], allSessions = []) {
   const calmStreak = countStreak(latestSessions, (s) => s.belowThreshold);
 
   if (stats.relapseRisk >= 0.72) return -0.25;
+  if (!hasPriorStressEvent(allSessions) && calmStreak >= 1) return 0.2;
   if (calmStreak >= 4 && stats.stabilityScore >= PROTOCOL.largeStepStabilityGate && stats.subtleDistressRate <= 0.15) {
     return 0.2;
   }
@@ -378,7 +400,7 @@ export function buildRecommendation(sessions = [], options = {}) {
   } else if (recommendationType === "insert_easy_sessions") {
     recommendedDuration = Math.round(safeAlone * PROTOCOL.easySessionRatio);
   } else {
-    const multiplier = getStepMultiplier(stats, recent);
+    const multiplier = getStepMultiplier(stats, recent, training);
     recommendedDuration = Math.round(safeAlone * (1 + multiplier));
   }
 

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -53,6 +53,17 @@ describe("training stats", () => {
     expect(stats.cueSensitivity[0].cue).toBe("shoes");
   });
 
+
+  it("prioritizes recent calm sessions when computing safe alone time", () => {
+    const sessions = [
+      { date: daysAgo(10), plannedDuration: 15, actualDuration: 15, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(9), plannedDuration: 15, actualDuration: 15, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(0), plannedDuration: 50, actualDuration: 50, distressLevel: "none", belowThreshold: true },
+    ];
+    const stats = calculateTrainingStats(sessions);
+    expect(stats.safeAloneTime).toBeGreaterThanOrEqual(40);
+  });
+
   it("raises relapse risk after recent severe and uncontrolled real-life absence", () => {
     const sessions = [
       { date: daysAgo(3), plannedDuration: 60, actualDuration: 20, distressLevel: "severe", departureType: "training" },
@@ -73,6 +84,25 @@ describe("recommendation engine", () => {
     const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
     expect(rec.recommendedDuration).toBeGreaterThanOrEqual(30);
     expect(rec.recommendedDuration).toBeLessThanOrEqual(36);
+  });
+
+
+  it("steps up by about 20% after calm sessions before first stress event", () => {
+    const sessions = [
+      { date: daysAgo(0), plannedDuration: 50, actualDuration: 50, distressLevel: "none", belowThreshold: true },
+    ];
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recommendedDuration).toBe(60);
+  });
+
+  it("does not let older short sessions drag recommendation near minimum", () => {
+    const sessions = [
+      { date: daysAgo(14), plannedDuration: 15, actualDuration: 15, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(8), plannedDuration: 15, actualDuration: 15, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(0), plannedDuration: 50, actualDuration: 50, distressLevel: "none", belowThreshold: true },
+    ];
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recommendedDuration).toBeGreaterThanOrEqual(52);
   });
 
   it("holds or reduces when subtle distress appears", () => {


### PR DESCRIPTION
### Motivation

- Make safe-alone time calculations more robust by prioritizing recent calm sessions so old short successes don't unduly bias recommendations.
- Allow an initial optimistic step increase when there has been no prior stress event to encourage reasonable progression after early calm sessions.
- Improve recommendation stability by preventing near-zero denominators when weighting sessions.

### Description

- Modify `computeSafeAloneTime` to apply a recency weight to calm sessions based on age (1 day, 3 days, 7 days tiers) and compute weighted averages using `recencyWeight` for both numerator and denominator.  Use a small floor (`0.01`) to avoid division by zero. 
- Add helper `hasPriorStressEvent` to detect any prior non-`none` distress in the session history. 
- Update `getStepMultiplier` signature to accept `allSessions` and return a 20% step-up (`0.2`) when there are no prior stress events and at least one calm streak, and pass `training` sessions into the new parameter when calling it. 
- Adjusted calls and imports accordingly in recommendation flow to use the new arguments.

### Testing

- Added unit tests in `tests/protocol.test.js`: `prioritizes recent calm sessions when computing safe alone time`, `steps up by about 20% after calm sessions before first stress event`, and `does not let older short sessions drag recommendation near minimum`, which verify recency weighting and initial step behavior. 
- Ran the full `tests/protocol.test.js` suite including the existing training and recommendation tests. All tests passed locally. 
- Existing assertions around stability, relapse risk, adherence, and recommendation bounds remain covered and continue to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b492d51a8c833288bde4d5adfec19d)