### PR TITLE
Drive Home recovery modal content from protocol recoveryMode metadata

### DIFF
--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -127,14 +127,15 @@ export default function HomeScreen(props) {
                 <ModalCloseButton onClick={() => setShowRecoveryInfo(false)} />
               </div>
               <div className="recovery-explain-steps">
-                <div className={`recovery-step-chip ${recoveryMode.step >= 1 ? "is-done" : ""}`}>1 min calm</div>
-                <div className={`recovery-step-chip ${recoveryMode.step >= 2 ? "is-done" : ""}`}>2 min calm</div>
+                {(recoveryMode.stepLabels || []).map((label, idx) => (
+                  <div key={`${label}-${idx}`} className={`recovery-step-chip ${recoveryMode.step >= (idx + 1) ? "is-done" : ""}`}>{label}</div>
+                ))}
               </div>
               <p className="recovery-explain-copy">
-                We temporarily shortened sessions after subtle stress so your dog can get two easy, positive wins.
+                {recoveryMode.planCopy}
               </p>
               <div className="recovery-explain-meta">
-                <span>Step {Math.max(1, recoveryMode.step)} of 2</span>
+                <span>{recoveryMode.currentStepLabel || `Step ${Math.max(1, recoveryMode.step)} of ${recoveryMode.totalSessions || 2}`}</span>
                 <span>{recoveryMode.remainingSessions} remaining</span>
               </div>
             </div>

--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -698,6 +698,36 @@ function computeFallbackFromCalmHistory(recentWindow = [], anchorDuration = null
   };
 }
 
+function formatRecoveryStepLabel(seconds = PROTOCOL.subtleRecoveryDurationSeconds) {
+  const roundedSeconds = Math.max(PROTOCOL.minDurationSeconds, Math.round(Number(seconds) || PROTOCOL.subtleRecoveryDurationSeconds));
+  const minutes = Math.round(roundedSeconds / 60);
+  return `${minutes} min calm`;
+}
+
+function buildRecoveryModeDetails({
+  stressLevel = DISTRESS_LEVELS.SUBTLE,
+  step = 0,
+  recoveryDurations = [],
+} = {}) {
+  const planDurations = recoveryDurations.length
+    ? recoveryDurations
+    : [PROTOCOL.subtleRecoveryDurationSeconds, PROTOCOL.subtleRecoveryDurationSeconds * 2];
+  const totalSessions = planDurations.length;
+  const safeStep = clamp(Math.round(Number(step) || 0), 0, totalSessions);
+  const stepLabels = planDurations.map((duration) => formatRecoveryStepLabel(duration));
+  const planCopy = [DISTRESS_LEVELS.ACTIVE, DISTRESS_LEVELS.SEVERE].includes(stressLevel)
+    ? `We temporarily switched to a ${totalSessions}-step confidence rebuild so your dog can stack calm wins before progression resumes.`
+    : `We temporarily shortened sessions after subtle stress so your dog can complete this ${totalSessions}-step confidence reset.`;
+
+  return {
+    step: safeStep,
+    totalSessions,
+    stepLabels,
+    planCopy,
+    currentStepLabel: `Step ${Math.max(1, safeStep)} of ${totalSessions}`,
+  };
+}
+
 function computeProgressiveIncrease(anchorDuration, calmStreak = 1) {
   if (!Number.isFinite(anchorDuration) || anchorDuration <= 0) return PROTOCOL.startDurationSeconds;
 
@@ -832,7 +862,11 @@ function evaluatePersistentRecoveryMode(
         active: true,
         recoveryActive: true,
         remainingSessions: Math.max(1, recoveryDurations.length - consecutiveCalm),
-        step: Math.min(recoveryDurations.length, consecutiveCalm + 1),
+        ...buildRecoveryModeDetails({
+          stressLevel,
+          step: Math.min(recoveryDurations.length, consecutiveCalm + 1),
+          recoveryDurations,
+        }),
         anchorSessionDate: trainingSessions[resolvedTriggerIndex]?.date || null,
         anchorDuration: normalized.anchorDuration,
         recoveryDuration: recommendedDuration,
@@ -850,7 +884,11 @@ function evaluatePersistentRecoveryMode(
       active: false,
       recoveryActive: false,
       remainingSessions: 0,
-      step: recoveryDurations.length,
+      ...buildRecoveryModeDetails({
+        stressLevel,
+        step: recoveryDurations.length,
+        recoveryDurations,
+      }),
       anchorSessionDate: trainingSessions[resolvedTriggerIndex]?.date || null,
       anchorDuration: normalized.anchorDuration,
       recoveryDuration: null,
@@ -876,7 +914,7 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
       recoveryMode: {
         active: false,
         remainingSessions: 0,
-        step: 0,
+        ...buildRecoveryModeDetails({ step: 0 }),
         anchorSessionDate: null,
         anchorDuration: null,
         recoveryDuration: null,
@@ -909,7 +947,7 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
       recoveryMode: {
         active: false,
         remainingSessions: 0,
-        step: 0,
+        ...buildRecoveryModeDetails({ step: 0 }),
         anchorSessionDate: lastSession?.date || null,
         anchorDuration: getSessionDurationAnchor(lastSession) ?? null,
         recoveryDuration: null,
@@ -936,7 +974,7 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
       recoveryMode: {
         active: false,
         remainingSessions: 0,
-        step: 0,
+        ...buildRecoveryModeDetails({ step: 0 }),
         anchorSessionDate: lastCalmSession?.date || null,
         anchorDuration,
         recoveryDuration: null,
@@ -962,7 +1000,7 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
     recoveryMode: {
       active: false,
       remainingSessions: 0,
-      step: 0,
+      ...buildRecoveryModeDetails({ step: 0 }),
       anchorSessionDate: lastCalmSession?.date || null,
       anchorDuration,
       recoveryDuration: null,


### PR DESCRIPTION
### Motivation
- Remove hard-coded UI assumptions (two recovery chips and fixed “Step … of 2” text) and let the protocol decide recovery plan shape and copy so severe/active paths can present 3-step plans when needed.

### Description
- Add `formatRecoveryStepLabel` and `buildRecoveryModeDetails` helpers in `src/lib/protocol.js` to produce step labels, total session count, current-step text, and adaptive plan copy from recovery durations and stress level.
- Wire the new metadata into all relevant `recoveryMode` return paths in `computeNextTarget` / `evaluatePersistentRecoveryMode` so protocol returns `stepLabels`, `totalSessions`, `currentStepLabel`, and `planCopy` instead of the UI guessing sizes.
- Update `src/features/home/HomeScreen.jsx` recovery modal to render chips from `recoveryMode.stepLabels`, display `recoveryMode.planCopy` for explanatory copy, and show `recoveryMode.currentStepLabel` (with a minimal fallback) instead of hardcoded two-step labels/text.

### Testing
- Ran `npm run test` (Vitest) and all tests passed (`6` files, `65` tests passed).
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5ade35148332a1e72dc677dc6d2f)