### PR TITLE
Allow long calm sessions to satisfy subtle recovery; update UI/help and tests

### DIFF
--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -135,6 +135,11 @@ export default function HomeScreen(props) {
               <p className="recovery-explain-copy">
                 {recoveryMode.planCopy}
               </p>
+              {recoveryMode.acceptsAnyCalmSession && (
+                <p className="recovery-explain-copy">
+                  For subtle recovery, calm sessions can be any length—you do not need to match the exact step duration.
+                </p>
+              )}
               <div className="recovery-explain-meta">
                 <span>{recoveryMode.currentStepLabel || `Step ${Math.max(1, recoveryMode.step)} of ${recoveryMode.totalSessions || 2}`}</span>
                 <span>{recoveryMode.remainingSessions} remaining</span>

--- a/src/features/settings/SettingsScreen.jsx
+++ b/src/features/settings/SettingsScreen.jsx
@@ -218,6 +218,7 @@ export default function SettingsScreen(props) {
               <div className="proto-section u-mt-none"><div className="proto-title">Sync devices</div><div className="proto-row">Share your Dog ID, then join with the same ID on the other device.</div></div>
               <div className="proto-section"><div className="proto-title">Session flow</div><div className="proto-row">Start a session, return before distress escalates, then rate how {name} did.</div></div>
               <div className="proto-section"><div className="proto-title">Next target</div><div className="proto-row">{recommendation?.explanation} It currently weighs {(recommendation?.details?.factors || []).join(" ")}</div></div>
+              <div className="proto-section"><div className="proto-title">Subtle recovery</div><div className="proto-row">After a subtle-distress trigger, any calm follow-up session counts toward recovery completion, even if the duration is longer than the suggested step.</div></div>
               <div className="proto-section"><div className="proto-title">Daily rhythm</div><div className="proto-row">Aim for up to {activeProto.sessionsPerDayMax} sessions, {activeProto.maxDailyAloneMinutes} min/day, and {pattern.recMin}–{pattern.recMax} pattern breaks.</div></div>
             </div>
           </div>

--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -711,13 +711,14 @@ function buildRecoveryModeDetails({
   const stepLabels = planDurations.map((duration) => formatRecoveryStepLabel(duration));
   const planCopy = [DISTRESS_LEVELS.ACTIVE, DISTRESS_LEVELS.SEVERE].includes(stressLevel)
     ? `We temporarily switched to a ${totalSessions}-step confidence rebuild so your dog can stack calm wins before progression resumes.`
-    : `We temporarily shortened sessions after subtle stress so your dog can complete this ${totalSessions}-step confidence reset.`;
+    : `We temporarily shortened sessions after subtle stress so your dog can complete this ${totalSessions}-step confidence reset. Any calm session counts toward completion.`;
 
   return {
     step: safeStep,
     totalSessions,
     stepLabels,
     planCopy,
+    acceptsAnyCalmSession: stressLevel === DISTRESS_LEVELS.SUBTLE,
     currentStepLabel: `Step ${Math.max(1, safeStep)} of ${totalSessions}`,
   };
 }
@@ -796,6 +797,9 @@ function evaluatePersistentRecoveryMode(
     recentWindow = [],
   } = {},
 ) {
+  // Policy decision: for subtle-trigger recovery, count any calm session toward completion.
+  // We still keep duration-bound checks for active/severe triggers.
+  const subtleRecoveryAcceptsAnyCalmSession = true;
   const normalized = normalizeRecoveryState(recoveryState);
   if (!normalized?.active) return null;
   const triggerIndex = trainingSessions.findIndex((session) => (
@@ -818,7 +822,7 @@ function evaluatePersistentRecoveryMode(
     const sessionDuration = getSessionDurationAnchor(session);
     const looksLikeRecovery = [DISTRESS_LEVELS.ACTIVE, DISTRESS_LEVELS.SEVERE].includes(stressLevel)
       ? Number.isFinite(sessionDuration) && sessionDuration <= 120
-      : true;
+      : subtleRecoveryAcceptsAnyCalmSession;
     if (session.distressLevel === DISTRESS_LEVELS.NONE && looksLikeRecovery) consecutiveCalm += 1;
     else consecutiveCalm = 0;
   }

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -286,6 +286,31 @@ describe("recommendation engine", () => {
     expect(rec.recommendedDuration).toBe(1140);
   });
 
+  it("counts long calm sessions toward subtle recovery completion", () => {
+    const sessions = [
+      { date: daysAgo(2), plannedDuration: 1200, actualDuration: 1200, distressLevel: "subtle", belowThreshold: false },
+      { date: daysAgo(1), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(0), plannedDuration: 960, actualDuration: 960, distressLevel: "none", belowThreshold: true },
+    ];
+
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recoveryMode.active).toBe(false);
+    expect(rec.recommendationType).toBe("recovery_mode_resume");
+    expect(rec.recommendedDuration).toBe(1140);
+  });
+
+  it("keeps subtle recovery active until two calm sessions, even when those sessions are long", () => {
+    const sessions = [
+      { date: daysAgo(2), plannedDuration: 1200, actualDuration: 1200, distressLevel: "subtle", belowThreshold: false },
+      { date: daysAgo(1), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
+    ];
+
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recoveryMode.active).toBe(true);
+    expect(rec.recoveryMode.remainingSessions).toBe(1);
+    expect(rec.recommendedDuration).toBe(120);
+  });
+
   it("does not fall to 30s after subtle->1m calm->2m calm recovery sequence", () => {
     const sessions = [
       { date: daysAgo(2), plannedDuration: 1200, actualDuration: 1200, distressLevel: "subtle", belowThreshold: false },
@@ -434,6 +459,7 @@ describe("public compatibility APIs", () => {
     const next = explainNextTarget(sessions, [], [], { goalSeconds: 3600 });
     expect(next.recoveryMode.active).toBe(true);
     expect(next.recoveryMode.remainingSessions).toBe(2);
+    expect(next.recoveryMode.acceptsAnyCalmSession).toBe(true);
     expect(next.recommendedDuration).toBe(60);
     expect(next.explanation).toMatch(/Short recovery sessions after stress/i);
   });


### PR DESCRIPTION
### Motivation
- Make an explicit policy choice for subtle-trigger recovery so calm follow-up sessions of any duration can count toward completing subtle recovery steps. 
- Keep active/severe-trigger recovery behavior unchanged by preserving duration-bound checks for those higher-stress levels.

### Description
- Updated recovery evaluation in `src/lib/protocol.js` to accept any calm post-trigger session for subtle triggers by enabling a `subtleRecoveryAcceptsAnyCalmSession` policy and using it when counting consecutive calm sessions. 
- Enhanced recovery metadata in `buildRecoveryModeDetails` to append explanatory copy and expose a boolean `acceptsAnyCalmSession` flag for UI consumption. 
- Added UI/help text in `src/features/home/HomeScreen.jsx` and `src/features/settings/SettingsScreen.jsx` to explain that subtle-recovery calm sessions can be any length and do not need to match the step duration. 
- Added tests in `tests/protocol.test.js` covering subtle recovery completion with long calm sessions and asserting the new `acceptsAnyCalmSession` metadata.

### Testing
- Ran the protocol tests with `npm test -- tests/protocol.test.js` and all tests passed (`48` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded2fad5608332939f840f3d2f9605)