### PR TITLE
Enforce daily session add limits and propagate blocked start behavior

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import { PROTOCOL, explainNextTarget, normalizeDistressLevel, suggestNext, sugge
 import { sortByDateAsc } from "./lib/activityDateTime";
 import { selectAppData } from "./features/app/selectors";
 import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeById, mergeSessionWithDerivedFields, normalizeFeedings, normalizeSessions, patKey, patLblKey, photoKey, save, sessKey, syncDelete, syncDeleteSessionsForDog, syncFetch, syncPush, syncUpsertDog, toDateTimeLocalValue, walkKey } from "./features/app/storage";
-import { fmt, getOutcomeTone, normalizeWalkType, walkTypeLabel } from "./features/app/helpers";
+import { fmt, fmtClock, getOutcomeTone, normalizeWalkType, walkTypeLabel } from "./features/app/helpers";
 import { CameraIcon, ChartIcon, HistoryIcon, HomeIcon, PawIcon, SettingsIcon } from "./features/app/ui.jsx";
 import { DogSelect, Onboarding } from "./features/setup/SetupScreens";
 import HomeScreen from "./features/home/HomeScreen";
@@ -520,7 +520,14 @@ export default function PawTimer() {
     setTarget(Math.max(Math.round(data.currentMaxCalm * 0.8), PROTOCOL.startDurationSeconds));
   };
 
-  const startSession = () => { setElapsed(0); setSessionCompleted(false); setSessionOutcome(null); setLatencyDraft(""); setDistressTypeDraft(""); setPhase("running"); };
+  const startSession = () => {
+    if (!appData.daily.canAdd) {
+      if (appData.daily.blockReason === "cap") showToast(`Daily alone-time cap reached (${fmtClock(appData.daily.capSec)}).`);
+      else if (appData.daily.blockReason === "max_sessions") showToast(`Daily session max reached (${appData.daily.maxCount}).`);
+      return;
+    }
+    setElapsed(0); setSessionCompleted(false); setSessionOutcome(null); setLatencyDraft(""); setDistressTypeDraft(""); setPhase("running");
+  };
   const endSession = () => { clearInterval(timerRef.current); setFinalElapsed(elapsed); setPhase("rating"); };
   const cancelSession = () => { setPhase("idle"); setElapsed(0); setFinalElapsed(0); setSessionCompleted(false); setSessionOutcome(null); setLatencyDraft(""); setDistressTypeDraft(""); clearInterval(timerRef.current); };
 

--- a/src/features/app/helpers.js
+++ b/src/features/app/helpers.js
@@ -28,8 +28,12 @@ export function dailyInfo(sessions) {
   const usedSec = today.reduce((sum, s) => sum + (s.actualDuration || 0), 0);
   const count = today.length;
   const capSec = PROTOCOL.maxDailyAloneMinutes * 60;
-  const canAdd = true;
-  return { count, usedSec, capSec, canAdd, maxCount: PROTOCOL.sessionsPerDayMax };
+  const maxCount = PROTOCOL.sessionsPerDayMax;
+  const underCap = usedSec < capSec;
+  const underSessionMax = count < maxCount;
+  const canAdd = underCap && underSessionMax;
+  const blockReason = !underCap ? "cap" : !underSessionMax ? "max_sessions" : null;
+  return { count, usedSec, capSec, canAdd, blockReason, maxCount };
 }
 
 export function patternInfo(patterns, walks, leavesPerDay = 3, protocol = PROTOCOL) {

--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -55,13 +55,29 @@ export default function HomeScreen(props) {
   const target = recommendation?.duration ?? 0;
   const recoveryMode = recommendation?.details?.recoveryMode;
   const [showRecoveryInfo, setShowRecoveryInfo] = useState(false);
+  const sessionBlockedMessage = daily.blockReason === "cap"
+    ? `Daily alone-time cap reached (${fmtClock(daily.capSec)}). Log more sessions tomorrow.`
+    : daily.blockReason === "max_sessions"
+      ? `Daily session max reached (${daily.maxCount}). Log more sessions tomorrow.`
+      : "";
 
   return (
     <div className="tab-content train-screen">
       <div className="train-main">
         <TrainProgressBar goalPct={goalPct} target={target} goalSec={goalSec} fmt={fmt} />
 
-        <SessionControl phase={phase} elapsed={elapsed} target={target} onStart={startSession} onEnd={endSession} onCancel={cancelSession} completed={sessionCompleted} fmt={fmt} />
+        <SessionControl
+          phase={phase}
+          elapsed={elapsed}
+          target={target}
+          onStart={startSession}
+          onEnd={endSession}
+          onCancel={cancelSession}
+          completed={sessionCompleted}
+          fmt={fmt}
+          canStart={daily.canAdd}
+          startBlockedMessage={sessionBlockedMessage}
+        />
 
         <SessionRatingPanel
           phase={phase}
@@ -143,7 +159,13 @@ export default function HomeScreen(props) {
           </div>
         )}
 
-        {daily.count >= Math.max(1, activeProto.sessionsPerDayMax - (pattern.normalizedLeaves >= 7 ? 1 : 0)) && (
+        {!daily.canAdd && (
+          <p className="status-msg status-msg--warning">
+            {sessionBlockedMessage}
+          </p>
+        )}
+
+        {daily.canAdd && daily.count >= Math.max(1, activeProto.sessionsPerDayMax - (pattern.normalizedLeaves >= 7 ? 1 : 0)) && (
           <p className="status-msg status-msg--warning">
             {daily.count} sessions today — for ~{pattern.normalizedLeaves} departures/day, keep it around {Math.max(1, activeProto.sessionsPerDayMax - (pattern.normalizedLeaves >= 7 ? 1 : 0))} to avoid overloading real departures.
           </p>

--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -18,6 +18,8 @@ export function SessionControl({
   onCancel,
   completed,
   fmt,
+  canStart = true,
+  startBlockedMessage = "Session limit reached for today.",
 }) {
   const [pressing, setPressing] = useState(false);
   const remaining = Math.max(target - elapsed, 0);
@@ -32,7 +34,7 @@ export function SessionControl({
   const timerValue = isRunning ? elapsed : remainingSeconds;
 
   const startWithFeedback = () => {
-    if (!onStart) return;
+    if (!onStart || !canStart) return;
     setPressing(true);
     setTimeout(() => {
       setPressing(false);
@@ -45,12 +47,15 @@ export function SessionControl({
       {phase !== "rating" && (<div className="session-control-wrap">
         <button
           className={`session-control ${isRunning ? "is-running" : ""} ${pressing ? "is-pressing" : ""} ${completed ? "is-complete" : ""} ${isPastTarget ? "is-over-target" : ""}`}
-          onClick={isIdle ? startWithFeedback : undefined}
+          onClick={isIdle && canStart ? startWithFeedback : undefined}
+          disabled={isIdle && !canStart}
           aria-label={isRunning
             ? (isPastTarget
               ? `${fmt(overTargetSeconds)} over target in current session`
               : `${fmt(remainingSeconds)} remaining in current session`)
-            : `Start ${fmt(target)} session`}
+            : canStart
+              ? `Start ${fmt(target)} session`
+              : startBlockedMessage}
           aria-live={isRunning ? "polite" : undefined}
         >
           <svg className="sc-ring-svg" viewBox="0 0 226 226" aria-hidden="true">
@@ -69,7 +74,7 @@ export function SessionControl({
             <div className="sc-idle" aria-hidden={isRunning}>
               <div className="sc-idle-label">
                 <span>Start</span>
-                <span>Session</span>
+                <span>{canStart ? "Session" : "Blocked"}</span>
               </div>
             </div>
 

--- a/tests/dailyInfoLimits.test.js
+++ b/tests/dailyInfoLimits.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { PROTOCOL } from "../src/lib/protocol";
+import { dailyInfo } from "../src/features/app/helpers";
+
+const nowIso = () => new Date().toISOString();
+
+describe("dailyInfo add-session limits", () => {
+  it("allows adding when both cap and session count are below limit", () => {
+    const sessions = [
+      { date: nowIso(), actualDuration: 300 },
+      { date: nowIso(), actualDuration: 300 },
+    ];
+
+    const info = dailyInfo(sessions);
+
+    expect(info.canAdd).toBe(true);
+    expect(info.blockReason).toBeNull();
+  });
+
+  it("blocks adding when usedSec reaches the daily cap boundary", () => {
+    const capSec = PROTOCOL.maxDailyAloneMinutes * 60;
+    const sessions = [{ date: nowIso(), actualDuration: capSec }];
+
+    const info = dailyInfo(sessions);
+
+    expect(info.usedSec).toBe(capSec);
+    expect(info.canAdd).toBe(false);
+    expect(info.blockReason).toBe("cap");
+  });
+
+  it("blocks adding when session count reaches sessionsPerDayMax boundary", () => {
+    const sessions = Array.from({ length: PROTOCOL.sessionsPerDayMax }, () => ({
+      date: nowIso(),
+      actualDuration: 60,
+    }));
+
+    const info = dailyInfo(sessions);
+
+    expect(info.count).toBe(PROTOCOL.sessionsPerDayMax);
+    expect(info.canAdd).toBe(false);
+    expect(info.blockReason).toBe("max_sessions");
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent starting sessions when daily alone-time or session-count limits are reached by replacing the previous unconditional allow with policy-driven checks.
- Surface why a start is blocked to the UI and runtime so users get a clear message and automated flows cannot bypass the restriction.

### Description
- Replace `canAdd = true` in `dailyInfo` with logic based on `usedSec < capSec` and `count < sessionsPerDayMax`, and return `blockReason` and `maxCount` alongside `canAdd` in `src/features/app/helpers.js`.
- Wire `daily.canAdd` and a contextual `startBlockedMessage` into the session start control in `src/features/train/TrainComponents.jsx` so the start button is disabled, its accessible label reflects the block, and the idle label shows `Blocked` when blocked.
- Show an explicit warning message on the Home screen when starts are blocked and pass the blocked state into `SessionControl` in `src/features/home/HomeScreen.jsx`.
- Add a defensive runtime guard in `startSession` in `src/App.jsx` that prevents non-UI starts and displays a toast with the `cap`/`max_sessions` reason; also import `fmtClock` to format cap messaging.
- Add boundary tests in `tests/dailyInfoLimits.test.js` covering allowed case, cap boundary (`usedSec === capSec`) blocking, and session-count boundary (`count === sessionsPerDayMax`) blocking.

### Testing
- Ran the test suite with `npm test` (Vitest); all test files passed including the new `tests/dailyInfoLimits.test.js` (10 files, 84 tests total passed).
- A run attempt using `npm test -- --runInBand` failed due to an unsupported Vitest CLI option, so the plain `npm test` run was used and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded2f6912883328bc9adab390f7c07)