### PR TITLE
Preserve legacy severe distress: dual-field persistence, migration, and round-trip test

### DIFF
--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -173,6 +173,13 @@ export const normalizeSession = (row = {}) => {
   const symptoms = row.symptoms ?? {};
   const preSession = row.preSession ?? row.pre_session ?? {};
   const environment = row.environment ?? {};
+  const normalizedDistressType = row.distressType ?? row.distress_type ?? null;
+  const normalizedDistressSeverity = row.distressSeverity ?? row.distress_severity ?? null;
+  const restoredLegacyDistress = decodeLegacyDistressFields({
+    distressLevel: row.distressLevel ?? row.distress_level ?? (row.result === "success" ? "none" : "strong"),
+    distressType: normalizedDistressType,
+    distressSeverity: normalizedDistressSeverity,
+  });
   const actualDuration = resolveDurationSeconds(row, {
     secondsKeys: ["actualDurationSeconds", "actual_duration_seconds", "durationSeconds", "duration_seconds", "completedDurationSeconds", "completed_duration_seconds"],
     canonicalKeys: ["actualDuration", "actual_duration"],
@@ -189,7 +196,7 @@ export const normalizeSession = (row = {}) => {
     ...row,
     actualDuration,
     plannedDuration,
-    distressLevel: normalizeDistressLevel(row.distressLevel ?? row.distress_level ?? (row.result === "success" ? "none" : "strong")),
+    distressLevel: restoredLegacyDistress.distressLevel,
     context: {
       timeOfDay: context.timeOfDay ?? context.time_of_day ?? null,
       departureType: context.departureType ?? context.departure_type ?? "training",
@@ -213,8 +220,8 @@ export const normalizeSession = (row = {}) => {
       : hasValue(row.below_threshold)
         ? asBool(row.below_threshold)
         : undefined,
-    distressType: row.distressType ?? row.distress_type ?? null,
-    distressSeverity: row.distressSeverity ?? row.distress_severity ?? null,
+    distressType: restoredLegacyDistress.distressType,
+    distressSeverity: normalizedDistressSeverity,
     videoReview: {
       recorded: hasValue((row.videoReview || {}).recorded) ? !!row.videoReview.recorded : asBool((row.video_review || {}).recorded),
       firstSubtleDistressTs: (row.videoReview || {}).firstSubtleDistressTs ?? (row.video_review || {}).first_subtle_distress_ts ?? null,
@@ -283,6 +290,39 @@ const LEGACY_DISTRESS_LEVEL_MAP = {
 };
 
 const mapDistressForLegacySupabase = (level) => LEGACY_DISTRESS_LEVEL_MAP[normalizeDistressLevel(level)] ?? "none";
+const LEGACY_SEVERITY_TYPE_PREFIX = "__severity:";
+
+const encodeLegacyDistressType = (distressType, distressLevel) => {
+  const type = distressType == null ? null : String(distressType).trim();
+  if (normalizeDistressLevel(distressLevel) !== "severe") return type || null;
+  const payload = type ? `severe|${type}` : "severe";
+  return `${LEGACY_SEVERITY_TYPE_PREFIX}${payload}`;
+};
+
+const decodeLegacyDistressFields = ({ distressLevel, distressType, distressSeverity }) => {
+  const typeRaw = distressType == null ? "" : String(distressType);
+  const decodeTypeFromRaw = () => {
+    if (!typeRaw.startsWith(LEGACY_SEVERITY_TYPE_PREFIX)) return distressType;
+    const encodedPayload = typeRaw.slice(LEGACY_SEVERITY_TYPE_PREFIX.length);
+    const [, ...rest] = encodedPayload.split("|");
+    return rest.length ? rest.join("|") : null;
+  };
+  const explicitSeverity = normalizeDistressLevel(distressSeverity);
+  const normalizedLevel = normalizeDistressLevel(distressLevel);
+  if (explicitSeverity === "severe") {
+    return { distressLevel: "severe", distressType: decodeTypeFromRaw() };
+  }
+  if (!typeRaw.startsWith(LEGACY_SEVERITY_TYPE_PREFIX)) {
+    return { distressLevel: normalizedLevel, distressType };
+  }
+  const encodedPayload = typeRaw.slice(LEGACY_SEVERITY_TYPE_PREFIX.length);
+  const [encodedLevel, ...rest] = encodedPayload.split("|");
+  const decodedType = rest.length ? rest.join("|") : null;
+  if (normalizeDistressLevel(encodedLevel) === "severe") {
+    return { distressLevel: "severe", distressType: decodedType };
+  }
+  return { distressLevel: normalizedLevel, distressType };
+};
 
 export const normalizeSessions = (rows = []) => ensureArray(rows).map(normalizeSession);
 const normalizeRevision = (value) => {
@@ -322,6 +362,7 @@ export const SESSION_SYNC_FETCH_FIELD_MAP = {
   result: "result",
   latencyToFirstDistress: "latency_to_first_distress",
   distressType: "distress_type",
+  distressSeverity: "distress_severity",
   context: "context",
   symptoms: "symptoms",
   recoverySeconds: "recovery_seconds",
@@ -360,6 +401,7 @@ const mapSyncFetchSessionRow = (r) => ({
   result: r[SESSION_SYNC_FETCH_FIELD_MAP.result],
   latencyToFirstDistress: r[SESSION_SYNC_FETCH_FIELD_MAP.latencyToFirstDistress],
   distressType: r[SESSION_SYNC_FETCH_FIELD_MAP.distressType],
+  distressSeverity: r[SESSION_SYNC_FETCH_FIELD_MAP.distressSeverity],
   context: r[SESSION_SYNC_FETCH_FIELD_MAP.context],
   symptoms: r[SESSION_SYNC_FETCH_FIELD_MAP.symptoms],
   recoverySeconds: r[SESSION_SYNC_FETCH_FIELD_MAP.recoverySeconds],
@@ -570,6 +612,7 @@ export const syncPush = async (dogId, kind, data, dogSettings = null) => {
         result: data.result,
         latency_to_first_distress: data.latencyToFirstDistress ?? null,
         distress_type: data.distressType ?? null,
+        distress_severity: normalizeDistressLevel(data.distressSeverity ?? data.distressLevel ?? null),
         context: data.context ?? null,
         symptoms: data.symptoms ?? null,
         recovery_seconds: data.recoverySeconds ?? null,
@@ -634,13 +677,23 @@ export const syncPush = async (dogId, kind, data, dogSettings = null) => {
         continue;
       }
 
+      if (/distress_severity/i.test(errorText)) {
+        delete sessionPayload.distress_severity;
+        res = await postRow(sessionPayload);
+        continue;
+      }
+
       if (/(distress_level|sessions_distress_level_check|check constraint)/i.test(errorText)) {
         const mappedDistressLevel = mapDistressForLegacySupabase(data.distressLevel);
+        const encodedLegacyType = encodeLegacyDistressType(data.distressType, data.distressLevel);
         if (sessionPayload.distress_level !== mappedDistressLevel) {
           sessionPayload.distress_level = mappedDistressLevel;
-          res = await postRow(sessionPayload);
-          continue;
         }
+        if (sessionPayload.distress_type !== encodedLegacyType) {
+          sessionPayload.distress_type = encodedLegacyType;
+        }
+        res = await postRow(sessionPayload);
+        continue;
       }
 
       break;

--- a/supabase_sync_schema_migration.sql
+++ b/supabase_sync_schema_migration.sql
@@ -20,6 +20,8 @@ create table if not exists public.sessions (
   planned_duration integer,
   actual_duration integer,
   distress_level text,
+  distress_type text,
+  distress_severity text,
   result text,
   revision bigint not null default 0,
   updated_at timestamptz not null default now(),
@@ -59,6 +61,8 @@ create table if not exists public.feedings (
 alter table public.sessions
   add column if not exists context jsonb,
   add column if not exists symptoms jsonb,
+  add column if not exists distress_type text,
+  add column if not exists distress_severity text,
   add column if not exists recovery_seconds integer,
   add column if not exists pre_session jsonb,
   add column if not exists environment jsonb,
@@ -108,6 +112,19 @@ update public.sessions
 set environment = '{}'::jsonb
 where environment is null;
 
+update public.sessions
+set distress_level = case
+  when lower(distress_level) = 'mild' then 'subtle'
+  when lower(distress_level) = 'strong' then 'active'
+  when lower(distress_level) = 'panic' then 'severe'
+  else lower(distress_level)
+end
+where distress_level is not null;
+
+update public.sessions
+set distress_severity = coalesce(nullif(lower(distress_severity), ''), distress_level)
+where distress_level is not null;
+
 -- 4) Tighten nullability/defaults only after backfill
 alter table public.walks
   alter column duration set default 0,
@@ -118,6 +135,25 @@ alter table public.sessions
   alter column symptoms set default '{}'::jsonb,
   alter column pre_session set default '{}'::jsonb,
   alter column environment set default '{}'::jsonb;
+
+do $$
+begin
+  if exists (
+    select 1
+    from pg_constraint
+    where conname = 'sessions_distress_level_check'
+      and conrelid = 'public.sessions'::regclass
+  ) then
+    alter table public.sessions drop constraint sessions_distress_level_check;
+  end if;
+end $$;
+
+alter table public.sessions
+  add constraint sessions_distress_level_check
+  check (
+    distress_level is null
+    or distress_level in ('none', 'subtle', 'active', 'severe')
+  );
 
 -- 5) Foreign keys/indexes required for dog-scoped sync queries
 -- Add FK constraints defensively (skip if already present by name)

--- a/tests/syncFetchRuntime.test.js
+++ b/tests/syncFetchRuntime.test.js
@@ -165,4 +165,50 @@ describe("syncFetch runtime fallbacks", () => {
       updatedAt: "2026-03-01T03:01:00.000Z",
     }]);
   });
+
+  it("round-trips severe distress via legacy distress_level constraints without collapsing to active", async () => {
+    const persistedSessions = [];
+    global.fetch = vi.fn(async (url, options = {}) => {
+      const { path } = getPathAndParams(url);
+      if (path === "dogs") return jsonResponse(200, []);
+      if (path === "sessions" && (options.method || "GET") === "POST") {
+        const payload = JSON.parse(options.body || "{}");
+        persistedSessions.push(payload);
+        if (payload.distress_level === "severe") {
+          return jsonResponse(400, { message: "new row for relation \"sessions\" violates check constraint \"sessions_distress_level_check\"" });
+        }
+        return jsonResponse(201, {});
+      }
+      if (path === "sessions") {
+        const latest = persistedSessions.at(-1);
+        return jsonResponse(200, latest ? [latest] : []);
+      }
+      if (path === "walks") return jsonResponse(200, []);
+      if (path === "patterns") return jsonResponse(200, []);
+      if (path === "feedings") return jsonResponse(200, []);
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const { syncFetch, syncPush } = await setupStorageModule();
+    const pushResult = await syncPush("dog4", "session", {
+      id: "s-severe",
+      date: "2026-04-01T00:00:00.000Z",
+      plannedDuration: 120,
+      actualDuration: 20,
+      distressLevel: "severe",
+      distressType: "vocalization",
+      result: "distress",
+    }, { id: "DOG4", dogName: "Nova" });
+
+    expect(pushResult.ok).toBe(true);
+    expect(persistedSessions).toHaveLength(2);
+    expect(persistedSessions[1].distress_level).toBe("strong");
+    expect(persistedSessions[1].distress_type).toBe("__severity:severe|vocalization");
+
+    const { result, error } = await syncFetch("DOG4");
+    expect(error).toBeNull();
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0].distressLevel).toBe("severe");
+    expect(result.sessions[0].distressType).toBe("vocalization");
+  });
 });


### PR DESCRIPTION
### Motivation

- Prevent loss of `severe` semantics when syncing to older Supabase schemas that only accept the legacy 3-level `distress_level` by introducing an explicit compatibility strategy.  

### Description

- Add encoding/decoding helpers and a small compatibility protocol in `src/features/app/storage.js` that encode severe intent into `distress_type` (prefix `__severity:`) on legacy-constrained writes and restore `severe` on read when possible.  
- Persist dual fields on upsert by writing `distress_severity` alongside `distress_level`, and update session fetch mapping to include `distress_severity` so reads can honor explicit severity when available.  
- On write failures caused by legacy `distress_level` check constraints the push logic now retries with a mapped 3-level `distress_level` while encoding severe details into `distress_type`, keeping the original semantics reconstructible.  
- Update `supabase_sync_schema_migration.sql` to add `distress_type` and `distress_severity`, normalize legacy values (`mild`/`strong`/`panic` → `subtle`/`active`/`severe`), backfill `distress_severity`, and replace the `sessions_distress_level_check` with a 4-level constraint.  

### Testing

- Ran the focused runtime tests with Vitest: `npm test -- tests/syncFetchRuntime.test.js`, and the suite passed (`5 tests, 5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded2de2e988332a7e625bde0660959)