### PR TITLE
Align recommendation explanations with actual emitted recommendation types

### DIFF
--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -1072,24 +1072,18 @@ function buildCueSessions(patterns = []) {
 
 function describeRecommendationType(type) {
   switch (type) {
+    case "baseline_start":
+      return "With no history yet, PawTimer starts with a short confidence-building target.";
     case "repeat_current_duration":
       return "Recent subtle stress keeps the next target at the current level.";
-    case "reduce_duration":
-      return "Recent active distress triggers a shorter next target.";
-    case "stabilization_block":
-      return "Recent severe distress triggers a deeper step back to stabilize.";
-    case "insert_easy_sessions":
-      return "The plan inserts an easier confidence-building session before pushing higher.";
     case "departure_cues_first":
       return "Pattern-break logs suggest cue practice should come first before stretching duration.";
-    case "subtle_recovery_mode":
-      return "Recent subtle stress triggered two short confidence-recovery sessions before normal progression resumes.";
-    case "subtle_recovery_resume":
-      return "Recovery sessions completed. The next target resumes from the subtle-stress anchor with a 5% step-down.";
     case "recovery_mode_active":
       return "Recovery mode is active: progression is paused and short confidence sessions are required.";
     case "recovery_mode_resume":
-      return "Two calm recovery sessions were completed, so progression resumes at 95% of the anchor.";
+      return "Calm recovery sessions were completed, so progression resumes at a cautious step below the prior anchor.";
+    case "keep_same_duration":
+      return "The next target keeps a steady progression from your recent calm baseline.";
     default:
       return "The next target is adjusted from the current safe-alone estimate.";
   }
@@ -1114,20 +1108,13 @@ function buildRecommendationExplanation({
 
   switch (recommendationType) {
     case "recovery_mode_active":
-    case "subtle_recovery_mode":
       return "Short recovery sessions after stress to rebuild confidence.";
-    case "stabilization_block":
-      return "Reduced after signs of distress to rebuild confidence.";
-    case "reduce_duration":
-      return "Holding shorter sessions due to stress signs.";
-    case "subtle_recovery_resume":
     case "recovery_mode_resume":
       return "Recovery sessions went well, so we are carefully stepping back up.";
     case "departure_cues_first":
       return "Holding duration while cue practice catches up.";
     case "keep_same_duration":
     case "repeat_current_duration":
-    case "insert_easy_sessions":
       if (prev > 0 && next > prev && changePct > 0) {
         return `Increased by ${changePct}% after ${calmLabel}.`;
       }

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -429,6 +429,64 @@ describe("recommendation engine", () => {
 });
 
 describe("public compatibility APIs", () => {
+  it("covers explanations/summaries for every emitted recommendation type", () => {
+    const noHistory = explainNextTarget([], [], [], {});
+    expect(noHistory.recommendationType).toBe("baseline_start");
+
+    const keepSameDuration = explainNextTarget([
+      { date: daysAgo(1), plannedDuration: 70, actualDuration: 70, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(0), plannedDuration: 72, actualDuration: 72, distressLevel: "none", belowThreshold: true },
+    ], [], [], { goalSeconds: 3600 });
+    expect(keepSameDuration.recommendationType).toBe("keep_same_duration");
+
+    const repeatCurrent = explainNextTarget([
+      { date: daysAgo(2), plannedDuration: 300, actualDuration: 260, distressLevel: "none", belowThreshold: false },
+      { date: daysAgo(1), plannedDuration: 300, actualDuration: 250, distressLevel: "none", belowThreshold: false },
+      { date: hoursAgo(2), plannedDuration: 300, actualDuration: 240, distressLevel: "none", belowThreshold: false },
+    ], [], [], { goalSeconds: 3600 });
+    expect(repeatCurrent.recommendationType).toBe("repeat_current_duration");
+
+    const recoveryResume = explainNextTarget([
+      { date: daysAgo(2), plannedDuration: 1200, actualDuration: 1200, distressLevel: "subtle", belowThreshold: false },
+      { date: daysAgo(1), plannedDuration: 60, actualDuration: 60, distressLevel: "none", belowThreshold: true },
+      { date: new Date().toISOString(), plannedDuration: 120, actualDuration: 120, distressLevel: "none", belowThreshold: true },
+    ], [], [], { goalSeconds: 3600 });
+    expect(recoveryResume.recommendationType).toBe("recovery_mode_resume");
+
+    const recoveryActive = explainNextTarget([
+      { date: daysAgo(0), plannedDuration: 600, actualDuration: 220, distressLevel: "active", belowThreshold: false },
+    ], [], [], { goalSeconds: 3600 });
+    expect(recoveryActive.recommendationType).toBe("recovery_mode_active");
+
+    const cueFirst = explainNextTarget([
+      { date: daysAgo(1), plannedDuration: 120, actualDuration: 120, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(0), plannedDuration: 130, actualDuration: 130, distressLevel: "none", belowThreshold: true },
+    ], [], [
+      { date: daysAgo(0), type: "keys", reactionLevel: "active" },
+      { date: daysAgo(0), type: "keys", reactionLevel: "active" },
+      { date: daysAgo(0), type: "keys", reactionLevel: "active" },
+    ], { goalSeconds: 3600 });
+    expect(cueFirst.recommendationType).toBe("departure_cues_first");
+
+    const results = [noHistory, keepSameDuration, repeatCurrent, recoveryActive, recoveryResume, cueFirst];
+    const emittedTypes = new Set(results.map((result) => result.recommendationType));
+    expect(emittedTypes).toEqual(new Set([
+      "baseline_start",
+      "keep_same_duration",
+      "repeat_current_duration",
+      "recovery_mode_active",
+      "recovery_mode_resume",
+      "departure_cues_first",
+    ]));
+
+    results.forEach((result) => {
+      expect(result.explanation).toBeTruthy();
+      expect(result.summary).toBeTruthy();
+      expect(result.explanation).not.toMatch(/Adjusted from recent results/i);
+      expect(result.summary).not.toMatch(/adjusted from the current safe-alone estimate/i);
+    });
+  });
+
   it("suggestNext starts from 80% baseline for new dogs", () => {
     expect(suggestNext([], { currentMaxCalm: 120 })).toBe(96);
   });


### PR DESCRIPTION
### Motivation
- Ensure summary and explanation copy only describe recommendation states the engine can actually emit so UI messaging is accurate.
- Remove unreachable explanation/summary branches that referenced stale `recommendationType` values.
- Add an assertion to guarantee future changes keep explanation coverage aligned with emitted types.

### Description
- Updated `describeRecommendationType` in `src/lib/protocol.js` to remove obsolete cases, add `baseline_start` and `keep_same_duration`, and revise the `recovery_mode_resume` summary for accuracy.
- Simplified `buildRecommendationExplanation` in `src/lib/protocol.js` by removing unreachable branches (stale recovery/stabilization/reduce cases) and consolidating returned explanations to match actual emitted `recommendationType` values.
- Added a test `covers explanations/summaries for every emitted recommendation type` to `tests/protocol.test.js` that exercises `explainNextTarget` scenarios for each currently emitted type and asserts both `explanation` and `summary` are present and not falling back to generic copy.

### Testing
- Ran `npm test -- tests/protocol.test.js` and all tests passed (49 tests, 0 failures).
- Changes were validated against `explainNextTarget` and `buildRecommendation` flows in `src/lib/protocol.js` via the added coverage test in `tests/protocol.test.js`.
- Modified files: `src/lib/protocol.js` and `tests/protocol.test.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded55f774c83328b977a03b15c87b0)