### PR TITLE
Fix Activity Log duration edit parsing and persistence

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -171,13 +171,16 @@ export default function PawTimer() {
   }, [appData.dog, patterns, walks]);
 
   const commitSessions = useCallback((updater) => {
-    const previous = ensureArray(syncSnapshotRef.current?.sessions);
-    const resolved = typeof updater === "function" ? updater(previous) : updater;
-    const normalized = normalizeSessions(ensureArray(resolved)).map(withHydratedSyncState);
-    setSessions(normalized);
-    if (activeDogId) save(sessKey(activeDogId), normalized);
-    recomputeTarget(normalized);
-    return normalized;
+    let committed = [];
+    setSessions((prev) => {
+      const resolved = typeof updater === "function" ? updater(prev) : updater;
+      const normalized = normalizeSessions(ensureArray(resolved)).map(withHydratedSyncState);
+      if (activeDogId) save(sessKey(activeDogId), normalized);
+      recomputeTarget(normalized);
+      committed = normalized;
+      return normalized;
+    });
+    return committed;
   }, [activeDogId, recomputeTarget, withHydratedSyncState]);
 
   const commitWalks = useCallback((updater) => {

--- a/src/features/app/helpers.js
+++ b/src/features/app/helpers.js
@@ -1,20 +1,11 @@
 import { PROTOCOL } from "../../lib/protocol";
-import { formatClockDuration, formatDuration } from "../../lib/time";
+import { formatClockDuration, formatDuration, parseHumanDurationSeconds } from "../../lib/time";
 
 export const fmt = formatDuration;
 export const fmtClock = formatClockDuration;
 
 export const parseDurationInput = (value) => {
-  const raw = String(value ?? "").trim();
-  if (!raw) return null;
-  if (raw.includes(":")) {
-    const [mm, ss] = raw.split(":").map((part) => Number(part));
-    if (!Number.isFinite(mm) || !Number.isFinite(ss) || mm < 0 || ss < 0 || ss >= 60) return null;
-    return Math.round(mm * 60 + ss);
-  }
-  const asSeconds = Number(raw);
-  if (!Number.isFinite(asSeconds) || asSeconds < 0) return null;
-  return Math.round(asSeconds);
+  return parseHumanDurationSeconds(value);
 };
 
 export const fmtDate = (iso) => {

--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -133,7 +133,7 @@ export function useHistoryEditing({
       const parsedDuration = parseDurationInput(historyModal.value);
       const requiresPositive = historyModal.kind === "session";
       if (!Number.isFinite(parsedDuration) || (requiresPositive ? parsedDuration <= 0 : parsedDuration < 0)) {
-        showToast(requiresPositive ? "Invalid duration. Use a positive value (seconds or mm:ss)" : "Invalid duration. Use seconds or mm:ss");
+        showToast(requiresPositive ? "Invalid duration. Use a positive value (seconds, m:ss, or h:mm:ss)" : "Invalid duration. Use seconds, m:ss, or h:mm:ss");
         return;
       }
       if (historyModal.kind === "walk") {
@@ -215,6 +215,12 @@ const renderSyncBadge = (entry) => {
 
 export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, historyModal, setHistoryModal, actions }) {
   const [expandedItemKey, setExpandedItemKey] = useState(null);
+  const parsedDuration = historyModal?.mode === "duration" ? parseDurationInput(historyModal.value) : null;
+  const requiresPositiveDuration = historyModal?.kind === "session";
+  const durationHasInput = historyModal?.mode === "duration" && String(historyModal.value ?? "").trim().length > 0;
+  const durationIsValid = historyModal?.mode === "duration"
+    ? Number.isFinite(parsedDuration) && (requiresPositiveDuration ? parsedDuration > 0 : parsedDuration >= 0)
+    : true;
 
   const toggleExpandedItem = (itemKey) => {
     setExpandedItemKey((prev) => (prev === itemKey ? null : itemKey));
@@ -421,14 +427,19 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
             </>}
 
             {historyModal.mode === "duration" && <>
-              <div className="t-helper activity-time-hint">Enter seconds or <code>mm:ss</code>.</div>
+              <div className="t-helper activity-time-hint">Enter seconds, <code>m:ss</code>, or <code>h:mm:ss</code>.</div>
               <label className="activity-time-field">
                 <span className="t-helper">Duration</span>
-                <input type="text" inputMode="numeric" placeholder="e.g. 90 or 1:30" value={historyModal.value} onChange={(e) => setHistoryModal((prev) => (prev ? { ...prev, value: e.target.value } : prev))} />
+                <input type="text" inputMode="text" placeholder="e.g. 90, 1:37, or 0:22:57" value={historyModal.value} onChange={(e) => setHistoryModal((prev) => (prev ? { ...prev, value: e.target.value } : prev))} />
               </label>
+              {durationHasInput && !durationIsValid ? (
+                <div className="t-helper" role="alert">
+                  Invalid duration. Use seconds, m:ss, or h:mm:ss.
+                </div>
+              ) : null}
               <div className="feeding-actions">
                 <button className="walk-cancel-btn button-base button-ghost button--md button--pill" type="button" onClick={() => setHistoryModal(null)}>Cancel</button>
-                <button className="walk-end-btn button-base button-primary button--md button--pill" type="button" onClick={() => actions.saveEditedActivityDuration(historyModal, setHistoryModal)}>Save</button>
+                <button className="walk-end-btn button-base button-primary button--md button--pill" type="button" disabled={!durationIsValid} onClick={() => actions.saveEditedActivityDuration(historyModal, setHistoryModal)}>Save</button>
               </div>
             </>}
 

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -25,3 +25,28 @@ export const formatClockDuration = (seconds) => {
   const secs = totalSeconds % 60;
   return `${totalMinutes}:${String(secs).padStart(2, "0")}`;
 };
+
+export const parseHumanDurationSeconds = (value) => {
+  const raw = String(value ?? "").trim();
+  if (!raw) return null;
+
+  if (!raw.includes(":")) {
+    const asSeconds = Number(raw);
+    if (!Number.isFinite(asSeconds) || asSeconds < 0) return null;
+    return Math.round(asSeconds);
+  }
+
+  const parts = raw.split(":");
+  // Accept only m:ss, mm:ss, or h:mm:ss. Empty segments (e.g. 1::2) are invalid.
+  if (parts.length < 2 || parts.length > 3 || parts.some((part) => !/^\d+$/.test(part))) return null;
+
+  if (parts.length === 2) {
+    const [minutes, seconds] = parts.map((part) => Number(part));
+    if (!Number.isFinite(minutes) || !Number.isFinite(seconds) || seconds >= 60) return null;
+    return minutes * 60 + seconds;
+  }
+
+  const [hours, minutes, seconds] = parts.map((part) => Number(part));
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes) || !Number.isFinite(seconds) || minutes >= 60 || seconds >= 60) return null;
+  return hours * 3600 + minutes * 60 + seconds;
+};

--- a/tests/historyDurationEditing.test.js
+++ b/tests/historyDurationEditing.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseDurationInput } from "../src/features/app/helpers";
+import { useHistoryEditing } from "../src/features/history/HistoryFeature";
+
+const baseSession = {
+  id: "sess-1",
+  date: new Date("2026-04-10T10:00:00.000Z").toISOString(),
+  plannedDuration: 120,
+  actualDuration: 120,
+  distressLevel: "none",
+  belowThreshold: true,
+  latencyToFirstDistress: 120,
+  result: "success",
+};
+
+const buildHistoryActions = (sessions, { commitSessions = vi.fn(), showToast = vi.fn() } = {}) => {
+  const pushWithSyncStatus = vi.fn(() => Promise.resolve({ ok: true }));
+  const stampLocalEntry = (entry) => ({ ...entry });
+  const actions = useHistoryEditing({
+    sessions,
+    walks: [],
+    patterns: [],
+    feedings: [],
+    patLabels: {},
+    showToast,
+    pushWithSyncStatus,
+    syncDelete: vi.fn(),
+    syncDeleteSessionsForDog: vi.fn(),
+    commitSessions,
+    setWalks: vi.fn(),
+    setPatterns: vi.fn(),
+    setFeedings: vi.fn(),
+    recomputeTarget: vi.fn(),
+    activeDogId: "dog-1",
+    stampLocalEntry,
+  });
+  return { actions, commitSessions, showToast };
+};
+
+describe("duration parser for history editing", () => {
+  it("parses supported duration formats into seconds", () => {
+    expect(parseDurationInput("1:37")).toBe(97);
+    expect(parseDurationInput("22:57")).toBe(1377);
+    expect(parseDurationInput("90")).toBe(90);
+    expect(parseDurationInput("1:00:00")).toBe(3600);
+  });
+
+  it("rejects malformed duration input", () => {
+    expect(parseDurationInput("1::2")).toBeNull();
+    expect(parseDurationInput("abc")).toBeNull();
+  });
+});
+
+describe("session duration edits in history", () => {
+  it("writes the parsed edited duration back to the matching session record", () => {
+    const { actions, commitSessions, showToast } = buildHistoryActions([baseSession]);
+
+    actions.saveEditedActivityDuration({ mode: "duration", kind: "session", id: "sess-1", value: "1:37" }, vi.fn());
+    const editedFromClock = commitSessions.mock.calls[0][0].find((session) => session.id === "sess-1");
+    expect(editedFromClock.actualDuration).toBe(97);
+
+    actions.saveEditedActivityDuration({ mode: "duration", kind: "session", id: "sess-1", value: "22:57" }, vi.fn());
+    const editedFromMinutes = commitSessions.mock.calls[1][0].find((session) => session.id === "sess-1");
+    expect(editedFromMinutes.actualDuration).toBe(1377);
+
+    actions.saveEditedActivityDuration({ mode: "duration", kind: "session", id: "sess-1", value: "90" }, vi.fn());
+    const editedFromSeconds = commitSessions.mock.calls[2][0].find((session) => session.id === "sess-1");
+    expect(editedFromSeconds.actualDuration).toBe(90);
+
+    expect(showToast).toHaveBeenCalledWith("Session updated to 1m 37s");
+  });
+
+  it("fails safely when the edited value is malformed", () => {
+    const { actions, commitSessions, showToast } = buildHistoryActions([baseSession]);
+    actions.saveEditedActivityDuration({ mode: "duration", kind: "session", id: "sess-1", value: "1::2" }, vi.fn());
+    actions.saveEditedActivityDuration({ mode: "duration", kind: "session", id: "sess-1", value: "abc" }, vi.fn());
+
+    expect(commitSessions).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenNthCalledWith(1, "Invalid duration. Use a positive value (seconds, m:ss, or h:mm:ss)");
+    expect(showToast).toHaveBeenNthCalledWith(2, "Invalid duration. Use a positive value (seconds, m:ss, or h:mm:ss)");
+  });
+});


### PR DESCRIPTION
### Motivation
- Fix two bugs in the Activity Log edit flow where edited session durations were not being reliably saved and colon-formatted durations (e.g. `1:37`) could not be entered or parsed. 
- Provide a single, robust parser for human-entered durations so UI and storage consistently use canonical seconds. 

### Description
- Added a centralized parser `parseHumanDurationSeconds` in `src/lib/time.js` that accepts `ss`, `m:ss`/`mm:ss`, and `h:mm:ss` and rejects malformed colon input like `1::2`. 
- Delegate `parseDurationInput` in `src/features/app/helpers.js` to the new parser so callers keep the same API but benefit from hardened parsing. 
- Improve the History UI in `src/features/history/HistoryFeature.jsx` by changing the duration input to `inputMode=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4f2d0e188332b0049c6d5f14767c)