### PR TITLE
Sort session commits and downstream analytics inputs by ascending date

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -163,7 +163,8 @@ export default function PawTimer() {
     [activeDogId, dogs],
   );
   const recommendation = useMemo(() => {
-    const nextTargetInfo = explainNextTarget(sessions, walks, patterns, activeDog || {});
+    const sortedSessions = sortByDateAsc(sessions);
+    const nextTargetInfo = explainNextTarget(sortedSessions, walks, patterns, activeDog || {});
     return {
       duration: target,
       decisionState: nextTargetInfo?.decisionState ?? null,
@@ -171,7 +172,8 @@ export default function PawTimer() {
       details: nextTargetInfo,
     };
   }, [activeDog, patterns, sessions, target, walks]);
-  const appData = selectAppData({ dogs, activeDogId, sessions, walks, patterns, feedings, target, protoOverride, recommendation });
+  const sortedSessions = useMemo(() => sortByDateAsc(sessions), [sessions]);
+  const appData = selectAppData({ dogs, activeDogId, sessions: sortedSessions, walks, patterns, feedings, target, protoOverride, recommendation });
 
   const recomputeTarget = useCallback((nextSessions, nextWalks = walks, nextPatterns = patterns, nextDog = appData.dog) => {
     const nextTarget = suggestNextWithContext(nextSessions, nextWalks, nextPatterns, nextDog) ?? suggestNext(nextSessions, nextDog);
@@ -183,7 +185,7 @@ export default function PawTimer() {
     let committed = [];
     setSessions((prev) => {
       const resolved = typeof updater === "function" ? updater(prev) : updater;
-      const normalized = normalizeSessions(ensureArray(resolved)).map(withHydratedSyncState);
+      const normalized = sortByDateAsc(normalizeSessions(ensureArray(resolved)).map(withHydratedSyncState));
       if (activeDogId) save(sessKey(activeDogId), normalized);
       recomputeTarget(normalized);
       committed = normalized;
@@ -251,7 +253,7 @@ export default function PawTimer() {
     const dog = dogs.find((d) => canonicalDogId(d.id) === normalizedId) ?? ensureArray(load(DOGS_KEY, [])).find((d) => canonicalDogId(d.id) === normalizedId);
     if (!dog) { setScreen("select"); return; }
     const local = hydrateDogFromLocal(normalizedId);
-    const hydratedSessions = normalizeSessions(local.sessions).map(withHydratedSyncState);
+    const hydratedSessions = sortByDateAsc(normalizeSessions(local.sessions).map(withHydratedSyncState));
     const hydratedWalks = sortByDateAsc(ensureArray(local.walks).map((item) => ({ ...withHydratedSyncState(item), type: normalizeWalkType(item?.type) })));
     const hydratedPatterns = sortByDateAsc(ensureArray(local.patterns).map(withHydratedSyncState));
     const hydratedFeedings = normalizeFeedings(local.feedings).map(withHydratedSyncState);
@@ -477,7 +479,7 @@ export default function PawTimer() {
       if (!remote?.dog) { setSyncStatus("err"); setSyncError(error || `No shared dog account found for ${normalizedId}`); showToast(`No shared profile found for ${normalizedId} yet.`); return; }
       const sharedDog = { ...remote.dog, id: normalizedId };
       setDogs((prev) => [...prev.filter((d) => canonicalDogId(d.id) !== normalizedId), sharedDog]);
-      const joinedSessions = normalizeSessions(remote.sessions).map(markRemoteEntryConfirmed);
+      const joinedSessions = sortByDateAsc(normalizeSessions(remote.sessions).map(markRemoteEntryConfirmed));
       const joinedWalks = sortByDateAsc(ensureArray(remote.walks).map((item) => markRemoteEntryConfirmed({ ...item, type: normalizeWalkType(item?.type) })));
       const joinedPatterns = sortByDateAsc(ensureArray(remote.patterns).map(markRemoteEntryConfirmed));
       const joinedFeedings = normalizeFeedings(remote.feedings).map(markRemoteEntryConfirmed);

--- a/src/lib/activityDateTime.js
+++ b/src/lib/activityDateTime.js
@@ -40,4 +40,21 @@ export const buildEditedActivityIso = (dateValue, timeValue) => {
   return nextDate.toISOString();
 };
 
-export const sortByDateAsc = (items = []) => [...items].sort((a, b) => new Date(a.date) - new Date(b.date));
+const toTimestamp = (value) => {
+  if (value == null || value === "") return Number.POSITIVE_INFINITY;
+  const timestamp = new Date(value).getTime();
+  return Number.isFinite(timestamp) ? timestamp : Number.POSITIVE_INFINITY;
+};
+
+export const sortByDateAsc = (items = []) => ensureArray(items)
+  .map((item, index) => ({ item, index }))
+  .sort((a, b) => {
+    const byDate = toTimestamp(a.item?.date) - toTimestamp(b.item?.date);
+    if (byDate !== 0) return byDate;
+    return a.index - b.index;
+  })
+  .map(({ item }) => item);
+
+function ensureArray(value) {
+  return Array.isArray(value) ? value : [];
+}

--- a/tests/activityDateTime.test.js
+++ b/tests/activityDateTime.test.js
@@ -35,4 +35,22 @@ describe("activity date/time helpers", () => {
 
     expect(reordered.map((entry) => entry.id)).toEqual(["walk-1", "walk-3", "walk-2"]);
   });
+
+  it("pushes invalid dates to the end while keeping stable order for ties", () => {
+    const reordered = sortByDateAsc([
+      { id: "same-time-a", date: "2026-03-17T10:00:00.000Z" },
+      { id: "invalid-a", date: "not-a-date" },
+      { id: "same-time-b", date: "2026-03-17T10:00:00.000Z" },
+      { id: "invalid-b", date: null },
+      { id: "earliest", date: "2026-03-16T10:00:00.000Z" },
+    ]);
+
+    expect(reordered.map((entry) => entry.id)).toEqual([
+      "earliest",
+      "same-time-a",
+      "same-time-b",
+      "invalid-a",
+      "invalid-b",
+    ]);
+  });
 });

--- a/tests/statusSemantics.test.js
+++ b/tests/statusSemantics.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { selectAppData } from "../src/features/app/selectors";
 import { getInformationalTone, getOutcomeTone, getRiskTone } from "../src/features/app/helpers";
 import { explainNextTarget } from "../src/lib/protocol";
+import { sortByDateAsc } from "../src/lib/activityDateTime";
 
 const daysAgo = (n) => new Date(Date.now() - n * 86400000).toISOString();
 const buildRecommendation = ({ sessions, walks, patterns, dog, target }) => {
@@ -101,5 +102,44 @@ describe("semantic status mapping", () => {
     expect(appData.recommendation.decisionState.readiness).toBe("building");
     expect(appData.relapseTone.label).toBe("Medium");
     expect(appData.headlineStatus).toBe("Stable");
+  });
+
+  it("keeps chart trend, calm streak, and risk stable when input sessions arrive unsorted", () => {
+    const unsortedSessions = [
+      { date: "2026-04-17T09:00:00.000Z", plannedDuration: 360, actualDuration: 360, distressLevel: "none", belowThreshold: true },
+      { date: "2026-04-10T09:00:00.000Z", plannedDuration: 120, actualDuration: 120, distressLevel: "active", belowThreshold: false },
+      { date: "2026-04-14T09:00:00.000Z", plannedDuration: 210, actualDuration: 210, distressLevel: "none", belowThreshold: true },
+      { date: "2026-04-12T09:00:00.000Z", plannedDuration: 150, actualDuration: 150, distressLevel: "none", belowThreshold: true },
+      { date: "2026-04-16T09:00:00.000Z", plannedDuration: 300, actualDuration: 300, distressLevel: "none", belowThreshold: true },
+      { date: "2026-04-15T09:00:00.000Z", plannedDuration: 240, actualDuration: 240, distressLevel: "none", belowThreshold: true },
+      { date: "2026-04-13T09:00:00.000Z", plannedDuration: 180, actualDuration: 180, distressLevel: "none", belowThreshold: true },
+      { date: "2026-04-11T09:00:00.000Z", plannedDuration: 130, actualDuration: 130, distressLevel: "active", belowThreshold: false },
+    ];
+    const sortedSessions = sortByDateAsc(unsortedSessions);
+    const dog = { id: "DOG-1", dogName: "Milo", goalSeconds: 1800, leavesPerDay: 3 };
+
+    const recommendation = buildRecommendation({
+      sessions: sortedSessions,
+      walks: [],
+      patterns: [],
+      dog,
+      target: 40,
+    });
+    const appData = selectAppData({
+      dogs: [dog],
+      activeDogId: "DOG-1",
+      sessions: sortedSessions,
+      walks: [],
+      patterns: [],
+      feedings: [],
+      target: 40,
+      protoOverride: {},
+      recommendation,
+    });
+
+    expect(appData.chartData.map((entry) => entry.durationSeconds)).toEqual([120, 130, 150, 180, 210, 240, 300, 360]);
+    expect(appData.chartTrendLabel).toBe("Trend: Improving");
+    expect(appData.streak).toBe(6);
+    expect(appData.relapseTone.label).toBe(recommendation.decisionState.riskLevel === "low" ? "Low" : recommendation.decisionState.riskLevel === "high" ? "High" : "Medium");
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent inconsistent analytics when sessions are accepted in arbitrary order by ensuring committed session history is chronologically ordered before downstream consumers run.
- Make protocol and selector inputs deterministic so trend/streak/risk computations are repeatable and robust to unsorted or invalid-date input.

### Description
- Updated `commitSessions` in `src/App.jsx` to normalize sessions, then sort with `sortByDateAsc` before saving, recomputing the next target, and committing state.
- Ensured callers consume sorted session arrays by passing `sortByDateAsc(sessions)` into `explainNextTarget` and using a `sortedSessions` memo for `selectAppData` in `src/App.jsx`.
- Sorted hydrated and joined remote sessions during dog-open/join and initial hydration paths so persisted/remote payloads are also ordered before state updates.
- Hardened `sortByDateAsc` in `src/lib/activityDateTime.js` to be stable and robust: it treats null/empty/invalid dates as trailing values and preserves input order for equal timestamps.
- Added regression tests: a date-helper test to verify invalid dates are pushed to the end while ties remain stable, and a semantics test that feeds unsorted sessions (then sorts them) and verifies chart trend, calm streak, and relapse-risk remain correct.

### Testing
- Ran the targeted test suite with `npm test -- tests/activityDateTime.test.js tests/statusSemantics.test.js` and all tests passed.
- `vitest` result: 2 test files passed and 11 tests passed in total.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de63cfda9c8332bbf0a7b0308e81d6)