### PR TITLE
Request walk sync metadata and add merge tests for walk_type/revision

### DIFF
--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -320,6 +320,16 @@ export const SESSION_SYNC_FETCH_SELECT = [
   ...Object.values(SESSION_SYNC_FETCH_FIELD_MAP),
 ].join(",");
 
+export const WALKS_SYNC_FETCH_SELECT = [
+  "id",
+  "dog_id",
+  "date",
+  "duration",
+  "walk_type",
+  "revision",
+  "updated_at",
+].join(",");
+
 const mapSyncFetchSessionRow = (r) => ({
   id: r.id,
   date: r.date,
@@ -342,7 +352,7 @@ export const syncFetch = async (dogId) => {
   const id = canonicalDogId(dogId);
   const dogFilter = `dog_id=eq.${encodeURIComponent(id)}`;
   const sessionsSelect = SESSION_SYNC_FETCH_SELECT;
-  const walksSelect = "id,dog_id,date,duration,walk_type,revision,updated_at";
+  const walksSelect = WALKS_SYNC_FETCH_SELECT;
   const patternsSelect = "id,dog_id,date,type,revision,updated_at";
   const feedingsSelect = "id,dog_id,date,food_type,amount,revision,updated_at";
   const parseMissingColumn = (errorText) => {

--- a/tests/syncConflict.test.js
+++ b/tests/syncConflict.test.js
@@ -41,4 +41,15 @@ describe("mergeById concurrent edits", () => {
     expect(merged[0].type).toBe("jacket");
     expect(merged[0].updatedAt).toBe(iso(12));
   });
+
+  it("preserves non-default walk type when higher revision wins", () => {
+    const localWalks = [{ id: "walk-1", date: iso(8), revision: 3, updatedAt: iso(8), type: "training_walk", duration: 900 }];
+    const remoteWalks = [{ id: "walk-1", date: iso(8), revision: 2, updatedAt: iso(10), type: "regular_walk", duration: 900 }];
+
+    const merged = mergeById(localWalks, remoteWalks);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].revision).toBe(3);
+    expect(merged[0].type).toBe("training_walk");
+  });
 });

--- a/tests/syncFetchRuntime.test.js
+++ b/tests/syncFetchRuntime.test.js
@@ -125,4 +125,44 @@ describe("syncFetch runtime fallbacks", () => {
     expect(result.sessions.some((session) => session.id === "s-activity")).toBe(true);
     expect(result.walks.some((walk) => walk.id === "w-activity")).toBe(true);
   });
+
+  it("requests walk sync metadata and preserves non-default walk types", async () => {
+    const walkSelectAttempts = [];
+    global.fetch = vi.fn(async (url) => {
+      const { path, params } = getPathAndParams(url);
+      if (path === "dogs") return jsonResponse(200, [{ id: "DOG3", settings: { dogName: "Luna" } }]);
+      if (path === "sessions") return jsonResponse(200, []);
+      if (path === "walks") {
+        walkSelectAttempts.push(params.get("select") || "");
+        return jsonResponse(200, [{
+          id: "w-training",
+          dog_id: "DOG3",
+          date: "2026-03-01T03:00:00.000Z",
+          duration: 1200,
+          walk_type: "training_walk",
+          revision: 7,
+          updated_at: "2026-03-01T03:01:00.000Z",
+        }]);
+      }
+      if (path === "patterns") return jsonResponse(200, []);
+      if (path === "feedings") return jsonResponse(200, []);
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const { syncFetch } = await setupStorageModule();
+    const { result, error } = await syncFetch("DOG3");
+
+    expect(error).toBeNull();
+    expect(walkSelectAttempts[0]).toContain("walk_type");
+    expect(walkSelectAttempts[0]).toContain("revision");
+    expect(walkSelectAttempts[0]).toContain("updated_at");
+    expect(result.walks).toEqual([{
+      id: "w-training",
+      date: "2026-03-01T03:00:00.000Z",
+      duration: 1200,
+      type: "training_walk",
+      revision: 7,
+      updatedAt: "2026-03-01T03:01:00.000Z",
+    }]);
+  });
 });

--- a/tests/syncFetchShape.test.js
+++ b/tests/syncFetchShape.test.js
@@ -2,12 +2,21 @@ import { describe, expect, it } from "vitest";
 import {
   SESSION_SYNC_FETCH_FIELD_MAP,
   SESSION_SYNC_FETCH_SELECT,
+  WALKS_SYNC_FETCH_SELECT,
 } from "../src/features/app/storage";
 
 describe("syncFetch sessions projection shape", () => {
   it("projection exactly matches mapped session fields", () => {
     const selectedFields = SESSION_SYNC_FETCH_SELECT.split(",").map((field) => field.trim());
     const expectedFields = ["id", "dog_id", "date", ...Object.values(SESSION_SYNC_FETCH_FIELD_MAP)];
+
+    expect(new Set(selectedFields).size).toBe(selectedFields.length);
+    expect([...selectedFields].sort()).toEqual([...expectedFields].sort());
+  });
+
+  it("walk projection includes sync merge metadata", () => {
+    const selectedFields = WALKS_SYNC_FETCH_SELECT.split(",").map((field) => field.trim());
+    const expectedFields = ["id", "dog_id", "date", "duration", "walk_type", "revision", "updated_at"];
 
     expect(new Set(selectedFields).size).toBe(selectedFields.length);
     expect([...selectedFields].sort()).toEqual([...expectedFields].sort());


### PR DESCRIPTION
### Motivation
- Ensure walk sync requests include `walk_type`, `revision`, and `updated_at` so remote walk rows carry the metadata needed for revision-based merges and to preserve non-default walk types.

### Description
- Add `WALKS_SYNC_FETCH_SELECT` and switch `syncFetch` to use it so walk queries explicitly request `id,dog_id,date,duration,walk_type,revision,updated_at`.
- Keep mapping to `type: normalizeWalkType(r.walk_type)` and return `revision`/`updatedAt` with the mapped walk to avoid data loss when normalizing `walk_type`.
- Add a projection-shape test for walks in `tests/syncFetchShape.test.js`.
- Add a runtime sync test in `tests/syncFetchRuntime.test.js` that asserts the walk query includes `walk_type`, `revision`, and `updated_at` and that a non-default walk type (`training_walk`) is preserved in the mapped output.
- Add a merge conflict test in `tests/syncConflict.test.js` to verify higher-revision wins while preserving a non-default walk type.

### Testing
- Ran `npm test -- tests/syncFetchShape.test.js tests/syncFetchRuntime.test.js tests/syncConflict.test.js` and all tests passed (3 files, 11 tests).
- The runtime test confirmed the `walks` select includes `walk_type`, `revision`, and `updated_at` and that `type` was normalized to `training_walk` without losing `revision` or `updatedAt`.
- The merge test confirmed `mergeById`/`resolveSyncConflict` keeps the higher revision entry and preserves the non-default walk type.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de858f13848332b8e465a63a08170b)