### PR TITLE
Unify recovery state machine and remove legacy subtle helper

### DIFF
--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -319,87 +319,6 @@ function computeSafeAloneTime(sessions = []) {
   return Math.max(PROTOCOL.minDurationSeconds, Math.round(weighted / Math.max(weight, 0.01)));
 }
 
-function getSubtleRecoveryContext(trainingSessions = []) {
-  const base = {
-    active: false,
-    remainingSessions: 0,
-    subtleIndex: -1,
-    completedRecoveryEndIndex: -1,
-    recoveryStep: 0,
-    nextRecoveryDuration: PROTOCOL.subtleRecoveryDurationSeconds,
-    anchorDuration: null,
-    postRecoveryDuration: null,
-    justCompleted: false,
-  };
-  if (!trainingSessions.length) return base;
-
-  let subtleIndex = -1;
-  for (let i = trainingSessions.length - 1; i >= 0; i -= 1) {
-    if (trainingSessions[i].distressLevel === DISTRESS_LEVELS.SUBTLE) {
-      subtleIndex = i;
-      break;
-    }
-  }
-  if (subtleIndex < 0) return base;
-
-  const subtle = trainingSessions[subtleIndex];
-  const nowTime = Date.now();
-  const subtleTime = toTimestamp(subtle?.date);
-  const anchorIsRecent = Number.isFinite(subtleTime)
-    && (nowTime - subtleTime) <= (PROTOCOL.subtleRecoveryAnchorMaxAgeDays * DAY_MS);
-
-  let trailingCalmAfterSubtle = 0;
-  for (let i = trainingSessions.length - 1; i > subtleIndex; i -= 1) {
-    if (trainingSessions[i].distressLevel !== DISTRESS_LEVELS.NONE) break;
-    trailingCalmAfterSubtle += 1;
-  }
-  const anchorHasCalmClosure = trailingCalmAfterSubtle >= PROTOCOL.subtleRecoveryAnchorClosureCalmSessions;
-  const anchorStillValid = anchorIsRecent && !anchorHasCalmClosure;
-  if (!anchorStillValid) return base;
-
-  const anchorDuration = Math.max(
-    PROTOCOL.minDurationSeconds,
-    Number(subtle?.actualDuration) > 0 ? Number(subtle.actualDuration) : Number(subtle?.plannedDuration || PROTOCOL.minDurationSeconds),
-  );
-  const after = trainingSessions.slice(subtleIndex + 1);
-  let step = 0; // 0 => next is 60s, 1 => next is 120s, 2 => complete
-  let completedRecoveryEndIndex = -1;
-
-  for (let offset = 0; offset < after.length; offset += 1) {
-    const session = after[offset];
-    const calm = session.distressLevel === DISTRESS_LEVELS.NONE;
-    if (!calm) {
-      step = 0; // restart sequence after any non-calm recovery attempt
-      continue;
-    }
-    if (step === 0) {
-      step = 1;
-      continue;
-    }
-    step = 2;
-    completedRecoveryEndIndex = subtleIndex + 1 + offset;
-    break;
-  }
-
-  const completed = step >= 2;
-  const justCompleted = completed && completedRecoveryEndIndex === (trainingSessions.length - 1);
-  const remainingSessions = completed ? 0 : Math.max(0, PROTOCOL.subtleRecoverySessionCount - step);
-
-  return {
-    active: !completed,
-    remainingSessions,
-    subtleIndex,
-    completedRecoveryEndIndex,
-    recoveryStep: Math.min(step + 1, PROTOCOL.subtleRecoverySessionCount),
-    nextRecoveryDuration: step === 0
-      ? PROTOCOL.subtleRecoveryDurationSeconds
-      : (PROTOCOL.subtleRecoveryDurationSeconds * 2),
-    anchorDuration,
-    postRecoveryDuration: Math.max(PROTOCOL.minDurationSeconds, Math.round(anchorDuration * 0.95)),
-    justCompleted,
-  };
-}
-
 function hasPriorStressEvent(sessions = []) {
   return sessions.some((session) => {
     const level = normalizeDistressLevel(session?.distressLevel);
@@ -797,6 +716,18 @@ function evaluatePersistentRecoveryMode(
     recentWindow = [],
   } = {},
 ) {
+  /**
+   * Recovery state machine (single source of truth):
+   *
+   * 1) Entry: resolveRecoveryState() activates recovery on latest subtle/active/severe trigger
+   *    unless there is already a persisted active state.
+   * 2) While active: this function recommends fixed short sessions (60s -> 120s, with a
+   *    severe extension) and tracks consecutive calm sessions after the trigger.
+   * 3) Exit: when required calm sessions are completed, we emit recovery_mode_resume and
+   *    persist active:false so normal progression can resume.
+   *
+   * Important: subtle recovery uses this same machine (no parallel/legacy subtle-only flow).
+   */
   // Policy decision: for subtle-trigger recovery, count any calm session toward completion.
   // We still keep duration-bound checks for active/severe triggers.
   const subtleRecoveryAcceptsAnyCalmSession = true;

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -426,6 +426,29 @@ describe("recommendation engine", () => {
     expect(twoCalm.recoveryState?.active).toBe(false);
     expect(twoCalm.recommendedDuration).toBe(375);
   });
+
+  it("uses the same persisted recovery state machine for subtle-trigger recovery", () => {
+    const subtleStress = [{ id: "subtle-1", date: daysAgo(2), plannedDuration: 1200, actualDuration: 1100, distressLevel: "subtle", belowThreshold: false }];
+    const start = buildRecommendation(subtleStress, { goalSeconds: 3600 });
+    expect(start.recommendationType).toBe("recovery_mode_active");
+    expect(start.recoveryState?.active).toBe(true);
+
+    const oneCalm = buildRecommendation([
+      ...subtleStress,
+      { id: "subtle-2", date: daysAgo(1), plannedDuration: 600, actualDuration: 600, distressLevel: "none", belowThreshold: true },
+    ], { goalSeconds: 3600, recoveryState: start.recoveryState });
+    expect(oneCalm.recommendationType).toBe("recovery_mode_active");
+    expect(oneCalm.recoveryMode.remainingSessions).toBe(1);
+    expect(oneCalm.recoveryState?.active).toBe(true);
+
+    const twoCalm = buildRecommendation([
+      ...subtleStress,
+      { id: "subtle-2", date: daysAgo(1), plannedDuration: 600, actualDuration: 600, distressLevel: "none", belowThreshold: true },
+      { id: "subtle-3", date: daysAgo(0), plannedDuration: 700, actualDuration: 700, distressLevel: "none", belowThreshold: true },
+    ], { goalSeconds: 3600, recoveryState: oneCalm.recoveryState });
+    expect(twoCalm.recommendationType).toBe("recovery_mode_resume");
+    expect(twoCalm.recoveryState?.active).toBe(false);
+  });
 });
 
 describe("public compatibility APIs", () => {


### PR DESCRIPTION
### Motivation
- Eliminate a dual subtle-recovery implementation path and make recovery decisions flow through a single persisted state machine to avoid inconsistent behaviour.
- Make the recovery flow explicit in-code so callers and future maintainers rely on one documented mechanism.

### Description
- Removed the unused legacy helper `getSubtleRecoveryContext` from `src/lib/protocol.js` so subtle-trigger logic no longer exists in a parallel path.
- Added an in-code documentation block to `evaluatePersistentRecoveryMode` describing the single recovery state machine (`resolveRecoveryState` → `evaluatePersistentRecoveryMode` → decision output) and that subtle recovery uses this same flow.
- Added a regression test to `tests/protocol.test.js` that verifies a subtle-triggered recovery uses the persisted `recoveryState` and transitions from `recovery_mode_active` to `recovery_mode_resume` after the required calm sessions.

### Testing
- Ran `npm test -- tests/protocol.test.js` and all tests passed (50 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded73c1b388332b9d14bf43ca68b55)