### PR TITLE
Expire stale subtle-stress recovery anchors to avoid unexpected re-triggering

### DIFF
--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -9,6 +9,8 @@ export const PROTOCOL = {
   goalDurationDefaultSeconds: 7200,
   subtleRecoveryDurationSeconds: 60,
   subtleRecoverySessionCount: 2,
+  subtleRecoveryAnchorClosureCalmSessions: 3,
+  subtleRecoveryAnchorMaxAgeDays: 7,
   stabilizationDistressThreshold: 2,
   stabilizationWindow: 6,
   calmWindow: 8,
@@ -347,6 +349,20 @@ function getSubtleRecoveryContext(trainingSessions = []) {
   if (subtleIndex < 0) return base;
 
   const subtle = trainingSessions[subtleIndex];
+  const nowTime = Date.now();
+  const subtleTime = toTimestamp(subtle?.date);
+  const anchorIsRecent = Number.isFinite(subtleTime)
+    && (nowTime - subtleTime) <= (PROTOCOL.subtleRecoveryAnchorMaxAgeDays * DAY_MS);
+
+  let trailingCalmAfterSubtle = 0;
+  for (let i = trainingSessions.length - 1; i > subtleIndex; i -= 1) {
+    if (trainingSessions[i].distressLevel !== DISTRESS_LEVELS.NONE) break;
+    trailingCalmAfterSubtle += 1;
+  }
+  const anchorHasCalmClosure = trailingCalmAfterSubtle >= PROTOCOL.subtleRecoveryAnchorClosureCalmSessions;
+  const anchorStillValid = anchorIsRecent && !anchorHasCalmClosure;
+  if (!anchorStillValid) return base;
+
   const anchorDuration = Math.max(
     PROTOCOL.minDurationSeconds,
     Number(subtle?.actualDuration) > 0 ? Number(subtle.actualDuration) : Number(subtle?.plannedDuration || PROTOCOL.minDurationSeconds),

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -158,6 +158,20 @@ describe("recommendation engine", () => {
     expect(step2.recoveryMode.step).toBe(2);
   });
 
+  it("does not let stale subtle anchors re-trigger recovery after clear calm closure", () => {
+    const sessions = [
+      { date: daysAgo(14), plannedDuration: 1200, actualDuration: 1200, distressLevel: "subtle", belowThreshold: false },
+      { date: daysAgo(3), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(2), plannedDuration: 1000, actualDuration: 1000, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(1), plannedDuration: 1100, actualDuration: 1100, distressLevel: "none", belowThreshold: true },
+    ];
+
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recoveryMode.active).toBe(false);
+    expect(rec.recommendationType).not.toBe("subtle_recovery_mode");
+    expect(rec.recommendationType).not.toBe("subtle_recovery_resume");
+  });
+
   it("does not collapse to 30s on subtle distress when latest actual duration is much longer", () => {
     const sessions = [
       { date: daysAgo(0), plannedDuration: 1380, actualDuration: 1380, distressLevel: "none", belowThreshold: true },
@@ -247,6 +261,30 @@ describe("recommendation engine", () => {
     const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
     expect(rec.recommendedDuration).toBeGreaterThanOrEqual(30);
     expect(rec.recommendationType).not.toBe("stabilization_block");
+  });
+
+  it("handles mixed unsorted history and still applies fresh subtle recovery steps", () => {
+    const sessions = [
+      { date: daysAgo(1), plannedDuration: 60, actualDuration: 60, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(0), plannedDuration: 180, actualDuration: 180, distressLevel: "none", belowThreshold: true, context: { departureType: "real_life" } },
+      { date: daysAgo(2), plannedDuration: 1200, actualDuration: 1200, distressLevel: "subtle", belowThreshold: false },
+    ];
+
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recoveryMode.active).toBe(true);
+    expect(rec.recoveryMode.step).toBe(2);
+    expect(rec.recommendedDuration).toBe(120);
+  });
+
+  it("does not break on empty or incomplete subtle history", () => {
+    const recEmpty = buildRecommendation([], { goalSeconds: 3600 });
+    expect(recEmpty.recommendedDuration).toBeGreaterThanOrEqual(30);
+
+    const recIncomplete = buildRecommendation([
+      { distressLevel: "subtle", plannedDuration: null, actualDuration: null },
+    ], { goalSeconds: 3600 });
+    expect(recIncomplete.recoveryMode.active).toBe(false);
+    expect(recIncomplete.recommendationType).not.toBe("subtle_recovery_mode");
   });
 
   it("rolls back and enters stabilization mode after repeated active distress", () => {


### PR DESCRIPTION
### Motivation
- Prevent an old subtle-stress session from being used as an active recovery anchor after the user has clearly moved on, which caused surprise short recommendations.
- Keep the change minimal and release-safe by only tightening anchor validity checks in the recommendation logic without touching UI, storage, or unrelated progression rules.

### Description
- Added two conservative protocol knobs to `PROTOCOL` in `src/lib/protocol.js`: `subtleRecoveryAnchorClosureCalmSessions: 3` and `subtleRecoveryAnchorMaxAgeDays: 7`.
- In `getSubtleRecoveryContext(trainingSessions)` implemented a combined expiry/closure guard that returns an inactive base when the subtle anchor is not both recent and meaningfully still active.
- The anchor is now treated valid only if the subtle event is within the last `subtleRecoveryAnchorMaxAgeDays` days and there are fewer than `subtleRecoveryAnchorClosureCalmSessions` trailing consecutive calm training sessions after it; otherwise the subtle-recovery context is ignored and normal recommendation logic proceeds.
- Kept the existing subtle-recovery flow (60s then 120s then resume at ~95% of anchor duration) and the recovery progression implementation unchanged for fresh anchors.

### Testing
- Added/updated tests in `tests/protocol.test.js` covering: stale subtle anchor not re-triggering recovery, mixed/unsorted history with a fresh subtle anchor, and empty/incomplete subtle history handling.
- Ran the focused tests (`vitest run tests/protocol.test.js`) and then the full suite (`npm test`), and all tests passed (all test files green).
- Existing subtle-recovery tests (fresh 1m→2m progression and resume behavior) continue to pass, confirming no regressions to intended fresh-anchor behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8cfead80c8332a51ee829e78284a9)