### PR TITLE
Add persistent Recovery Mode with stateful override and persistence

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -539,6 +539,15 @@ export default function PawTimer() {
     } finally { setSyncDiagRunning(false); }
   };
 
+  const persistRecoveryState = useCallback((nextRecoveryState) => {
+    if (!activeDogId) return;
+    setDogs((prev) => prev.map((dog) => (
+      canonicalDogId(dog?.id) === canonicalDogId(activeDogId)
+        ? { ...dog, recoveryState: nextRecoveryState ?? null }
+        : dog
+    )));
+  }, [activeDogId]);
+
   const recordResult = (distressLevelInput, options = {}) => {
     const distressLevel = normalizeDistressLevel(distressLevelInput);
     const dog = appData.dog;
@@ -552,7 +561,9 @@ export default function PawTimer() {
     const session = stampLocalEntry(rawSession);
     const updated = commitSessions((prev) => [...prev, session]);
     pushWithSyncStatus("session", session).then(({ ok, error }) => { if (!ok) showToast(`Sync failed: ${error}`); });
-    const next = suggestNextWithContext(updated, walks, patterns, dog) ?? suggestNext(updated, dog);
+    const nextTarget = explainNextTarget(updated, walks, patterns, dog);
+    persistRecoveryState(nextTarget?.recoveryState ?? null);
+    const next = nextTarget?.recommendedDuration ?? (suggestNextWithContext(updated, walks, patterns, dog) ?? suggestNext(updated, dog));
     cancelSession();
     const n = dog?.dogName ?? "your dog";
     if (distressLevel === "none") showToast(`${n} was calm. Next: ${fmt(next)}`);

--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -670,6 +670,77 @@ function computeFallbackFromCalmHistory(recentWindow = [], anchorDuration = null
   };
 }
 
+function normalizeRecoveryState(state = null) {
+  if (!state || typeof state !== "object") return null;
+  const anchorDuration = Number(state.anchorDuration);
+  const fixedDuration = Number(state.fixedDuration);
+  const consecutiveCalm = Number(state.consecutiveCalm);
+  return {
+    active: state.active === true,
+    triggerSessionId: state.triggerSessionId || null,
+    anchorDuration: Number.isFinite(anchorDuration) && anchorDuration > 0 ? Math.round(anchorDuration) : null,
+    fixedDuration: Number.isFinite(fixedDuration) && fixedDuration >= 60 && fixedDuration <= 90 ? Math.round(fixedDuration) : 60,
+    consecutiveCalm: Number.isFinite(consecutiveCalm) ? clamp(Math.round(consecutiveCalm), 0, 2) : 0,
+  };
+}
+
+function evaluatePersistentRecoveryMode(trainingSessions = [], recoveryState = null, goalSeconds = PROTOCOL.goalDurationDefaultSeconds) {
+  const normalized = normalizeRecoveryState(recoveryState);
+  if (!normalized?.active) return null;
+  const triggerIndex = trainingSessions.findIndex((session) => session.id && session.id === normalized.triggerSessionId);
+  if (triggerIndex < 0) return null;
+
+  const afterTrigger = trainingSessions.slice(triggerIndex + 1);
+  let consecutiveCalm = 0;
+  for (const session of afterTrigger) {
+    if (session.distressLevel === DISTRESS_LEVELS.NONE) consecutiveCalm += 1;
+    else consecutiveCalm = 0;
+  }
+
+  const completed = consecutiveCalm >= 2;
+  const persistedState = {
+    ...normalized,
+    active: !completed,
+    consecutiveCalm: clamp(consecutiveCalm, 0, 2),
+  };
+
+  if (!completed) {
+    const fixedDuration = clamp(normalized.fixedDuration, 60, 90);
+    return {
+      recommendedDuration: clamp(fixedDuration, PROTOCOL.minDurationSeconds, goalSeconds),
+      recommendationType: "recovery_mode_active",
+      recoveryMode: {
+        active: true,
+        recoveryActive: true,
+        remainingSessions: Math.max(1, 2 - consecutiveCalm),
+        step: Math.min(2, consecutiveCalm + 1),
+        anchorSessionDate: trainingSessions[triggerIndex]?.date || null,
+        anchorDuration: normalized.anchorDuration,
+        recoveryDuration: fixedDuration,
+        postRecoveryDuration: normalized.anchorDuration ? Math.max(PROTOCOL.minDurationSeconds, Math.round(normalized.anchorDuration * 0.95)) : null,
+      },
+      recoveryState: persistedState,
+    };
+  }
+
+  const resumeDuration = Math.max(PROTOCOL.minDurationSeconds, Math.round((normalized.anchorDuration || PROTOCOL.startDurationSeconds) * 0.95));
+  return {
+    recommendedDuration: clamp(resumeDuration, PROTOCOL.minDurationSeconds, goalSeconds),
+    recommendationType: "recovery_mode_resume",
+    recoveryMode: {
+      active: false,
+      recoveryActive: false,
+      remainingSessions: 0,
+      step: 2,
+      anchorSessionDate: trainingSessions[triggerIndex]?.date || null,
+      anchorDuration: normalized.anchorDuration,
+      recoveryDuration: null,
+      postRecoveryDuration: resumeDuration,
+    },
+    recoveryState: persistedState,
+  };
+}
+
 export function computeNextTarget(trainingSessions = [], options = {}) {
   const normalizedTraining = sortByDateAsc(trainingSessions).map(toRichSession);
   const recentWindow = getRecentTrainingWindow(normalizedTraining, 7);
@@ -677,6 +748,7 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
   const goalSeconds = Number(options.goalSeconds || PROTOCOL.goalDurationDefaultSeconds);
   const relapseRisk = clamp01(Number(options.relapseRisk));
   const reductionPercent = relapseRisk >= 0.72 ? 0.2 : relapseRisk >= 0.58 ? 0.15 : 0.1;
+  const existingRecoveryState = normalizeRecoveryState(options.recoveryState);
 
   if (!lastSession) {
     return {
@@ -691,6 +763,38 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
         recoveryDuration: null,
         postRecoveryDuration: null,
       },
+      recoveryState: existingRecoveryState,
+    };
+  }
+
+  const activePersistentRecovery = evaluatePersistentRecoveryMode(normalizedTraining, existingRecoveryState, goalSeconds);
+  if (activePersistentRecovery) return activePersistentRecovery;
+
+  if (!existingRecoveryState?.active && [DISTRESS_LEVELS.SUBTLE, DISTRESS_LEVELS.ACTIVE, DISTRESS_LEVELS.SEVERE].includes(lastSession.distressLevel)) {
+    const anchorDuration = getSessionDurationAnchor(getLastCalmSession(normalizedTraining.slice(0, -1)))
+      ?? getSessionDurationAnchor(lastSession)
+      ?? PROTOCOL.startDurationSeconds;
+    const recoveryState = {
+      active: true,
+      triggerSessionId: lastSession.id || null,
+      anchorDuration: Math.max(PROTOCOL.minDurationSeconds, Math.round(anchorDuration)),
+      fixedDuration: 60,
+      consecutiveCalm: 0,
+    };
+    return {
+      recommendedDuration: 60,
+      recommendationType: "recovery_mode_active",
+      recoveryMode: {
+        active: true,
+        recoveryActive: true,
+        remainingSessions: 2,
+        step: 1,
+        anchorSessionDate: lastSession.date || null,
+        anchorDuration: recoveryState.anchorDuration,
+        recoveryDuration: 60,
+        postRecoveryDuration: Math.max(PROTOCOL.minDurationSeconds, Math.round(recoveryState.anchorDuration * 0.95)),
+      },
+      recoveryState,
     };
   }
 
@@ -944,6 +1048,7 @@ export function buildRecommendation(sessions = [], options = {}) {
     recommendationType: focusArea,
     stabilizationMode: stats.relapseRisk >= 0.72,
     recoveryMode: nextTarget.recoveryMode,
+    recoveryState: nextTarget.recoveryState ?? normalizeRecoveryState(options.recoveryState),
     stats,
     warnings,
     safeAbsenceAlert: Number(options.plannedRealAbsenceSeconds || 0) > safeAlone,
@@ -974,6 +1079,10 @@ function describeRecommendationType(type) {
       return "Recent subtle stress triggered two short confidence-recovery sessions before normal progression resumes.";
     case "subtle_recovery_resume":
       return "Recovery sessions completed. The next target resumes from the subtle-stress anchor with a 5% step-down.";
+    case "recovery_mode_active":
+      return "Recovery mode is active: progression is paused and short confidence sessions are required.";
+    case "recovery_mode_resume":
+      return "Two calm recovery sessions were completed, so progression resumes at 95% of the anchor.";
     default:
       return "The next target is adjusted from the current safe-alone estimate.";
   }
@@ -1025,6 +1134,7 @@ export function explainNextTarget(sessions = [], walks = [], patterns = [], dog 
   const recommendation = buildRecommendation(sortedSessions, {
     goalSeconds: dog?.goalSeconds,
     plannedRealAbsenceSeconds: dog?.plannedRealAbsenceSeconds,
+    recoveryState: dog?.recoveryState,
     cueSessions,
     plan: {
       recommendedDuration: lastTraining?.plannedDuration || null,
@@ -1071,6 +1181,7 @@ export function explainNextTarget(sessions = [], walks = [], patterns = [], dog 
     warnings: recommendation.warnings,
     walkAdjustmentApplied,
     recoveryMode: recommendation.recoveryMode,
+    recoveryState: recommendation.recoveryState ?? null,
     decisionState: buildDecisionState({
       recommendedDuration,
       recommendationType: recommendation.recommendationType,

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -141,7 +141,7 @@ describe("recommendation engine", () => {
     ];
     const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
     expect(rec.recommendedDuration).toBe(60);
-    expect(rec.recommendationType).toBe("subtle_recovery_mode");
+    expect(rec.recommendationType).toBe("recovery_mode_active");
   });
 
   it("recovery step progression follows 1min then 2min after subtle stress", () => {
@@ -178,7 +178,7 @@ describe("recommendation engine", () => {
       { date: new Date().toISOString(), plannedDuration: 30, actualDuration: 1200, distressLevel: "subtle", belowThreshold: false },
     ];
     const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
-    expect(rec.recommendationType).toBe("subtle_recovery_mode");
+    expect(rec.recommendationType).toBe("recovery_mode_active");
     expect(rec.recommendedDuration).toBe(60);
   });
 
@@ -192,7 +192,7 @@ describe("recommendation engine", () => {
       { date: second, plannedDuration: 1380, actualDuration: 1200, distressLevel: "subtle", belowThreshold: false },
     ];
     const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
-    expect(rec.recommendationType).toBe("subtle_recovery_mode");
+    expect(rec.recommendationType).toBe("recovery_mode_active");
     expect(rec.recommendedDuration).toBe(60);
   });
 
@@ -283,8 +283,8 @@ describe("recommendation engine", () => {
     const recIncomplete = buildRecommendation([
       { distressLevel: "subtle", plannedDuration: null, actualDuration: null },
     ], { goalSeconds: 3600 });
-    expect(recIncomplete.recoveryMode.active).toBe(false);
-    expect(recIncomplete.recommendationType).not.toBe("subtle_recovery_mode");
+    expect(recIncomplete.recoveryMode.active).toBe(true);
+    expect(recIncomplete.recommendationType).toBe("recovery_mode_active");
   });
 
   it("rolls back and enters stabilization mode after repeated active distress", () => {
@@ -296,8 +296,9 @@ describe("recommendation engine", () => {
       { date: daysAgo(0), plannedDuration: 30, actualDuration: 6, distressLevel: "severe", belowThreshold: false },
     ];
     const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
-    expect(["stabilization_block", "departure_cues_first"]).toContain(rec.recommendationType);
-    expect(rec.recommendedDuration).toBeLessThan(35);
+    expect(["stabilization_block", "departure_cues_first", "recovery_mode_active"]).toContain(rec.recommendationType);
+    expect(rec.recommendedDuration).toBeGreaterThanOrEqual(60);
+    expect(rec.recommendedDuration).toBeLessThanOrEqual(90);
   });
 
   it("flags safety warning for panic pattern", () => {
@@ -315,6 +316,30 @@ describe("recommendation engine", () => {
     ];
     const rec = buildRecommendation(sessions, { goalSeconds: 3600, plannedRealAbsenceSeconds: 200 });
     expect(rec.safeAbsenceAlert).toBe(true);
+  });
+
+  it("persists recovery state and exits only after two consecutive calm sessions", () => {
+    const stress = [{ id: "s1", date: daysAgo(2), plannedDuration: 600, actualDuration: 500, distressLevel: "active", belowThreshold: false }];
+    const start = buildRecommendation(stress, { goalSeconds: 3600 });
+    expect(start.recoveryMode.active).toBe(true);
+    expect(start.recoveryState?.active).toBe(true);
+
+    const oneCalm = buildRecommendation([
+      ...stress,
+      { id: "s2", date: daysAgo(1), plannedDuration: 60, actualDuration: 60, distressLevel: "none", belowThreshold: true },
+    ], { goalSeconds: 3600, recoveryState: start.recoveryState });
+    expect(oneCalm.recoveryMode.active).toBe(true);
+    expect(oneCalm.recoveryMode.remainingSessions).toBe(1);
+    expect(oneCalm.recommendedDuration).toBe(60);
+
+    const twoCalm = buildRecommendation([
+      ...stress,
+      { id: "s2", date: daysAgo(1), plannedDuration: 60, actualDuration: 60, distressLevel: "none", belowThreshold: true },
+      { id: "s3", date: daysAgo(0), plannedDuration: 60, actualDuration: 60, distressLevel: "none", belowThreshold: true },
+    ], { goalSeconds: 3600, recoveryState: oneCalm.recoveryState });
+    expect(twoCalm.recoveryMode.active).toBe(false);
+    expect(twoCalm.recoveryState?.active).toBe(false);
+    expect(twoCalm.recommendedDuration).toBe(475);
   });
 });
 
@@ -404,8 +429,7 @@ describe("public compatibility APIs", () => {
       { date: daysAgo(0), plannedDuration: 1300, actualDuration: 300, distressLevel: "active", belowThreshold: false },
     ];
     const next = explainNextTarget(sessions, [], [], { goalSeconds: 3600 });
-    expect(next.recommendedDuration).toBeGreaterThan(900);
-    expect(next.recommendedDuration).toBeLessThan(1300);
+    expect(next.recommendedDuration).toBe(60);
   });
 
   it("keeps decision risk level aligned with stats relapse risk bands", () => {


### PR DESCRIPTION
### Motivation
- Implement a structured, persistent "Recovery Mode" that activates after subtle/active/severe stress and forces short recovery sessions (60–90s), blocking normal progression until two consecutive calm sessions complete.
- Recovery must override other recommendation logic, persist across runs, expose a `recoveryActive` flag, and resume progression from `anchor * 0.95` when exited.

### Description
- Add `normalizeRecoveryState` and `evaluatePersistentRecoveryMode` helpers and integrate persistent recovery handling into `computeNextTarget` to short-circuit the normal pipeline when recovery state is active (src/lib/protocol.js).
- Trigger a new structured `recoveryState` when a recent stress session is observed and return explicit `recoveryMode` metadata (active, remainingSessions, step, anchor, postRecoveryDuration); include `recoveryState` in `buildRecommendation` and `explainNextTarget` outputs (src/lib/protocol.js).
- Integrate persistence into the app by saving `recoveryState` on the active dog profile when a session is recorded via `recordResult`, using `explainNextTarget` to compute and persist state (src/App.jsx).
- Update and extend unit tests to reflect the new structured/persistent recovery behavior and added coverage for persistence and exit conditions (tests/protocol.test.js).

### Testing
- Ran the updated protocol unit tests with `npm test -- --run tests/protocol.test.js` and they passed (all protocol tests green).
- Ran the full test suite with `npm test` and all tests passed (57 tests across all suites).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de48961cf08332ae1399786a703aa8)