### PR TITLE
Include revision/updated_at for patterns & feedings; normalize and add conflict tests

### DIFF
--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -285,14 +285,32 @@ const LEGACY_DISTRESS_LEVEL_MAP = {
 const mapDistressForLegacySupabase = (level) => LEGACY_DISTRESS_LEVEL_MAP[normalizeDistressLevel(level)] ?? "none";
 
 export const normalizeSessions = (rows = []) => ensureArray(rows).map(normalizeSession);
+const normalizeRevision = (value) => {
+  const revision = Number(value);
+  return Number.isFinite(revision) ? revision : null;
+};
+
+const normalizeUpdatedAt = (row = {}) => row?.updatedAt ?? row?.updated_at ?? null;
+
+export const normalizePatterns = (rows = []) => ensureArray(rows)
+  .map((row) => ({
+    id: String(row?.id || ""),
+    date: row?.date || new Date().toISOString(),
+    type: row?.type || "",
+    revision: normalizeRevision(row?.revision),
+    updatedAt: normalizeUpdatedAt(row),
+  }))
+  .filter((row) => row.id)
+  .sort((a, b) => new Date(a.date) - new Date(b.date));
+
 export const normalizeFeedings = (rows = []) => ensureArray(rows)
   .map((row) => ({
     id: String(row?.id || ""),
     date: row?.date || new Date().toISOString(),
     foodType: row?.foodType ?? row?.food_type ?? "meal",
     amount: row?.amount ?? "small",
-    revision: Number.isFinite(row?.revision) ? Number(row.revision) : null,
-    updatedAt: row?.updatedAt ?? row?.updated_at ?? null,
+    revision: normalizeRevision(row?.revision),
+    updatedAt: normalizeUpdatedAt(row),
   }))
   .filter((row) => row.id)
   .sort((a, b) => new Date(a.date) - new Date(b.date));
@@ -330,6 +348,9 @@ export const WALKS_SYNC_FETCH_SELECT = [
   "updated_at",
 ].join(",");
 
+export const PATTERNS_SYNC_FETCH_SELECT = "id,dog_id,date,type,revision,updated_at";
+export const FEEDINGS_SYNC_FETCH_SELECT = "id,dog_id,date,food_type,amount,revision,updated_at";
+
 const mapSyncFetchSessionRow = (r) => ({
   id: r.id,
   date: r.date,
@@ -353,8 +374,8 @@ export const syncFetch = async (dogId) => {
   const dogFilter = `dog_id=eq.${encodeURIComponent(id)}`;
   const sessionsSelect = SESSION_SYNC_FETCH_SELECT;
   const walksSelect = WALKS_SYNC_FETCH_SELECT;
-  const patternsSelect = "id,dog_id,date,type,revision,updated_at";
-  const feedingsSelect = "id,dog_id,date,food_type,amount,revision,updated_at";
+  const patternsSelect = PATTERNS_SYNC_FETCH_SELECT;
+  const feedingsSelect = FEEDINGS_SYNC_FETCH_SELECT;
   const parseMissingColumn = (errorText) => {
     const text = String(errorText || "");
     const match = text.match(/column\s+([a-zA-Z0-9_."]+)\s+does not exist/i);
@@ -500,7 +521,13 @@ export const syncFetch = async (dogId) => {
         revision: r.revision,
         updatedAt: r.updated_at,
       })),
-      patterns: patRows.map((r) => ({ id: r.id, date: r.date, type: r.type, revision: r.revision, updatedAt: r.updated_at })),
+      patterns: normalizePatterns(patRows.map((r) => ({
+        id: r.id,
+        date: r.date,
+        type: r.type,
+        revision: r.revision,
+        updatedAt: r.updated_at,
+      }))),
       feedings: normalizeFeedings(feedingRows.map((r) => ({
         id: r.id,
         date: r.date,
@@ -659,7 +686,7 @@ export const hydrateDogFromLocal = (dogId) => {
   return {
     sessions: localSessions,
     walks: ensureArray(load(walkKey(id), load(legacyWalkKey(id), []))).map((w) => ({ ...w, type: normalizeWalkType(w?.type) })),
-    patterns: ensureArray(load(patKey(id), [])),
+    patterns: normalizePatterns(load(patKey(id), [])),
     feedings: normalizeFeedings(load(feedingKey(id), [])),
     patLabels: ensureObject(load(patLblKey(id), {})),
     photo: load(photoKey(id), null),

--- a/tests/storageNormalization.test.js
+++ b/tests/storageNormalization.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { normalizeFeedings, normalizePatterns } from "../src/features/app/storage";
+
+describe("storage normalization", () => {
+  it("keeps feeding revision/updatedAt non-null when provided", () => {
+    const rows = normalizeFeedings([{
+      id: "feeding-1",
+      date: "2026-04-01T09:00:00.000Z",
+      food_type: "meal",
+      amount: "medium",
+      revision: "12",
+      updated_at: "2026-04-01T09:10:00.000Z",
+    }]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].revision).toBe(12);
+    expect(rows[0].updatedAt).toBe("2026-04-01T09:10:00.000Z");
+  });
+
+  it("keeps pattern revision/updatedAt non-null when provided", () => {
+    const rows = normalizePatterns([{
+      id: "pattern-1",
+      date: "2026-04-01T08:00:00.000Z",
+      type: "keys",
+      revision: "7",
+      updated_at: "2026-04-01T08:30:00.000Z",
+    }]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].revision).toBe(7);
+    expect(rows[0].updatedAt).toBe("2026-04-01T08:30:00.000Z");
+  });
+});

--- a/tests/syncConflict.test.js
+++ b/tests/syncConflict.test.js
@@ -42,6 +42,28 @@ describe("mergeById concurrent edits", () => {
     expect(merged[0].updatedAt).toBe(iso(12));
   });
 
+  it("prefers higher pattern revision over newer updatedAt", () => {
+    const localPatterns = [{ id: "pattern-2", date: iso(8), revision: 10, updatedAt: iso(9), type: "keys" }];
+    const remotePatterns = [{ id: "pattern-2", date: iso(8), revision: 9, updatedAt: iso(12), type: "jacket" }];
+
+    const merged = mergeById(localPatterns, remotePatterns);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].revision).toBe(10);
+    expect(merged[0].type).toBe("keys");
+  });
+
+  it("prefers higher feeding revision over newer updatedAt", () => {
+    const localFeedings = [{ id: "feeding-1", date: iso(8), revision: 6, updatedAt: iso(9), foodType: "meal", amount: "small" }];
+    const remoteFeedings = [{ id: "feeding-1", date: iso(8), revision: 5, updatedAt: iso(12), foodType: "snack", amount: "large" }];
+
+    const merged = mergeById(localFeedings, remoteFeedings);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].revision).toBe(6);
+    expect(merged[0].foodType).toBe("meal");
+  });
+
   it("preserves non-default walk type when higher revision wins", () => {
     const localWalks = [{ id: "walk-1", date: iso(8), revision: 3, updatedAt: iso(8), type: "training_walk", duration: 900 }];
     const remoteWalks = [{ id: "walk-1", date: iso(8), revision: 2, updatedAt: iso(10), type: "regular_walk", duration: 900 }];

--- a/tests/syncFetchShape.test.js
+++ b/tests/syncFetchShape.test.js
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  FEEDINGS_SYNC_FETCH_SELECT,
+  PATTERNS_SYNC_FETCH_SELECT,
   SESSION_SYNC_FETCH_FIELD_MAP,
   SESSION_SYNC_FETCH_SELECT,
   WALKS_SYNC_FETCH_SELECT,
@@ -20,5 +22,16 @@ describe("syncFetch sessions projection shape", () => {
 
     expect(new Set(selectedFields).size).toBe(selectedFields.length);
     expect([...selectedFields].sort()).toEqual([...expectedFields].sort());
+  });
+
+  it("pattern/feedings projection includes sync merge metadata", () => {
+    const patternFields = PATTERNS_SYNC_FETCH_SELECT.split(",").map((field) => field.trim());
+    const feedingFields = FEEDINGS_SYNC_FETCH_SELECT.split(",").map((field) => field.trim());
+
+    expect(new Set(patternFields).size).toBe(patternFields.length);
+    expect(patternFields).toEqual(["id", "dog_id", "date", "type", "revision", "updated_at"]);
+
+    expect(new Set(feedingFields).size).toBe(feedingFields.length);
+    expect(feedingFields).toEqual(["id", "dog_id", "date", "food_type", "amount", "revision", "updated_at"]);
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure pattern and feeding records include sync metadata (`revision`, `updated_at`) consistently so conflict resolution can prefer revision precedence.
- Keep normalization outputs coercing numeric-like revisions and preserving `updatedAt` so downstream logic sees non-null metadata when present.
- Add tests to cover projection shape, normalization, and conflict-resolution behavior for patterns/feedings.

### Description
- Exported `PATTERNS_SYNC_FETCH_SELECT` and `FEEDINGS_SYNC_FETCH_SELECT` and wired `syncFetch` to use them so queries include `revision` and `updated_at`.
- Added `normalizePatterns`, shared `normalizeRevision` and `normalizeUpdatedAt` helpers, and updated `normalizeFeedings` to coerce/retain `revision` and `updatedAt` consistently; updated local hydration to use `normalizePatterns`.
- Adjusted sync result mapping to normalize pattern rows and feeding rows before returning them.
- Extended tests: added `tests/storageNormalization.test.js`, updated `tests/syncFetchShape.test.js` to assert projection fields, and extended `tests/syncConflict.test.js` with pattern/feeding conflict cases.

### Testing
- Ran the unit tests with `npm test -- tests/syncFetchShape.test.js tests/storageNormalization.test.js tests/syncConflict.test.js`.
- All test files passed: 3 test files, 12 tests total passed.
- The new normalization and conflict tests exercise numeric-string revision coercion and revision-over-updatedAt precedence and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de8717d010833281148521ba19e995)