### PR TITLE
Always start active/severe recovery at first step (60s); reserve fallback for resume

### DIFF
--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -830,6 +830,23 @@ function evaluatePersistentRecoveryMode(
   }
 
   const completed = consecutiveCalm >= recoveryDurations.length;
+  const beforeTrigger = trainingSessions.slice(0, resolvedTriggerIndex);
+  const anchorDuration = normalized.anchorDuration ?? getSessionDurationAnchor(getLastCalmSession(beforeTrigger));
+  const fallbackInfo = [DISTRESS_LEVELS.ACTIVE, DISTRESS_LEVELS.SEVERE].includes(stressLevel)
+    ? computeFallbackFromCalmHistory(recentWindow, anchorDuration)
+    : null;
+  const reducedFallback = fallbackInfo?.usedRelaxedCalmEvidence
+    ? Math.max(PROTOCOL.minDurationSeconds, Math.round(fallbackInfo.fallbackBase * (1 - reductionPercent)))
+    : fallbackInfo?.fallbackBase;
+  const fallbackDuration = Number.isFinite(reducedFallback)
+    ? clampRateChange(
+      clamp(reducedFallback, PROTOCOL.minDurationSeconds, goalSeconds),
+      Number.isFinite(anchorDuration) ? anchorDuration : getSessionDurationAnchor(triggerSession),
+    )
+    : null;
+  const postRecoveryDuration = Number.isFinite(fallbackDuration)
+    ? fallbackDuration
+    : Math.max(PROTOCOL.minDurationSeconds, Math.round((normalized.anchorDuration || PROTOCOL.startDurationSeconds) * 0.95));
   const persistedState = {
     ...normalized,
     active: !completed,
@@ -838,25 +855,8 @@ function evaluatePersistentRecoveryMode(
 
   if (!completed) {
     const recoveryDuration = recoveryDurations[Math.min(consecutiveCalm, recoveryDurations.length - 1)];
-    const beforeTrigger = trainingSessions.slice(0, resolvedTriggerIndex);
-    const anchorDuration = normalized.anchorDuration ?? getSessionDurationAnchor(getLastCalmSession(beforeTrigger));
-    const fallbackInfo = [DISTRESS_LEVELS.ACTIVE, DISTRESS_LEVELS.SEVERE].includes(stressLevel)
-      ? computeFallbackFromCalmHistory(recentWindow, anchorDuration)
-      : null;
-    const reducedFallback = fallbackInfo?.usedRelaxedCalmEvidence
-      ? Math.max(PROTOCOL.minDurationSeconds, Math.round(fallbackInfo.fallbackBase * (1 - reductionPercent)))
-      : fallbackInfo?.fallbackBase;
-    const fallbackDuration = Number.isFinite(reducedFallback)
-      ? clampRateChange(
-        clamp(reducedFallback, PROTOCOL.minDurationSeconds, goalSeconds),
-        Number.isFinite(anchorDuration) ? anchorDuration : getSessionDurationAnchor(triggerSession),
-      )
-      : recoveryDuration;
-    const recommendedDuration = [DISTRESS_LEVELS.ACTIVE, DISTRESS_LEVELS.SEVERE].includes(stressLevel) && afterTrigger.length === 0
-      ? fallbackDuration
-      : recoveryDuration;
     return {
-      recommendedDuration: clamp(recommendedDuration, PROTOCOL.minDurationSeconds, goalSeconds),
+      recommendedDuration: clamp(recoveryDuration, PROTOCOL.minDurationSeconds, goalSeconds),
       recommendationType: "recovery_mode_active",
       recoveryMode: {
         active: true,
@@ -869,14 +869,14 @@ function evaluatePersistentRecoveryMode(
         }),
         anchorSessionDate: trainingSessions[resolvedTriggerIndex]?.date || null,
         anchorDuration: normalized.anchorDuration,
-        recoveryDuration: recommendedDuration,
-        postRecoveryDuration: normalized.anchorDuration ? Math.max(PROTOCOL.minDurationSeconds, Math.round(normalized.anchorDuration * 0.95)) : null,
+        recoveryDuration,
+        postRecoveryDuration,
       },
       recoveryState: persistedState,
     };
   }
 
-  const resumeDuration = Math.max(PROTOCOL.minDurationSeconds, Math.round((normalized.anchorDuration || PROTOCOL.startDurationSeconds) * 0.95));
+  const resumeDuration = postRecoveryDuration;
   return {
     recommendedDuration: clamp(resumeDuration, PROTOCOL.minDurationSeconds, goalSeconds),
     recommendationType: "recovery_mode_resume",

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -382,7 +382,7 @@ describe("recommendation engine", () => {
     ], { goalSeconds: 3600, recoveryState: oneCalm.recoveryState });
     expect(twoCalm.recoveryMode.active).toBe(false);
     expect(twoCalm.recoveryState?.active).toBe(false);
-    expect(twoCalm.recommendedDuration).toBe(475);
+    expect(twoCalm.recommendedDuration).toBe(375);
   });
 });
 
@@ -466,7 +466,7 @@ describe("public compatibility APIs", () => {
     expect(next.recommendedDuration).toBeGreaterThan(1000);
   });
 
-  it("uses unified recovery fallback logic for active distress", () => {
+  it("starts active-distress recovery at first step and keeps fallback for post-recovery resume", () => {
     const sessions = [
       { date: daysAgo(2), plannedDuration: 1500, actualDuration: 1200, distressLevel: "none", belowThreshold: false },
       { date: daysAgo(1), plannedDuration: 1600, actualDuration: 1300, distressLevel: "none", belowThreshold: false },
@@ -474,7 +474,20 @@ describe("public compatibility APIs", () => {
     ];
     const next = explainNextTarget(sessions, [], [], { goalSeconds: 3600 });
     expect(next.recommendationType).toBe("recovery_mode_active");
-    expect(next.recommendedDuration).toBe(1125);
+    expect(next.recommendedDuration).toBe(60);
+    expect(next.recoveryMode.postRecoveryDuration).toBe(1125);
+  });
+
+  it("starts severe-distress recovery at first step and keeps fallback for post-recovery resume", () => {
+    const sessions = [
+      { date: daysAgo(2), plannedDuration: 1800, actualDuration: 1500, distressLevel: "none", belowThreshold: false },
+      { date: daysAgo(1), plannedDuration: 1700, actualDuration: 1400, distressLevel: "none", belowThreshold: false },
+      { date: daysAgo(0), plannedDuration: 1500, actualDuration: 120, distressLevel: "severe", belowThreshold: false },
+    ];
+    const next = explainNextTarget(sessions, [], [], { goalSeconds: 3600 });
+    expect(next.recommendationType).toBe("recovery_mode_active");
+    expect(next.recommendedDuration).toBe(60);
+    expect(next.recoveryMode.postRecoveryDuration).toBe(1260);
   });
 
   it("keeps decision risk level aligned with stats relapse risk bands", () => {


### PR DESCRIPTION
### Motivation
- Ensure that an immediate recovery recommendation after an `active` or `severe` trigger always returns the first recovery step (60s) instead of substituting the fallback duration, while preserving fallback logic for post-recovery resumption.

### Description
- Updated `evaluatePersistentRecoveryMode` in `src/lib/protocol.js` to compute fallback/post-recovery duration separately and to always return the appropriate `recoveryDuration` (first step) when recovery is still active.
- Exposed the computed fallback as `postRecoveryDuration` and use it for the resume path (`recovery_mode_resume`) so the fallback influences only the post-recovery resume target.
- Simplified and re-ordered logic so the fallback computation is shared and consistent between active and completed recovery outcomes. 
- Updated `tests/protocol.test.js` to assert immediate post-trigger behavior for both `active` and `severe` distress (expect `recommendedDuration === 60`) and to validate that the fallback is preserved as `recoveryMode.postRecoveryDuration`; adjusted one resumed-duration expectation accordingly.

### Testing
- Ran the targeted test suite with `npm test -- tests/protocol.test.js`. 
- All tests passed: `45 tests, 0 failures`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5e2895188332829e5a6c579546bf)