### PR TITLE
Enhance recovery 'Next session' ring pulse: brighter, extended glow, slower fade

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -328,6 +328,7 @@
     flex:0 0 auto;
   }
   .ring-wrap--recovery-pulse {
+    --recovery-cycle:1.72s;
     isolation:isolate;
     overflow:visible;
   }
@@ -338,12 +339,21 @@
     z-index:1;
   }
   .ring-recovery-pulse__core,
-  .ring-recovery-pulse__bloom {
+  .ring-recovery-pulse__bloom,
+  .ring-recovery-pulse__core::before,
+  .ring-recovery-pulse__bloom::before {
     position:absolute;
     inset:0;
     border-radius:50%;
     transform-origin:center;
     will-change:transform, opacity;
+  }
+  .ring-recovery-pulse__core::before,
+  .ring-recovery-pulse__bloom::before,
+  .ring-inner-recovery-wave::before,
+  .ring-inner-recovery-core::before {
+    content:"";
+    pointer-events:none;
   }
   .ring-recovery-pulse__core {
     inset:6%;
@@ -354,7 +364,12 @@
       color-mix(in srgb, var(--warm-accent-soft) 30%, transparent) 76%,
       transparent 92%);
     filter:saturate(1.1) brightness(1.08);
-    animation:ringRecoveryPulseInner 1.72s cubic-bezier(0.22, 0.61, 0.36, 1) infinite;
+    animation:ringRecoveryPulseInner var(--recovery-cycle) linear infinite;
+  }
+  .ring-recovery-pulse__core::before {
+    background:inherit;
+    filter:inherit;
+    animation:ringRecoveryPulseInner var(--recovery-cycle) linear infinite calc(var(--recovery-cycle) * -0.5);
   }
   .ring-recovery-pulse__bloom {
     inset:-22%;
@@ -364,7 +379,12 @@
       color-mix(in srgb, var(--color-warm-accent) 26%, transparent) 70%,
       transparent 88%);
     filter:blur(0.2px) saturate(1.06) brightness(1.06);
-    animation:ringRecoveryPulseBloom 1.72s cubic-bezier(0.22, 0.61, 0.36, 1) infinite 0.22s;
+    animation:ringRecoveryPulseBloom var(--recovery-cycle) linear infinite -0.14s;
+  }
+  .ring-recovery-pulse__bloom::before {
+    background:inherit;
+    filter:inherit;
+    animation:ringRecoveryPulseBloom var(--recovery-cycle) linear infinite calc(var(--recovery-cycle) * -0.64);
   }
   .ring-svg { position:absolute; inset:0; width:100%; height:100%; overflow:visible; z-index:2; }
   .ring-bg   { fill:none; stroke:color-mix(in srgb, var(--border) 72%, white); stroke-width:7; }
@@ -394,7 +414,9 @@
   }
   .ring-inner-recovery-face,
   .ring-inner-recovery-wave,
-  .ring-inner-recovery-core {
+  .ring-inner-recovery-core,
+  .ring-inner-recovery-wave::before,
+  .ring-inner-recovery-core::before {
     position:absolute;
     inset:0;
     border-radius:inherit;
@@ -417,12 +439,23 @@
       rgba(255, 216, 178, 0.24) 94%,
       rgba(255, 221, 189, 0) 100%);
     filter:saturate(1.12) brightness(1.06);
-    animation:ringRecoveryWaveTravel 1.72s cubic-bezier(0.22, 0.61, 0.36, 1) infinite;
+    animation:ringRecoveryWaveTravel var(--recovery-cycle) linear infinite;
+  }
+  .ring-inner-recovery-wave::before {
+    background:inherit;
+    filter:inherit;
+    animation:ringRecoveryWaveTravel var(--recovery-cycle) linear infinite calc(var(--recovery-cycle) * -0.5);
   }
   .ring-inner-recovery-core {
     inset:24%;
     background:radial-gradient(circle, rgba(177, 105, 38, 0.62) 0%, rgba(202, 129, 62, 0.48) 40%, rgba(233, 174, 119, 0.24) 72%, rgba(233, 174, 119, 0) 100%);
-    animation:ringRecoveryCoreSeed 1.72s cubic-bezier(0.22, 0.61, 0.36, 1) infinite;
+    filter:blur(0.25px);
+    animation:ringRecoveryCoreSeed var(--recovery-cycle) linear infinite;
+  }
+  .ring-inner-recovery-core::before {
+    background:inherit;
+    filter:inherit;
+    animation:ringRecoveryCoreSeed var(--recovery-cycle) linear infinite calc(var(--recovery-cycle) * -0.48);
   }
   .ring-val {
     inline-size:max-content;
@@ -665,39 +698,39 @@
   .settings-sync-copy { font-size:var(--type-helper-text-size); color:var(--text-muted); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); }
   @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
   @keyframes ringRecoveryPulseInner {
-    0% { transform:scale(0.22); opacity:0.08; }
-    10% { transform:scale(0.34); opacity:0.54; }
-    24% { transform:scale(0.5); opacity:0.84; }
-    44% { transform:scale(0.72); opacity:0.78; }
-    66% { transform:scale(0.92); opacity:0.58; }
-    84% { transform:scale(1.06); opacity:0.34; }
-    100% { transform:scale(1.16); opacity:0.08; }
+    0% { transform:scale(0.28); opacity:0.16; }
+    12% { transform:scale(0.42); opacity:0.52; }
+    28% { transform:scale(0.58); opacity:0.78; }
+    46% { transform:scale(0.76); opacity:0.72; }
+    64% { transform:scale(0.92); opacity:0.56; }
+    82% { transform:scale(1.06); opacity:0.34; }
+    100% { transform:scale(1.18); opacity:0.16; }
   }
   @keyframes ringRecoveryPulseBloom {
-    0% { transform:scale(0.62); opacity:0.08; }
-    18% { transform:scale(0.78); opacity:0.34; }
-    40% { transform:scale(0.96); opacity:0.44; }
-    64% { transform:scale(1.14); opacity:0.36; }
-    84% { transform:scale(1.26); opacity:0.22; }
-    100% { transform:scale(1.34); opacity:0.08; }
+    0% { transform:scale(0.68); opacity:0.12; }
+    18% { transform:scale(0.84); opacity:0.3; }
+    38% { transform:scale(1.02); opacity:0.4; }
+    58% { transform:scale(1.16); opacity:0.34; }
+    78% { transform:scale(1.28); opacity:0.24; }
+    100% { transform:scale(1.38); opacity:0.12; }
   }
   @keyframes ringRecoveryWaveTravel {
-    0% { transform:scale(0.14); opacity:0.08; }
-    12% { transform:scale(0.28); opacity:0.64; }
-    28% { transform:scale(0.46); opacity:0.82; }
-    50% { transform:scale(0.7); opacity:0.78; }
-    72% { transform:scale(0.9); opacity:0.62; }
-    88% { transform:scale(1.04); opacity:0.44; }
-    100% { transform:scale(1.14); opacity:0.08; }
+    0% { transform:scale(0.2); opacity:0.14; }
+    14% { transform:scale(0.34); opacity:0.56; }
+    30% { transform:scale(0.5); opacity:0.8; }
+    48% { transform:scale(0.68); opacity:0.78; }
+    66% { transform:scale(0.84); opacity:0.66; }
+    84% { transform:scale(0.98); opacity:0.5; }
+    100% { transform:scale(1.14); opacity:0.14; }
   }
   @keyframes ringRecoveryCoreSeed {
-    0% { transform:scale(0.5); opacity:0.12; }
-    10% { transform:scale(0.62); opacity:0.66; }
-    24% { transform:scale(0.74); opacity:0.9; }
-    42% { transform:scale(0.86); opacity:0.82; }
-    62% { transform:scale(0.96); opacity:0.62; }
-    82% { transform:scale(1.05); opacity:0.34; }
-    100% { transform:scale(1.12); opacity:0.12; }
+    0% { transform:scale(0.56); opacity:0.2; }
+    12% { transform:scale(0.66); opacity:0.62; }
+    28% { transform:scale(0.76); opacity:0.88; }
+    46% { transform:scale(0.86); opacity:0.82; }
+    64% { transform:scale(0.94); opacity:0.66; }
+    82% { transform:scale(1.02); opacity:0.42; }
+    100% { transform:scale(1.1); opacity:0.2; }
   }
 
   /* ── History action buttons ── */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -333,7 +333,7 @@
   }
   .ring-recovery-pulse {
     position:absolute;
-    inset:0;
+    inset:-10%;
     pointer-events:none;
     z-index:1;
   }
@@ -345,13 +345,25 @@
     transform-origin:center;
   }
   .ring-recovery-pulse__core {
-    background:radial-gradient(circle, color-mix(in srgb, var(--color-warm-accent-strong) 48%, white) 0%, color-mix(in srgb, var(--warm-accent-soft) 58%, transparent) 30%, color-mix(in srgb, var(--warm-accent-soft) 32%, transparent) 54%, transparent 78%);
-    animation:ringRecoveryPulseInner 1.9s cubic-bezier(0.33, 0, 0.2, 1) infinite;
+    inset:6%;
+    background:radial-gradient(circle,
+      color-mix(in srgb, var(--color-warm-accent-strong) 62%, white) 0%,
+      color-mix(in srgb, var(--color-warm-accent) 58%, rgba(255, 232, 200, 0.96)) 26%,
+      color-mix(in srgb, var(--warm-accent-soft) 56%, transparent) 56%,
+      color-mix(in srgb, var(--warm-accent-soft) 30%, transparent) 76%,
+      transparent 92%);
+    filter:saturate(1.1) brightness(1.08);
+    animation:ringRecoveryPulseInner 1.78s cubic-bezier(0.33, 0, 0.2, 1) infinite;
   }
   .ring-recovery-pulse__bloom {
-    inset:-14%;
-    background:radial-gradient(circle, color-mix(in srgb, var(--amber-light) 28%, transparent) 0%, color-mix(in srgb, var(--color-warm-accent) 30%, transparent) 42%, transparent 72%);
-    animation:ringRecoveryPulseBloom 1.9s cubic-bezier(0.33, 0, 0.2, 1) infinite 0.42s;
+    inset:-22%;
+    background:radial-gradient(circle,
+      color-mix(in srgb, var(--amber-light) 38%, rgba(255, 238, 214, 0.72)) 0%,
+      color-mix(in srgb, var(--color-warm-accent) 40%, rgba(255, 221, 178, 0.52)) 48%,
+      color-mix(in srgb, var(--color-warm-accent) 26%, transparent) 70%,
+      transparent 88%);
+    filter:blur(0.2px) saturate(1.06) brightness(1.06);
+    animation:ringRecoveryPulseBloom 1.78s cubic-bezier(0.33, 0, 0.2, 1) infinite 0.3s;
   }
   .ring-svg { position:absolute; inset:0; width:100%; height:100%; overflow:visible; z-index:2; }
   .ring-bg   { fill:none; stroke:color-mix(in srgb, var(--border) 72%, white); stroke-width:7; }
@@ -396,18 +408,19 @@
   .ring-inner-recovery-wave {
     inset:0;
     background:radial-gradient(circle,
-      rgba(255, 240, 220, 0.28) 0%,
-      rgba(255, 234, 206, 0.22) 34%,
-      rgba(255, 228, 198, 0.28) 62%,
-      rgba(255, 221, 189, 0.2) 84%,
-      rgba(255, 221, 189, 0.1) 95%,
+      rgba(255, 241, 219, 0.44) 0%,
+      rgba(255, 234, 203, 0.42) 36%,
+      rgba(255, 226, 191, 0.4) 68%,
+      rgba(255, 219, 182, 0.32) 84%,
+      rgba(255, 216, 178, 0.24) 94%,
       rgba(255, 221, 189, 0) 100%);
-    animation:ringRecoveryWaveTravel 1.82s cubic-bezier(0.32, 0, 0.2, 1) infinite;
+    filter:saturate(1.12) brightness(1.06);
+    animation:ringRecoveryWaveTravel 1.78s cubic-bezier(0.32, 0, 0.2, 1) infinite;
   }
   .ring-inner-recovery-core {
     inset:24%;
-    background:radial-gradient(circle, rgba(177, 105, 38, 0.48) 0%, rgba(202, 129, 62, 0.36) 38%, rgba(233, 174, 119, 0.12) 66%, rgba(233, 174, 119, 0) 100%);
-    animation:ringRecoveryCoreSeed 1.82s cubic-bezier(0.32, 0, 0.2, 1) infinite;
+    background:radial-gradient(circle, rgba(177, 105, 38, 0.62) 0%, rgba(202, 129, 62, 0.48) 40%, rgba(233, 174, 119, 0.24) 72%, rgba(233, 174, 119, 0) 100%);
+    animation:ringRecoveryCoreSeed 1.78s cubic-bezier(0.32, 0, 0.2, 1) infinite;
   }
   .ring-val {
     inline-size:max-content;
@@ -650,29 +663,33 @@
   .settings-sync-copy { font-size:var(--type-helper-text-size); color:var(--text-muted); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); }
   @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
   @keyframes ringRecoveryPulseInner {
-    0% { transform:scale(0.14); opacity:0; }
-    16% { opacity:0.66; }
-    58% { opacity:0.3; }
-    100% { transform:scale(1.08); opacity:0; }
+    0% { transform:scale(0.18); opacity:0; }
+    14% { opacity:0.86; }
+    52% { opacity:0.72; }
+    78% { opacity:0.38; }
+    100% { transform:scale(1.16); opacity:0; }
   }
   @keyframes ringRecoveryPulseBloom {
-    0% { transform:scale(0.5); opacity:0; }
-    22% { opacity:0.36; }
-    68% { opacity:0.16; }
-    100% { transform:scale(1.22); opacity:0; }
+    0% { transform:scale(0.58); opacity:0; }
+    20% { opacity:0.46; }
+    62% { opacity:0.34; }
+    86% { opacity:0.18; }
+    100% { transform:scale(1.34); opacity:0; }
   }
   @keyframes ringRecoveryWaveTravel {
-    0% { transform:scale(0.02); opacity:0; filter:brightness(0.99); }
-    12% { opacity:0.68; }
-    54% { opacity:0.56; }
-    88% { opacity:0.3; }
-    100% { transform:scale(1.06); opacity:0; filter:brightness(1.04); }
+    0% { transform:scale(0.08); opacity:0; filter:saturate(1.08) brightness(1.01); }
+    12% { opacity:0.82; }
+    56% { opacity:0.78; }
+    80% { opacity:0.56; }
+    94% { opacity:0.32; }
+    100% { transform:scale(1.14); opacity:0; filter:saturate(1) brightness(1.08); }
   }
   @keyframes ringRecoveryCoreSeed {
-    0% { transform:scale(0.44); opacity:0; filter:saturate(1.05) brightness(0.88); }
-    14% { transform:scale(0.68); opacity:0.78; }
-    46% { opacity:0.38; }
-    100% { transform:scale(1.08); opacity:0; filter:saturate(1) brightness(1.02); }
+    0% { transform:scale(0.46); opacity:0; filter:saturate(1.15) brightness(0.9); }
+    12% { transform:scale(0.7); opacity:0.9; }
+    48% { opacity:0.64; }
+    78% { opacity:0.28; }
+    100% { transform:scale(1.12); opacity:0; filter:saturate(1.02) brightness(1.04); }
   }
 
   /* ── History action buttons ── */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -343,6 +343,7 @@
     inset:0;
     border-radius:50%;
     transform-origin:center;
+    will-change:transform, opacity;
   }
   .ring-recovery-pulse__core {
     inset:6%;
@@ -353,7 +354,7 @@
       color-mix(in srgb, var(--warm-accent-soft) 30%, transparent) 76%,
       transparent 92%);
     filter:saturate(1.1) brightness(1.08);
-    animation:ringRecoveryPulseInner 1.78s cubic-bezier(0.33, 0, 0.2, 1) infinite;
+    animation:ringRecoveryPulseInner 1.72s cubic-bezier(0.22, 0.61, 0.36, 1) infinite;
   }
   .ring-recovery-pulse__bloom {
     inset:-22%;
@@ -363,7 +364,7 @@
       color-mix(in srgb, var(--color-warm-accent) 26%, transparent) 70%,
       transparent 88%);
     filter:blur(0.2px) saturate(1.06) brightness(1.06);
-    animation:ringRecoveryPulseBloom 1.78s cubic-bezier(0.33, 0, 0.2, 1) infinite 0.3s;
+    animation:ringRecoveryPulseBloom 1.72s cubic-bezier(0.22, 0.61, 0.36, 1) infinite 0.22s;
   }
   .ring-svg { position:absolute; inset:0; width:100%; height:100%; overflow:visible; z-index:2; }
   .ring-bg   { fill:none; stroke:color-mix(in srgb, var(--border) 72%, white); stroke-width:7; }
@@ -399,6 +400,7 @@
     border-radius:inherit;
     transform-origin:center;
     pointer-events:none;
+    will-change:transform, opacity;
   }
   .ring-inner-recovery-face {
     background:
@@ -415,12 +417,12 @@
       rgba(255, 216, 178, 0.24) 94%,
       rgba(255, 221, 189, 0) 100%);
     filter:saturate(1.12) brightness(1.06);
-    animation:ringRecoveryWaveTravel 1.78s cubic-bezier(0.32, 0, 0.2, 1) infinite;
+    animation:ringRecoveryWaveTravel 1.72s cubic-bezier(0.22, 0.61, 0.36, 1) infinite;
   }
   .ring-inner-recovery-core {
     inset:24%;
     background:radial-gradient(circle, rgba(177, 105, 38, 0.62) 0%, rgba(202, 129, 62, 0.48) 40%, rgba(233, 174, 119, 0.24) 72%, rgba(233, 174, 119, 0) 100%);
-    animation:ringRecoveryCoreSeed 1.78s cubic-bezier(0.32, 0, 0.2, 1) infinite;
+    animation:ringRecoveryCoreSeed 1.72s cubic-bezier(0.22, 0.61, 0.36, 1) infinite;
   }
   .ring-val {
     inline-size:max-content;
@@ -663,33 +665,39 @@
   .settings-sync-copy { font-size:var(--type-helper-text-size); color:var(--text-muted); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); }
   @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
   @keyframes ringRecoveryPulseInner {
-    0% { transform:scale(0.18); opacity:0; }
-    14% { opacity:0.86; }
-    52% { opacity:0.72; }
-    78% { opacity:0.38; }
-    100% { transform:scale(1.16); opacity:0; }
+    0% { transform:scale(0.22); opacity:0.08; }
+    10% { transform:scale(0.34); opacity:0.54; }
+    24% { transform:scale(0.5); opacity:0.84; }
+    44% { transform:scale(0.72); opacity:0.78; }
+    66% { transform:scale(0.92); opacity:0.58; }
+    84% { transform:scale(1.06); opacity:0.34; }
+    100% { transform:scale(1.16); opacity:0.08; }
   }
   @keyframes ringRecoveryPulseBloom {
-    0% { transform:scale(0.58); opacity:0; }
-    20% { opacity:0.46; }
-    62% { opacity:0.34; }
-    86% { opacity:0.18; }
-    100% { transform:scale(1.34); opacity:0; }
+    0% { transform:scale(0.62); opacity:0.08; }
+    18% { transform:scale(0.78); opacity:0.34; }
+    40% { transform:scale(0.96); opacity:0.44; }
+    64% { transform:scale(1.14); opacity:0.36; }
+    84% { transform:scale(1.26); opacity:0.22; }
+    100% { transform:scale(1.34); opacity:0.08; }
   }
   @keyframes ringRecoveryWaveTravel {
-    0% { transform:scale(0.08); opacity:0; filter:saturate(1.08) brightness(1.01); }
-    12% { opacity:0.82; }
-    56% { opacity:0.78; }
-    80% { opacity:0.56; }
-    94% { opacity:0.32; }
-    100% { transform:scale(1.14); opacity:0; filter:saturate(1) brightness(1.08); }
+    0% { transform:scale(0.14); opacity:0.08; }
+    12% { transform:scale(0.28); opacity:0.64; }
+    28% { transform:scale(0.46); opacity:0.82; }
+    50% { transform:scale(0.7); opacity:0.78; }
+    72% { transform:scale(0.9); opacity:0.62; }
+    88% { transform:scale(1.04); opacity:0.44; }
+    100% { transform:scale(1.14); opacity:0.08; }
   }
   @keyframes ringRecoveryCoreSeed {
-    0% { transform:scale(0.46); opacity:0; filter:saturate(1.15) brightness(0.9); }
-    12% { transform:scale(0.7); opacity:0.9; }
-    48% { opacity:0.64; }
-    78% { opacity:0.28; }
-    100% { transform:scale(1.12); opacity:0; filter:saturate(1.02) brightness(1.04); }
+    0% { transform:scale(0.5); opacity:0.12; }
+    10% { transform:scale(0.62); opacity:0.66; }
+    24% { transform:scale(0.74); opacity:0.9; }
+    42% { transform:scale(0.86); opacity:0.82; }
+    62% { transform:scale(0.96); opacity:0.62; }
+    82% { transform:scale(1.05); opacity:0.34; }
+    100% { transform:scale(1.12); opacity:0.12; }
   }
 
   /* ── History action buttons ── */


### PR DESCRIPTION
### Motivation
- The left “Next session” ring in recovery mode was under-communicating interactivity and needed a clearer, warmer tap cue.
- The visual signal must be noticeably stronger and extend slightly outside the ring while retaining a premium, soft-edged look.
- Changes must be scoped to the recovery pulse only so the right ring and layout remain unchanged.

### Description
- Increased the pulse container overflow and bloom reach by changing `.ring-recovery-pulse` to `inset:-10%` and expanding the bloom to `inset:-22%` so a soft glow can extend beyond the circle edge. (file: `src/styles/app.css`)
- Strengthened core luminance and saturation by adding `inset:6%`, richer radial-gradient stops, and `filter:saturate(1.1) brightness(1.08)` to `.ring-recovery-pulse__core`, making the center-origin wave visually stronger and more noticeable. (file: `src/styles/app.css`)
- Made the outer bloom more visible and supportive by intensifying bloom color stops, adding a mild blur/saturate filter, and increasing bloom timing/scale so the supportive glow reads outside the circle without becoming harsh. (file: `src/styles/app.css`)
- Slowed and re-tuned fade/desaturation by adjusting keyframes (`ringRecoveryPulseInner`, `ringRecoveryPulseBloom`, `ringRecoveryWaveTravel`, `ringRecoveryCoreSeed`) to hold higher opacity and color further into the outward travel and to finish at a larger scale, preserving warm color longer before fading. (file: `src/styles/app.css`)
- Increased inner wave richness by boosting alpha stops and adding `filter:saturate(1.12) brightness(1.06)` so the wave keeps color intensity longer while the primary motion remains inside the circle. (file: `src/styles/app.css`)
- Scope preserved: `showRecoveryPulse` and `ring-wrap--recovery-pulse` usage is unchanged in `src/features/home/HomeScreen.jsx`, so only the left "Next session" ring animates. (files read: `src/features/home/HomeScreen.jsx`, `src/features/stats/StatsComponents.jsx`)

### Testing
- Built the production bundle with `npm run build` and the build completed successfully. 
- Changes were committed (`git` status clean) and no other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfcc05ef88833286c806ccc0141965)