### PR TITLE
Move recommendation coverage copy into Progress statistics section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2446,12 +2446,6 @@ ${syncError}`);
                       : "Rolled back after higher distress — steady progress matters most."}
               </p>
             )}
-            {phase !== "running" && sessions.length > 0 && (
-              <p className="t-helper train-coverage" style={{ marginTop: -4, marginBottom: 10 }}>
-                Data coverage for smarter recommendations: {recommendationCoveragePct}% ({recommendationCoverageCount}/{totalCount})
-              </p>
-            )}
-
             {/* 4. Stats rings card */}
             {phase === "idle" && (() => {
               const R = 36; const C = 2*Math.PI*R;
@@ -2855,6 +2849,9 @@ ${syncError}`);
                 <div className="stat-icon"><Img src="pattern-keys.png" size={36} alt="pattern breaks"/></div>
               </div>
             </div>
+            <p className="t-helper train-coverage" style={{ marginTop: 0, marginBottom: 14 }}>
+              Data coverage for smarter recommendations: {recommendationCoveragePct}% ({recommendationCoverageCount}/{totalCount})
+            </p>
             <div className="goal-card" style={{margin:"0 0 14px"}}>
               <div className="goal-label">
                 <span className="goal-title">Progress toward goal</span>


### PR DESCRIPTION
### Motivation

- The recommendation-coverage helper line belonged with user statistics rather than the Home training area to improve contextual relevance. 
- Relocating it reduces UI clutter on the home/status area and surfaces the metric where users review progress.

### Description

- Removed the `Data coverage for smarter recommendations` paragraph from the Home/training area in `src/App.jsx`.
- Added the same sentence into the Progress/Statistics section directly beneath the stats grid in `src/App.jsx` using the same variables (`recommendationCoveragePct`, `recommendationCoverageCount`, `totalCount`).
- Adjusted inline spacing styles for the relocated paragraph (`marginTop: 0, marginBottom: 14`).
- All changes are contained in `src/App.jsx`.

### Testing

- Ran `npm test` which executes `vitest`, and all tests passed (`1` test file, `17` tests) successfully. 
- Executed an automated Playwright script that opened the running dev server and captured a screenshot of the Progress tab, which completed and produced an artifact for visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b498a58e4c83328c331fa81a9ecaa3)