### PR TITLE
Emit structured sync degradation state for compatibility fallbacks and surface in diagnostics

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import { useRegisterSW } from "virtual:pwa-register/react";
 import { PROTOCOL, explainNextTarget, normalizeDistressLevel, suggestNext, suggestNextWithContext } from "./lib/protocol";
 import { sortByDateAsc } from "./lib/activityDateTime";
 import { selectAppData } from "./features/app/selectors";
-import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeById, mergeSessionWithDerivedFields, normalizeFeedings, normalizeSessions, patKey, patLblKey, photoKey, save, sessKey, syncDelete, syncDeleteSessionsForDog, syncFetch, syncPush, syncUpsertDog, toDateTimeLocalValue, walkKey } from "./features/app/storage";
+import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeById, mergeSessionWithDerivedFields, normalizeFeedings, normalizeSessions, patKey, patLblKey, photoKey, save, sessKey, syncDelete, syncDeleteSessionsForDog, syncFetch, syncPush, syncUpsertDog, toDateTimeLocalValue, walkKey } from "./features/app/storage";
 import { fmt, fmtClock, getOutcomeTone, normalizeWalkType, walkTypeLabel } from "./features/app/helpers";
 import { CameraIcon, ChartIcon, HistoryIcon, HomeIcon, PawIcon, SettingsIcon } from "./features/app/ui.jsx";
 import { DogSelect, Onboarding } from "./features/setup/SetupScreens";
@@ -49,6 +49,7 @@ export default function PawTimer() {
   const [syncError, setSyncError] = useState("");
   const [syncDiagRunning, setSyncDiagRunning] = useState(false);
   const [syncDiagResult, setSyncDiagResult] = useState(null);
+  const [syncDegradation, setSyncDegradation] = useState(() => getSyncDegradationState());
   const [notifTime, setNotifTime] = useState(() => load("pawtimer_notif_time", "09:00"));
   const [notifEnabled, setNotifEnabled] = useState(() => load("pawtimer_notif_on", false));
   const [protoWarnAck, setProtoWarnAck] = useState(false);
@@ -282,6 +283,7 @@ export default function PawTimer() {
       if (!entry?.pendingSync || !entry?.id) return true;
       setEntrySyncState(kind, entry.id, SYNC_STATE.SYNCING);
       const { ok, error } = await syncPush(canonicalDogId(activeDogId), kind, entry, dogSettings);
+      setSyncDegradation(getSyncDegradationState());
       if (!live) return ok;
       if (ok) {
         setEntrySyncState(kind, entry.id, SYNC_STATE.SYNCED);
@@ -297,6 +299,7 @@ export default function PawTimer() {
       try {
         setSyncStatus("syncing");
         const { result: remote, error } = await syncFetch(canonicalDogId(activeDogId));
+        setSyncDegradation(getSyncDegradationState());
         if (!live) return;
         if (!remote) { setSyncStatus("err"); setSyncError(error || "Unknown sync fetch error"); return; }
 
@@ -476,6 +479,7 @@ export default function PawTimer() {
     if (isJoin && SYNC_ENABLED) {
       setSyncStatus("syncing");
       const { result: remote, error } = await syncFetch(normalizedId);
+      setSyncDegradation(getSyncDegradationState());
       if (!remote?.dog) { setSyncStatus("err"); setSyncError(error || `No shared dog account found for ${normalizedId}`); showToast(`No shared profile found for ${normalizedId} yet.`); return; }
       const sharedDog = { ...remote.dog, id: normalizedId };
       setDogs((prev) => [...prev.filter((d) => canonicalDogId(d.id) !== normalizedId), sharedDog]);
@@ -539,6 +543,7 @@ export default function PawTimer() {
     setEntrySyncState(kind, data.id, SYNC_STATE.SYNCING);
     setSyncStatus("syncing");
     const { ok, error } = await syncPush(canonicalDogId(activeDogId), kind, data, dogSettings);
+    setSyncDegradation(getSyncDegradationState());
     if (ok) {
       setEntrySyncState(kind, data.id, SYNC_STATE.SYNCED);
       setSyncError("");
@@ -556,6 +561,7 @@ export default function PawTimer() {
     setSyncDiagRunning(true);
     try {
       const report = { checkedAt: new Date().toISOString(), env: { syncEnabled: SYNC_ENABLED, hasUrl: Boolean(SB_URL), hasAnonKey: Boolean(SB_KEY), normalizedUrl: SB_BASE_URL || "(missing)", urlLooksValid: /^https:\/\/[^\s]+\.supabase\.co$/i.test(SB_BASE_URL || "") }, checks: {} };
+      report.checks.syncDegradation = getSyncDegradationState();
       setSyncDiagResult(report);
     } finally { setSyncDiagRunning(false); }
   };
@@ -709,7 +715,7 @@ export default function PawTimer() {
         {tab === "home" && <HomeScreen name={appData.name} sessions={sessions} recommendation={appData.recommendation} goalPct={appData.goalPct} goalSec={appData.goalSec} phase={phase} elapsed={elapsed} finalElapsed={finalElapsed} sessionCompleted={sessionCompleted} sessionOutcome={sessionOutcome} setSessionOutcome={setSessionOutcome} recordResult={recordResult} latencyDraft={latencyDraft} setLatencyDraft={setLatencyDraft} distressTypeDraft={distressTypeDraft} setDistressTypeDraft={setDistressTypeDraft} setPhase={setPhase} setElapsed={setElapsed} setFinalElapsed={setFinalElapsed} startSession={startSession} endSession={endSession} cancelSession={cancelSession} activeProto={appData.activeProto} daily={appData.daily} pattern={appData.pattern} walkPhase={walkPhase} startWalk={startWalk} cancelWalk={cancelWalk} walkElapsed={walkElapsed} endWalk={endWalk} walkPendingDuration={walkPendingDuration} saveWalkWithType={saveWalkWithType} patOpen={patOpen} setPatOpen={setPatOpen} patReminderText={appData.patReminderText} logPattern={logPattern} patLabels={patLabels} patterns={patterns} feedings={feedings} feedingOpen={feedingOpen} openFeedingForm={openFeedingForm} feedingDraft={feedingDraft} setFeedingDraft={setFeedingDraft} cancelFeedingForm={cancelFeedingForm} saveFeeding={saveFeeding} />}
         {tab === "history" && <HistoryScreen timeline={appData.timeline} sessions={sessions} name={appData.name} setTab={setTab} patLabels={patLabels} historyModal={historyModal} setHistoryModal={setHistoryModal} actions={historyActions} />}
         {tab === "progress" && <StatsScreen name={appData.name} totalCount={appData.totalCount} setTab={setTab} bestCalm={appData.bestCalm} recommendation={appData.recommendation} relapseTone={appData.relapseTone} chartData={appData.chartData} goalSec={appData.goalSec} CustomDot={CustomDot} distressLabel={appData.distressLabel} chartTrendLabel={appData.chartTrendLabel} aloneLastWeek={appData.aloneLastWeek} avgWalkDuration={appData.avgWalkDuration} avgSessionsPerDay={appData.avgSessionsPerDay} avgWalksPerDay={appData.avgWalksPerDay} headlineStatus={appData.headlineStatus} headlineStatusTone={appData.headlineStatusTone} />}
-        {tab === "settings" && <SettingsScreen name={appData.name} activeDogId={activeDogId} copyDogId={copyDogId} notifEnabled={notifEnabled} handleToggleNotif={handleToggleNotif} notifTime={notifTime} setNotifTime={setNotifTime} scheduleNotif={scheduleNotif} dogs={dogs} activeProto={appData.activeProto} pattern={appData.pattern} recommendation={appData.recommendation} setTrainingSettingsOpen={setTrainingSettingsOpen} patLabels={patLabels} editingPat={editingPat} setEditingPat={setEditingPat} setPatLabels={setPatLabels} settingsDisclosure={settingsDisclosure} setSettingsDisclosure={setSettingsDisclosure} syncDiagRunning={syncDiagRunning} runSyncDiagnostics={runSyncDiagnostics} SYNC_ENABLED={SYNC_ENABLED} SB_URL={SB_URL} SB_KEY={SB_KEY} SB_BASE_URL={SB_BASE_URL} syncDiagResult={syncDiagResult} syncSummary={syncSummary} trainingSettingsOpen={trainingSettingsOpen} setProtoWarnAck={setProtoWarnAck} protoWarnAck={protoWarnAck} protoOverride={protoOverride} setProtoOverride={setProtoOverride} setScreen={setScreen} setOnboardingState={setOnboardingState} dogsState={dogs} setDogs={setDogs} save={save} ACTIVE_DOG_KEY={ACTIVE_DOG_KEY} setActiveDogId={setActiveDogId} clearDogActivityState={clearDogActivityState} />}
+        {tab === "settings" && <SettingsScreen name={appData.name} activeDogId={activeDogId} copyDogId={copyDogId} notifEnabled={notifEnabled} handleToggleNotif={handleToggleNotif} notifTime={notifTime} setNotifTime={setNotifTime} scheduleNotif={scheduleNotif} dogs={dogs} activeProto={appData.activeProto} pattern={appData.pattern} recommendation={appData.recommendation} setTrainingSettingsOpen={setTrainingSettingsOpen} patLabels={patLabels} editingPat={editingPat} setEditingPat={setEditingPat} setPatLabels={setPatLabels} settingsDisclosure={settingsDisclosure} setSettingsDisclosure={setSettingsDisclosure} syncDiagRunning={syncDiagRunning} runSyncDiagnostics={runSyncDiagnostics} SYNC_ENABLED={SYNC_ENABLED} SB_URL={SB_URL} SB_KEY={SB_KEY} SB_BASE_URL={SB_BASE_URL} syncDiagResult={syncDiagResult} syncSummary={syncSummary} syncDegradation={syncDegradation} trainingSettingsOpen={trainingSettingsOpen} setProtoWarnAck={setProtoWarnAck} protoWarnAck={protoWarnAck} protoOverride={protoOverride} setProtoOverride={setProtoOverride} setScreen={setScreen} setOnboardingState={setOnboardingState} dogsState={dogs} setDogs={setDogs} save={save} ACTIVE_DOG_KEY={ACTIVE_DOG_KEY} setActiveDogId={setActiveDogId} clearDogActivityState={clearDogActivityState} />}
       </div>
 
       <div className="tabs">{[{ id: "home", label: "Train", icon: <HomeIcon /> }, { id: "history", label: "History", icon: <HistoryIcon /> }, { id: "progress", label: "Progress", icon: <ChartIcon /> }, { id: "settings", label: "Settings", icon: <SettingsIcon /> }].map((t) => <button key={t.id} className={`tab-btn ${tab === t.id ? "active" : ""}`} onClick={() => setTab(t.id)}>{t.icon}{t.label}</button>)}</div>

--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -42,6 +42,63 @@ export const logSyncDebug = (...args) => {
   console.info("[pawtimer-sync]", ...args);
 };
 
+const createSyncDegradationState = () => ({
+  isDegraded: false,
+  flags: [],
+  messages: [],
+  events: [],
+});
+
+let syncDegradationState = createSyncDegradationState();
+
+const recordSyncDegradation = ({
+  code,
+  operation,
+  table,
+  field = null,
+  message,
+  severity = "warning",
+}) => {
+  const normalizedCode = String(code || "").trim();
+  const normalizedOperation = String(operation || "").trim();
+  const normalizedTable = String(table || "").trim();
+  const normalizedField = field ? String(field).trim() : null;
+  const normalizedMessage = String(message || "").trim();
+  if (!normalizedCode || !normalizedOperation || !normalizedTable || !normalizedMessage) return;
+
+  const eventKey = [normalizedCode, normalizedOperation, normalizedTable, normalizedField || ""].join("|");
+  const exists = syncDegradationState.events.some((event) => event.key === eventKey);
+  if (exists) return;
+
+  const nextEvent = {
+    key: eventKey,
+    code: normalizedCode,
+    severity,
+    operation: normalizedOperation,
+    table: normalizedTable,
+    field: normalizedField,
+    message: normalizedMessage,
+    recordedAt: new Date().toISOString(),
+  };
+  syncDegradationState = {
+    isDegraded: true,
+    flags: syncDegradationState.flags.includes(normalizedCode)
+      ? syncDegradationState.flags
+      : [...syncDegradationState.flags, normalizedCode],
+    messages: syncDegradationState.messages.includes(normalizedMessage)
+      ? syncDegradationState.messages
+      : [...syncDegradationState.messages, normalizedMessage],
+    events: [...syncDegradationState.events, nextEvent],
+  };
+};
+
+export const getSyncDegradationState = () => ({
+  isDegraded: Boolean(syncDegradationState.isDegraded),
+  flags: [...syncDegradationState.flags],
+  messages: [...syncDegradationState.messages],
+  events: syncDegradationState.events.map((event) => ({ ...event })),
+});
+
 const normalizeSbUrl = (value) => String(value || "").replace(/\/+$/, "").replace(/\/rest\/v1$/i, "");
 export const SB_BASE_URL = normalizeSbUrl(SB_URL);
 
@@ -441,6 +498,12 @@ export const syncFetch = async (dogId) => {
       if (res.ok) return { table, ok: true, res, select, droppedColumns: [], degraded: false };
 
       if (optional && isMissingTableError(res.error)) {
+        recordSyncDegradation({
+          code: "missing_optional_table",
+          operation: "fetch",
+          table,
+          message: `Optional ${table} history could not be fetched because the ${table} table is missing. Sync remains available for other activity.`,
+        });
         logSyncDebug("syncFetch:optionalTableMissing", { table, error: res.error });
         return { table, ok: true, res: { ok: true, data: [], error: null, status: res.status }, select, droppedColumns: [], degraded: true };
       }
@@ -452,6 +515,13 @@ export const syncFetch = async (dogId) => {
       if (nextColumns.length === selectedColumns.length) {
         return { table, ok: false, res, select, droppedColumns: [], degraded: false };
       }
+      recordSyncDegradation({
+        code: "missing_fetch_column",
+        operation: "fetch",
+        table,
+        field: missingColumn,
+        message: `Sync for ${table} is running in compatibility mode because ${table}.${missingColumn} is unavailable. Some fields may be omitted until the schema is updated.`,
+      });
       logSyncDebug("syncFetch:retryWithoutMissingColumn", { table, missingColumn, previousSelect: select });
       selectedColumns = nextColumns;
       attempt += 1;
@@ -547,6 +617,7 @@ export const syncFetch = async (dogId) => {
 
   return {
     error: relatedErrors.length ? `Related data fetch failed (${relatedErrors.join(" | ")})` : null,
+    degradation: getSyncDegradationState(),
     result: {
       dog: matchedDog
         ? {
@@ -665,12 +736,26 @@ export const syncPush = async (dogId, kind, data, dogSettings = null) => {
       const errorText = String(res.error || "");
       const missingColumn = errorText.match(/Could not find the '([^']+)' column/i)?.[1];
       if (missingColumn && missingColumn in sessionPayload) {
+        recordSyncDegradation({
+          code: "missing_push_column",
+          operation: "push",
+          table: "sessions",
+          field: missingColumn,
+          message: `Session sync used compatibility mode and skipped ${missingColumn} because that column is missing on the server.`,
+        });
         delete sessionPayload[missingColumn];
         res = await postRow(sessionPayload);
         continue;
       }
 
       if (/(latency_to_first_distress|distress_type)/i.test(errorText)) {
+        recordSyncDegradation({
+          code: "missing_push_column",
+          operation: "push",
+          table: "sessions",
+          field: "latency_to_first_distress,distress_type",
+          message: "Session sync used compatibility mode and skipped latency/distress-type fields because the server schema is behind.",
+        });
         delete sessionPayload.latency_to_first_distress;
         delete sessionPayload.distress_type;
         res = await postRow(sessionPayload);
@@ -678,6 +763,13 @@ export const syncPush = async (dogId, kind, data, dogSettings = null) => {
       }
 
       if (/distress_severity/i.test(errorText)) {
+        recordSyncDegradation({
+          code: "missing_push_column",
+          operation: "push",
+          table: "sessions",
+          field: "distress_severity",
+          message: "Session sync used compatibility mode and skipped distress severity because the server schema is behind.",
+        });
         delete sessionPayload.distress_severity;
         res = await postRow(sessionPayload);
         continue;

--- a/src/features/settings/SettingsScreen.jsx
+++ b/src/features/settings/SettingsScreen.jsx
@@ -57,6 +57,7 @@ export default function SettingsScreen(props) {
     SB_BASE_URL,
     syncDiagResult,
     syncSummary,
+    syncDegradation,
     recommendation,
     trainingSettingsOpen,
     setProtoWarnAck,
@@ -244,7 +245,13 @@ export default function SettingsScreen(props) {
                 <div className="diag-grid diag-grid--kv">
                   <div className="diag-kv-row"><span>Account sync</span><strong>{SYNC_ENABLED ? "Available" : "Unavailable"}</strong></div>
                   <div className="diag-kv-row"><span>Connection test</span><strong>{syncDiagResult?.checks?.summary?.ok ? "Passing" : "Not run yet"}</strong></div>
+                  <div className="diag-kv-row"><span>Schema compatibility</span><strong>{syncDegradation?.isDegraded ? "Partial sync mode" : "Healthy"}</strong></div>
                 </div>
+                {syncDegradation?.isDegraded && (
+                  <div className="settings-secondary-text" role="status" aria-live="polite">
+                    Sync is working in compatibility mode. Some fields are being skipped until your server schema is updated.
+                  </div>
+                )}
               </div>
               <div className="settings-advanced-group">
                 <button type="button" className="settings-inline-reset-btn t-helper secondary-control secondary-control--inline-text" onClick={() => setDiagDetailsOpen((prev) => !prev)}>{diagDetailsOpen ? "Hide technical details" : "Show technical details"}</button>
@@ -256,7 +263,15 @@ export default function SettingsScreen(props) {
                   <div className="diag-kv-row"><span>VITE_SUPABASE_URL</span><strong>{SB_URL ? "Set" : "Missing"}</strong></div>
                   <div className="diag-kv-row"><span>VITE_SUPABASE_ANON_KEY</span><strong>{SB_KEY ? "Set" : "Missing"}</strong></div>
                   <div className="diag-kv-row diag-kv-row--code"><span>Supabase base URL</span><code>{SB_BASE_URL || "(missing)"}</code></div>
+                  <div className="diag-kv-row"><span>Degradation flags</span><code>{(syncDegradation?.flags || []).join(", ") || "(none)"}</code></div>
                 </div>
+                {syncDegradation?.messages?.length > 0 && (
+                  <ul className="settings-secondary-text">
+                    {syncDegradation.messages.map((message) => (
+                      <li key={message}>{message}</li>
+                    ))}
+                  </ul>
+                )}
               </div>}
               {diagDetailsOpen && syncDiagResult && <div className="settings-advanced-group settings-advanced-group--technical"><div className={`diag-summary ${syncDiagResult.checks?.summary?.ok ? "ok" : "err"}`}>{syncDiagResult.checks?.summary?.ok ? "All checks passed" : "Some checks failed"}</div><pre className="diag-json">{JSON.stringify(syncDiagResult, null, 2)}</pre></div>}
             </div>

--- a/tests/syncFetchRuntime.test.js
+++ b/tests/syncFetchRuntime.test.js
@@ -56,13 +56,17 @@ describe("syncFetch runtime fallbacks", () => {
     });
 
     const { syncFetch } = await setupStorageModule();
-    const { result, error } = await syncFetch("dog1");
+    const { result, error, degradation } = await syncFetch("dog1");
 
     expect(error).toBeNull();
     expect(result.sessions).toHaveLength(1);
     expect(sessionSelectAttempts.length).toBe(2);
     expect(sessionSelectAttempts[0]).toContain("latency_to_first_distress");
     expect(sessionSelectAttempts[1]).not.toContain("latency_to_first_distress");
+    expect(degradation?.isDegraded).toBe(true);
+    expect(degradation?.flags).toContain("missing_fetch_column");
+    expect(degradation?.messages.join(" ")).toMatch(/compatibility mode/i);
+    expect(degradation?.events.some((event) => event.table === "sessions" && event.field === "latency_to_first_distress")).toBe(true);
   });
 
   it("degrades gracefully when optional tables are missing", async () => {


### PR DESCRIPTION
### Motivation
- Preserve existing compatibility fallbacks for missing columns/tables while making those degradations observable and machine-readable so users know when sync is partial.

### Description
- Added a structured degradation tracker and APIs in `src/features/app/storage.js` (`recordSyncDegradation`, `getSyncDegradationState`) to collect `flags`, `messages`, and `events` when fetch/push fallbacks run. 
- Kept retry/compatibility behavior in `syncFetch` and `syncPush` but call `recordSyncDegradation` when optional tables are missing or projected/pushed columns are stripped. The `syncFetch` return value now includes a `degradation` snapshot via `getSyncDegradationState()`.
- Wired degradation state into app diagnostics (`src/App.jsx`) by calling `getSyncDegradationState()` after fetch/push operations and including it in the diagnostics report, and passed `syncDegradation` down to settings.
- Surface partial-sync state in the UI (`src/features/settings/SettingsScreen.jsx`) under Advanced diagnostics with a `Schema compatibility` status row, explanatory text, and technical details showing `Degradation flags` and messages.
- Extended `tests/syncFetchRuntime.test.js` to assert that a missing-column retry emits the degradation state (flags/messages/events) while preserving the existing retry behavior.

### Testing
- Added and ran the modified runtime test file: `npm test -- tests/syncFetchRuntime.test.js`, which passed (all tests green).
- Verified the existing fallback behavior still retries and returns activity when columns/tables are missing while also producing `degradation` metadata as asserted by the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded57fab0083329aea786ba626566c)