### PR TITLE
Remove Activity Log entry icons

### DIFF
--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -3,7 +3,7 @@ import EmptyState from "../../components/EmptyState";
 import { buildEditedActivityIso, sortByDateAsc, toDateInputValue, toTimeInputValue } from "../../lib/activityDateTime";
 import { normalizeDistressLevel } from "../../lib/protocol";
 import { PATTERN_TYPES, fmt, fmtDate, parseDurationInput, sessionDetailBadges, walkTypeLabel } from "../app/helpers";
-import { ClockIcon, DeleteIcon, EditIcon, FoodIcon, Img, ModalCloseButton, TrendIcon } from "../app/ui";
+import { ClockIcon, DeleteIcon, EditIcon, ModalCloseButton, TrendIcon } from "../app/ui";
 import { mergeSessionWithDerivedFields, normalizeSession } from "../app/storage";
 
 function HistoryActionGroup({ actions }) {
@@ -220,7 +220,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
     setExpandedItemKey((prev) => (prev === itemKey ? null : itemKey));
   };
 
-  const renderHistoryCard = ({ itemKey, iconClassName, markerClassName, icon, title, date, value, badge, syncBadge, expandedContent }) => {
+  const renderHistoryCard = ({ itemKey, title, date, value, badge, syncBadge, expandedContent }) => {
     const isExpanded = expandedItemKey === itemKey;
     const detailsId = `history-details-${itemKey}`;
 
@@ -239,7 +239,6 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
           toggleExpandedItem(itemKey);
         }}
       >
-        <div className={`h-dot ${iconClassName} ${markerClassName}`.trim()}>{icon}</div>
         <div className="h-body">
           <div className="h-content">
             <div className="h-info">
@@ -279,13 +278,9 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
             if (item.kind === "session") {
               const s = item.data;
               const lv = normalizeDistressLevel(s.distressLevel ?? (s.result === "success" ? "none" : "strong"));
-              const icon = lv === "none" ? "result-calm.png" : lv === "subtle" ? "result-mild.png" : "result-strong.png";
               const detailBadges = sessionDetailBadges(s);
               return renderHistoryCard({
                 itemKey: `s-${s.id}`,
-                iconClassName: `dot-${lv}`,
-                markerClassName: "marker-session",
-                icon: <Img src={icon} size={22} />,
                 title: "Training session",
                 date: fmtDate(s.date),
                 value: fmt(s.actualDuration),
@@ -315,9 +310,6 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
               const w = item.data;
               return renderHistoryCard({
                 itemKey: `w-${w.id}`,
-                iconClassName: "dot-walk",
-                markerClassName: "marker-walk",
-                icon: <Img src="walk.png" size={22} />,
                 title: `${walkTypeLabel(w.type)} with ${name}`,
                 date: fmtDate(w.date),
                 value: w.duration ? fmt(w.duration) : "—",
@@ -348,9 +340,6 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
               const pt = PATTERN_TYPES.find((x) => x.type === p.type) ?? PATTERN_TYPES[0];
               return renderHistoryCard({
                 itemKey: `p-${p.id}`,
-                iconClassName: "dot-pat",
-                markerClassName: "marker-pat",
-                icon: <Img src={pt.icon} size={22} />,
                 title: patLabels[pt.type] || pt.label,
                 date: fmtDate(p.date),
                 badge: <span className="h-badge badge-pat">Pattern break</span>,
@@ -377,9 +366,6 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
               const f = item.data;
               return renderHistoryCard({
                 itemKey: `f-${f.id}`,
-                iconClassName: "dot-feed",
-                markerClassName: "marker-feed",
-                icon: <FoodIcon />,
                 title: <span className="history-food-type">{f.foodType}</span>,
                 date: fmtDate(f.date),
                 value: f.amount,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -738,32 +738,8 @@
   .pat-edit-btn:hover { color:var(--blue-darker); }
   .h-item { margin-bottom:var(--space-card-row-gap); align-items:flex-start; animation:surfaceEnter var(--motion-enter) var(--ease-out); }
   .h-item.is-expanded { box-shadow:var(--shadow-lg); }
-  .h-dot { width:40px; height:40px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-size:var(--type-button-size); flex-shrink:0; position:relative; }
-  .h-dot svg { width:22px; height:22px; display:block; }
-  .h-dot::after {
-    content:"";
-    position:absolute;
-    right:4px;
-    bottom:4px;
-    width:8px;
-    height:8px;
-    background:var(--surf);
-    border:1.5px solid var(--brown-mid);
-    box-sizing:border-box;
-  }
-  .marker-session::after { border-radius:50%; }
-  .marker-walk::after { border-radius:2px; }
-  .marker-pat::after { border-radius:1px; transform:rotate(45deg); }
-  .marker-feed::after { width:10px; height:6px; border-radius:999px; }
   .h-body { flex:1; min-width:0; display:flex; flex-direction:column; gap:var(--space-control-gap); }
   .h-content { display:flex; align-items:flex-start; justify-content:space-between; gap:var(--space-control-gap); min-width:0; }
-  .dot-none   { background:var(--status-success-bg); }
-  .dot-subtle { background:color-mix(in srgb, var(--warning) 16%, transparent); }
-  .dot-active { background:var(--status-attention-bg); }
-  .dot-severe { background:var(--status-danger-bg); }
-  .dot-walk   { background:color-mix(in srgb, var(--success) 20%, transparent); }
-  .dot-feed   { background:var(--status-warning-bg-strong); color:var(--brown); }
-  .dot-pat    { background:var(--status-neutral-bg); }
   .h-info { flex:1; min-width:0; display:flex; flex-direction:column; gap:var(--row-gap-dense); padding-top:1px; }
   .h-main { font-size:var(--type-list-row-title-size); font-weight:var(--type-list-row-title-weight); line-height:var(--type-list-row-title-line); letter-spacing:var(--type-list-row-title-track); color:var(--brown); }
   .h-meta-line { display:flex; flex-wrap:wrap; align-items:center; gap:8px; min-width:0; }


### PR DESCRIPTION
### Motivation
- Activity Log rows feel visually noisy due to leading/trailing icons; the goal is a cleaner, text-first list with the same behavior and content.

### Description
- Removed the leading decorative icon slot from Activity Log rows by eliminating the icon container and icon-related props from `renderHistoryCard` so rows render text-only titles, dates, values and badges.
- Deleted unused imports tied to row icons (`FoodIcon`, `Img`) while preserving action icons used inside expanded row actions (`ClockIcon`, `EditIcon`, `DeleteIcon`).
- Removed icon-related CSS rules (the `.h-dot` wrapper, marker variants and the `dot-*` color classes) while keeping spacing, alignment and all other row styles intact.
- Files changed: `src/features/history/HistoryFeature.jsx` and `src/styles/app.css`.

### Testing
- Ran the test suite with `npm run test` and all automated tests passed: 5 test files, 46 tests total (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfd13ff7948332b58187a169d7f8fd)