### PR TITLE
Add always-on recommendation explanations to explainNextTarget

### DIFF
--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -1088,6 +1088,53 @@ function describeRecommendationType(type) {
   }
 }
 
+function buildRecommendationExplanation({
+  recommendationType,
+  recommendedDuration,
+  previousDuration,
+  lastTraining,
+  hasHistory,
+}) {
+  if (!hasHistory) {
+    return "Starting with a short first session to build confidence.";
+  }
+
+  const prev = Number(previousDuration) || 0;
+  const next = Number(recommendedDuration) || 0;
+  const changePct = prev > 0 ? Math.round(Math.abs(((next - prev) / prev) * 100)) : 0;
+  const distress = normalizeDistressLevel(lastTraining?.distressLevel);
+  const calmLabel = distress === DISTRESS_LEVELS.NONE ? "calm session" : "calmer session";
+
+  switch (recommendationType) {
+    case "recovery_mode_active":
+    case "subtle_recovery_mode":
+      return "Short recovery sessions after stress to rebuild confidence.";
+    case "stabilization_block":
+      return "Reduced after signs of distress to rebuild confidence.";
+    case "reduce_duration":
+      return "Holding shorter sessions due to stress signs.";
+    case "subtle_recovery_resume":
+    case "recovery_mode_resume":
+      return "Recovery sessions went well, so we are carefully stepping back up.";
+    case "departure_cues_first":
+      return "Holding duration while cue practice catches up.";
+    case "keep_same_duration":
+    case "repeat_current_duration":
+    case "insert_easy_sessions":
+      if (prev > 0 && next > prev && changePct > 0) {
+        return `Increased by ${changePct}% after ${calmLabel}.`;
+      }
+      if (prev > 0 && next < prev && changePct > 0) {
+        return `Reduced by ${changePct}% after stress signs.`;
+      }
+      return distress === DISTRESS_LEVELS.SUBTLE
+        ? "Holding duration due to mild stress."
+        : "Holding duration while your dog stays steady.";
+    default:
+      return "Adjusted from recent results to keep progress steady.";
+  }
+}
+
 export function explainNextTarget(sessions = [], walks = [], patterns = [], dog = {}) {
   const sortedSessions = sortByDateAsc(sessions).map(toRichSession);
   const trainingSessions = sortedSessions.filter((s) => s.departureType !== "real_life");
@@ -1103,6 +1150,13 @@ export function explainNextTarget(sessions = [], walks = [], patterns = [], dog 
     return {
       recommendedDuration,
       recommendationType: "baseline_start",
+      explanation: buildRecommendationExplanation({
+        recommendationType: "baseline_start",
+        recommendedDuration,
+        previousDuration: 0,
+        lastTraining: null,
+        hasHistory: false,
+      }),
       summary: baseline > 0
         ? "The first target starts at about 80% of your dog's current calm-alone estimate so the opening sessions stay easy."
         : "With no history yet, PawTimer starts with the default 30-second confidence-building target.",
@@ -1175,6 +1229,13 @@ export function explainNextTarget(sessions = [], walks = [], patterns = [], dog 
   return {
     recommendedDuration,
     recommendationType: recommendation.recommendationType,
+    explanation: buildRecommendationExplanation({
+      recommendationType: recommendation.recommendationType,
+      recommendedDuration,
+      previousDuration: lastTraining?.plannedDuration || 0,
+      lastTraining,
+      hasHistory: true,
+    }),
     summary: describeRecommendationType(recommendation.recommendationType),
     factors,
     stats: recommendation.stats,

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -375,6 +375,7 @@ describe("public compatibility APIs", () => {
     expect(next.recoveryMode.active).toBe(true);
     expect(next.recoveryMode.remainingSessions).toBe(2);
     expect(next.recommendedDuration).toBe(60);
+    expect(next.explanation).toMatch(/Short recovery sessions after stress/i);
   });
 
   it("explainNextTarget disables recovery metadata after two calm recovery sessions", () => {
@@ -469,5 +470,7 @@ describe("public compatibility APIs", () => {
     expect(next.decisionState.riskLevel).toBe("medium");
     expect(next.decisionState.readiness).toBe("building");
     expect(next.decisionState.statusLabel).toBe("Stable");
+    expect(next.explanation).toBeTruthy();
+    expect(next.explanation).toMatch(/Starting with a short first session/i);
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure every recommended session includes a short, plain-language explanation that reflects the actual recommendation branch and avoids technical jargon.
- Make explanations available for both new dogs (no history) and history-based recommendations so the UI always has a user-friendly message.
- Align messaging with existing decision logic so the explanation matches why a duration was held, reduced, or increased.

### Description
- Added a `buildRecommendationExplanation` helper that maps recommendation branches to concise, non-technical explanations and emits dynamic percent-up/down phrasing when a duration change is detectable. 
- Wired the helper into `explainNextTarget()` so the returned object always includes an `explanation` for both the `baseline_start` (no history) and normal recommendation flows. 
- Kept existing `summary` and `factors` values intact while adding the new `explanation` field to the returned recommendation payload. 
- Updated `tests/protocol.test.js` to assert explanation presence and branch-aligned phrasing for recovery-mode and baseline-start scenarios.

### Testing
- Ran `npm test -- tests/protocol.test.js` which completed successfully with 1 test file and 40 tests passing. 
- An earlier attempt using `npm test -- --runInBand tests/protocol.test.js` failed due to an invalid Vitest CLI flag, but the correct test run passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4b785adc83329e216332ef4702d1)