### PR TITLE
Remove decorative icons from Settings → Custom labels

### DIFF
--- a/src/features/settings/SettingsScreen.jsx
+++ b/src/features/settings/SettingsScreen.jsx
@@ -1,5 +1,5 @@
 import { PATTERN_TYPES } from "../app/helpers";
-import { DeleteIcon, EditIcon, Img, ModalCloseButton } from "../app/ui";
+import { DeleteIcon, ModalCloseButton } from "../app/ui";
 import { useState } from "react";
 
 const SETTINGS_PANEL = {
@@ -191,14 +191,15 @@ export default function SettingsScreen(props) {
             <div className="settings-modal-stack">
               {PATTERN_TYPES.map((pt) => (
                 <div key={pt.type} className="pat-edit-row">
-                  <Img src={pt.icon} size={28} alt={pt.label} />
                   {editingPat === pt.type ? (
                     <input className="pat-edit-input" autoFocus aria-label={`Rename ${pt.label}`} defaultValue={patLabels[pt.type] || pt.label} onBlur={(e) => { const val = e.target.value.trim(); if (val) setPatLabels((prev) => ({ ...prev, [pt.type]: val })); setEditingPat(null); }} onKeyDown={(e) => { if (e.key === "Enter") e.target.blur(); if (e.key === "Escape") setEditingPat(null); }} />
                   ) : (
                     <span className="pat-edit-label">{patLabels[pt.type] || pt.label}</span>
                   )}
-                  <button className="pat-edit-btn secondary-control secondary-control--icon" onClick={() => setEditingPat(pt.type)} aria-label={`Edit ${pt.label} name`}><EditIcon /></button>
-                  {editingPat === pt.type && patLabels[pt.type] && <button className="settings-inline-reset-btn t-helper secondary-control secondary-control--inline-text" onMouseDown={(e) => e.preventDefault()} onClick={() => setPatLabels((prev) => { const n = { ...prev }; delete n[pt.type]; return n; })} aria-label="Reset to default">Reset</button>}
+                  <div className="pat-edit-actions">
+                    <button className="pat-edit-btn t-helper secondary-control secondary-control--inline-text" onClick={() => setEditingPat(pt.type)} aria-label={`Edit ${pt.label} name`}>Edit</button>
+                    {editingPat === pt.type && patLabels[pt.type] && <button className="settings-inline-reset-btn t-helper secondary-control secondary-control--inline-text" onMouseDown={(e) => e.preventDefault()} onClick={() => setPatLabels((prev) => { const n = { ...prev }; delete n[pt.type]; return n; })} aria-label="Reset to default">Reset</button>}
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -733,41 +733,9 @@
   .pat-edit-label { flex:1; font-size:var(--type-body-size); color:var(--brown); }
   /* Form controls: inline edit */
   .pat-edit-input { flex:1; padding:var(--space-field-padding-default); border:1.5px solid var(--primaryBlue); border-radius:var(--radius-sm); font-size:var(--type-body-size); color:var(--brown); background:var(--surface-muted); outline:none; }
-  .pat-edit-btn,
-  .pat-edit-reset {
-    --small-tertiary-size:40px;
-    background:none;
-    border:1px solid transparent;
-    border-radius:999px;
-    inline-size:var(--small-tertiary-size);
-    block-size:var(--small-tertiary-size);
-    flex:0 0 var(--small-tertiary-size);
-    display:inline-flex;
-    align-items:center;
-    justify-content:center;
-    line-height:1;
-    cursor:pointer;
-    padding:0;
-    transition:color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
-  }
-  .pat-edit-btn { font-size:var(--type-button-size); color:var(--primaryBlue); }
-  .pat-edit-btn svg,
-  .pat-edit-reset svg {
-    inline-size:18px;
-    block-size:18px;
-    display:block;
-  }
-  .pat-edit-btn:hover {
-    color:var(--blue-darker);
-    background:color-mix(in srgb, var(--softBlue) 72%, transparent);
-    border-color:color-mix(in srgb, var(--mutedBlue) 24%, transparent);
-  }
-  .pat-edit-reset { font-size:var(--type-button-compact-size); color:var(--brown-muted); }
-  .pat-edit-reset:hover {
-    color:var(--red);
-    background:color-mix(in srgb, var(--status-danger-bg) 80%, transparent);
-    border-color:color-mix(in srgb, var(--status-danger-bg-strong) 84%, transparent);
-  }
+  .pat-edit-actions { display:flex; align-items:center; gap:var(--space-control-gap); flex-shrink:0; }
+  .pat-edit-btn { border:none; background:none; cursor:pointer; color:var(--primaryBlue); text-decoration:underline; }
+  .pat-edit-btn:hover { color:var(--blue-darker); }
   .h-item { margin-bottom:var(--space-card-row-gap); align-items:flex-start; animation:surfaceEnter var(--motion-enter) var(--ease-out); }
   .h-item.is-expanded { box-shadow:var(--shadow-lg); }
   .h-dot { width:40px; height:40px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-size:var(--type-button-size); flex-shrink:0; position:relative; }
@@ -964,7 +932,7 @@
     letter-spacing: var(--secondary-letter-spacing);
   }
 
-  :is(.modal-close-btn, .pat-edit-btn, .pat-edit-reset, .h-action-btn).secondary-control--icon {
+  :is(.modal-close-btn, .h-action-btn).secondary-control--icon {
     min-height: var(--secondary-min-height);
     min-width: var(--secondary-min-height);
   }

--- a/src/styles/shared.css
+++ b/src/styles/shared.css
@@ -766,7 +766,7 @@
 }
 
 
-:is(.walk-cancel-btn, .settings-inline-btn, .settings-btn, .copy-btn, .diag-run-btn, .pat-edit-btn, .pat-edit-reset, .settings-collapsible-toggle, .history-delete-confirm, .btn-save-outcome, .btn-result, .quick-action-btn, .walk-type-option, .btn-pat, .modal-close-btn, .ring-sub-btn, .tab-btn, .notif-toggle, .session-end-btn, .session-cancel-btn, .es-cta):active:not(:disabled) {
+:is(.walk-cancel-btn, .settings-inline-btn, .settings-btn, .copy-btn, .diag-run-btn, .pat-edit-btn, .settings-collapsible-toggle, .history-delete-confirm, .btn-save-outcome, .btn-result, .quick-action-btn, .walk-type-option, .btn-pat, .modal-close-btn, .ring-sub-btn, .tab-btn, .notif-toggle, .session-end-btn, .session-cancel-btn, .es-cta):active:not(:disabled) {
   transform: scale(0.96);
 }
 


### PR DESCRIPTION
### Motivation
- The Custom labels panel contained decorative icons and an icon-only edit button that added visual noise and made the section feel heavier than necessary.
- The goal is to make the Custom labels rows text-only and visually lighter while preserving all behavior and interactions.

### Description
- Removed the per-row decorative icon element by deleting the `<Img src={pt.icon} ... />` usage in `src/features/settings/SettingsScreen.jsx` and removed the now-unused `Img` and `EditIcon` imports from that file.
- Replaced the icon-only edit affordance with a visible text `Edit` button and grouped the edit/reset controls inside a new `.pat-edit-actions` wrapper to preserve layout and keep vertical alignment in `src/features/settings/SettingsScreen.jsx`.
- Cleaned up CSS by removing icon/button-specific styles for the old circular icon button, adding `.pat-edit-actions` and a simpler `.pat-edit-btn` rule in `src/styles/app.css`, and removing the removed-class from a shared active-state selector in `src/styles/shared.css`.
- No logic, data binding, save, reset behavior, or translations were changed; only presentational/icon code and related styles were removed or adapted.

### Testing
- Built the production bundle with `npm run build` and the build completed successfully.
- No automated unit tests were present for this UI area, so validation was limited to successful build and style/layout adjustments during development.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfce21075083329200b599e951f7e1)