### PR TITLE
Unify date sorting and malformed-date handling across protocol and activity helpers

### DIFF
--- a/src/lib/activityDateTime.js
+++ b/src/lib/activityDateTime.js
@@ -1,3 +1,5 @@
+import { sortByDateAsc as sortByDateAscShared } from "./dateSort";
+
 const pad = (value) => String(value).padStart(2, "0");
 
 export const toDateInputValue = (value) => {
@@ -40,21 +42,6 @@ export const buildEditedActivityIso = (dateValue, timeValue) => {
   return nextDate.toISOString();
 };
 
-const toTimestamp = (value) => {
-  if (value == null || value === "") return Number.POSITIVE_INFINITY;
-  const timestamp = new Date(value).getTime();
-  return Number.isFinite(timestamp) ? timestamp : Number.POSITIVE_INFINITY;
-};
-
-export const sortByDateAsc = (items = []) => ensureArray(items)
-  .map((item, index) => ({ item, index }))
-  .sort((a, b) => {
-    const byDate = toTimestamp(a.item?.date) - toTimestamp(b.item?.date);
-    if (byDate !== 0) return byDate;
-    return a.index - b.index;
-  })
-  .map(({ item }) => item);
-
-function ensureArray(value) {
-  return Array.isArray(value) ? value : [];
-}
+export const sortByDateAsc = (items = []) => sortByDateAscShared(items, {
+  invalidPolicy: "push-to-end",
+});

--- a/src/lib/dateSort.js
+++ b/src/lib/dateSort.js
@@ -1,0 +1,41 @@
+const INVALID_DATE_POLICIES = {
+  DROP: "drop",
+  PUSH_TO_END: "push-to-end",
+};
+
+const toTimestampOrNull = (value) => {
+  if (value == null || value === "") return null;
+  const timestamp = new Date(value).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+};
+
+const ensureArray = (value) => (Array.isArray(value) ? value : []);
+
+export const sortByDateAsc = (items = [], options = {}) => {
+  const invalidPolicy = options.invalidPolicy || INVALID_DATE_POLICIES.PUSH_TO_END;
+  const mapped = ensureArray(items)
+    .map((item, index) => ({ item, index, timestamp: toTimestampOrNull(item?.date) }));
+
+  if (invalidPolicy === INVALID_DATE_POLICIES.DROP) {
+    return mapped
+      .filter((entry) => entry.timestamp != null)
+      .sort((a, b) => {
+        const byDate = a.timestamp - b.timestamp;
+        if (byDate !== 0) return byDate;
+        return a.index - b.index;
+      })
+      .map(({ item }) => item);
+  }
+
+  return mapped
+    .sort((a, b) => {
+      const timeA = a.timestamp == null ? Number.POSITIVE_INFINITY : a.timestamp;
+      const timeB = b.timestamp == null ? Number.POSITIVE_INFINITY : b.timestamp;
+      const byDate = timeA - timeB;
+      if (byDate !== 0) return byDate;
+      return a.index - b.index;
+    })
+    .map(({ item }) => item);
+};
+
+export { INVALID_DATE_POLICIES, toTimestampOrNull };

--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -1,3 +1,5 @@
+import { sortByDateAsc as sortByDateAscShared } from "./dateSort";
+
 export const PROTOCOL = {
   sessionsPerDayDefault: 1,
   sessionsPerDayMax: 5,
@@ -110,16 +112,8 @@ function getLatestSessions(sessions, count) {
   return sessions.slice(-count);
 }
 
-function sortByDateAsc(sessions = []) {
-  return [...sessions].sort((a, b) => {
-    const timeA = toTimestamp(a?.date);
-    const timeB = toTimestamp(b?.date);
-    if (timeA == null && timeB == null) return 0;
-    if (timeA == null) return -1;
-    if (timeB == null) return 1;
-    return timeA - timeB;
-  });
-}
+const sortByDateAsc = (sessions = []) => sortByDateAscShared(sessions, { invalidPolicy: "drop" });
+
 
 function countStreak(items, predicate) {
   let streak = 0;

--- a/tests/activityDateTime.test.js
+++ b/tests/activityDateTime.test.js
@@ -42,6 +42,8 @@ describe("activity date/time helpers", () => {
       { id: "invalid-a", date: "not-a-date" },
       { id: "same-time-b", date: "2026-03-17T10:00:00.000Z" },
       { id: "invalid-b", date: null },
+      { id: "invalid-c", date: "" },
+      { id: "invalid-d" },
       { id: "earliest", date: "2026-03-16T10:00:00.000Z" },
     ]);
 
@@ -51,6 +53,8 @@ describe("activity date/time helpers", () => {
       "same-time-b",
       "invalid-a",
       "invalid-b",
+      "invalid-c",
+      "invalid-d",
     ]);
   });
 });

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -126,6 +126,17 @@ describe("recommendation engine", () => {
     expect(rec.recommendedDuration).toBeGreaterThanOrEqual(1800);
   });
 
+  it("drops malformed date rows before computing recommendations", () => {
+    const sessions = [
+      { date: daysAgo(0), plannedDuration: 50, actualDuration: 50, distressLevel: "none", belowThreshold: true },
+      { date: "not-a-date", plannedDuration: 50, actualDuration: 10, distressLevel: "severe", belowThreshold: false },
+    ];
+
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recommendedDuration).toBe(57);
+    expect(rec.recommendationType).toBe("keep_same_duration");
+  });
+
   it("does not let older short sessions drag recommendation near minimum", () => {
     const sessions = [
       { date: daysAgo(14), plannedDuration: 15, actualDuration: 15, distressLevel: "none", belowThreshold: true },
@@ -319,15 +330,21 @@ describe("recommendation engine", () => {
     expect(rec.recommendedDuration).toBe(120);
   });
 
-  it("does not break on empty or incomplete subtle history", () => {
+  it("drops malformed rows and still handles incomplete subtle history safely", () => {
     const recEmpty = buildRecommendation([], { goalSeconds: 3600 });
     expect(recEmpty.recommendedDuration).toBeGreaterThanOrEqual(30);
 
     const recIncomplete = buildRecommendation([
       { distressLevel: "subtle", plannedDuration: null, actualDuration: null },
     ], { goalSeconds: 3600 });
-    expect(recIncomplete.recoveryMode.active).toBe(true);
-    expect(recIncomplete.recommendationType).toBe("recovery_mode_active");
+    expect(recIncomplete.recoveryMode.active).toBe(false);
+    expect(recIncomplete.recommendedDuration).toBeGreaterThanOrEqual(30);
+
+    const recDated = buildRecommendation([
+      { date: daysAgo(0), distressLevel: "subtle", plannedDuration: null, actualDuration: null },
+    ], { goalSeconds: 3600 });
+    expect(recDated.recoveryMode.active).toBe(true);
+    expect(recDated.recommendationType).toBe("recovery_mode_active");
   });
 
   it("rolls back and enters stabilization mode after repeated active distress", () => {


### PR DESCRIPTION
### Motivation
- Centralize and standardize chronological sorting so UI and recommendation logic agree on how dates (including malformed values) are handled.
- Make invalid-date behavior explicit to avoid legacy/partial rows silently influencing recommendation decisions.

### Description
- Added a shared utility `src/lib/dateSort.js` that exposes `sortByDateAsc(items, { invalidPolicy })`, `INVALID_DATE_POLICIES`, and `toTimestampOrNull` and implements stable ordering with explicit policies `push-to-end` and `drop`.
- Replaced ad-hoc sorting in `src/lib/activityDateTime.js` to call the shared sorter with `invalidPolicy: "push-to-end"` so malformed UI rows are pushed to the end while preserving tie order.
- Replaced ad-hoc sorting in `src/lib/protocol.js` to call the shared sorter with `invalidPolicy: "drop"` so malformed/undated session rows are excluded from recommendation and recovery-state computations.
- Updated tests to assert the new behavior by expanding `tests/activityDateTime.test.js` (additional malformed rows: `""` and missing `date`) and modifying `tests/protocol.test.js` to verify malformed rows are dropped and that subtle-history behavior is safe when rows lack dates.

### Testing
- Ran the targeted test suite with `npm test -- --run tests/activityDateTime.test.js tests/protocol.test.js` and all tests passed: `51 passed (51)`.
- Verified `activityDateTime` tests assert stable push-to-end ordering for invalid dates and `protocol` tests verify malformed rows are quarantined from recommendation logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de672080e4833292cd37c77004c5d2)