### PR TITLE
Make recovery modal messaging context-aware by trigger severity

### DIFF
--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -54,6 +54,18 @@ export default function HomeScreen(props) {
   } = props;
   const target = recommendation?.duration ?? 0;
   const recoveryMode = recommendation?.details?.recoveryMode;
+  const recommendationType = recommendation?.details?.recommendationType;
+  const recoveryModalTitle = (() => {
+    if (!recoveryMode?.active) return "Recovery plan";
+    if (recommendationType === "stabilization_block") return "Recovery rebuild sessions";
+    if (recommendationType === "reduce_duration") return "Recovery support sessions";
+    if (recommendationType === "repeat_current_duration" || recommendationType === "subtle_recovery_mode") return "Recovery reset sessions";
+    return "Recovery sessions active";
+  })();
+  const recoveryModalCopy = recoveryMode?.planCopy
+    || recommendation?.details?.summary
+    || recommendation?.explanation
+    || "We temporarily adjusted session targets to rebuild calm confidence before progression resumes.";
   const [showRecoveryInfo, setShowRecoveryInfo] = useState(false);
 
   return (
@@ -124,7 +136,7 @@ export default function HomeScreen(props) {
           <div className="quick-modal-overlay" role="dialog" aria-modal="true" onClick={() => setShowRecoveryInfo(false)}>
             <div className="quick-modal-card modal-card modal-card--dialog-md recovery-explain-modal" onClick={(e) => e.stopPropagation()}>
               <div className="quick-modal-head">
-                <div className="quick-modal-title">Recovery sessions active</div>
+                <div className="quick-modal-title">{recoveryModalTitle}</div>
                 <ModalCloseButton onClick={() => setShowRecoveryInfo(false)} />
               </div>
               <div className="recovery-explain-steps">
@@ -133,7 +145,7 @@ export default function HomeScreen(props) {
                 ))}
               </div>
               <p className="recovery-explain-copy">
-                {recoveryMode.planCopy}
+                {recoveryModalCopy}
               </p>
               <div className="recovery-explain-meta">
                 <span>{recoveryMode.currentStepLabel || `Step ${Math.max(1, recoveryMode.step)} of ${recoveryMode.totalSessions || 2}`}</span>


### PR DESCRIPTION
### Motivation
- The recovery modal used fixed, subtle-specific wording and didn’t vary by the trigger severity or use the richer `recommendation` context.
- Goal is to surface copy that reflects the actual recommendation details so users see appropriate titles and explanations for different recovery triggers.

### Description
- Derive `recommendationType` from `recommendation.details` and compute `recoveryModalTitle` with branches for `stabilization_block`, `reduce_duration`, `repeat_current_duration`/`subtle_recovery_mode`, and a sensible default in `src/features/home/HomeScreen.jsx`.
- Replace the hardcoded modal title and body with `recoveryModalTitle` and `recoveryModalCopy` respectively so the UI uses `recoveryMode.planCopy` or falls back to `recommendation.details.summary`, `recommendation.explanation`, or a neutral default.
- Keep existing recovery step chips and metadata rendering while only changing header/body text selection logic.

### Testing
- Ran an initial invalid test invocation `npm test -- --runInBand` which failed due to an unsupported Vitest CLI flag (expected CLI error).
- Ran `npm test` and all automated tests passed: 9 test files, 81 tests total (all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded2fcf5c88332bfd6fd6646f1467e)