### PR TITLE
Update Help & README to reflect current recommendation states and recovery flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,17 +150,46 @@ This app is based on the gradual desensitisation method for separation anxiety:
 
 PawTimer uses the progression engine in `src/lib/protocol.js` as the source of truth.
 
-1. **First session starts conservatively** — with no history yet, the app starts at about **80% of the dog's current calm-alone estimate** from onboarding, with a 30-second minimum.
-2. **Safe-alone time is recalculated from recent calm sessions** — calm sessions are weighted by recency and confidence so newer successful reps matter most.
-3. **All-calm streaks unlock the clearest increase** — when the latest 5 training sessions are fully calm, the next target is usually **+15%** from the latest calm duration.
-4. **Distress slows or reverses progression**:
-   - **Subtle stress** → usually repeat the same duration.
-   - **Active distress** → shorten the next target by about **25%**.
-   - **Severe distress / panic** → move into a deeper stabilization step at about **60%** of the safe-alone estimate.
-5. **Risk management can insert easier sessions** — higher relapse risk or regular “easy session” checkpoints can temporarily drop the target to **80%** of the safe-alone estimate instead of pushing forward.
-6. **Context can trim the target further** — if recent walks are mostly intense and stability is still low, the final recommendation can be reduced by another **5%**.
+### Current emitted recommendation states
 
-In short: the next target is based on the current safe-alone estimate, recent calm streaks, distress severity, relapse risk, and a small amount of walk/cue context — not on one fixed step rule every time.
+The app currently emits these recommendation types:
+
+- `baseline_start`
+- `keep_same_duration`
+- `repeat_current_duration`
+- `departure_cues_first`
+- `recovery_mode_active`
+- `recovery_mode_resume`
+
+### How those states are decided
+
+1. **`baseline_start` (no training history)**  
+   The first target starts conservatively (about 80% of current calm-alone estimate, minimum 30 seconds).
+
+2. **`recovery_mode_active` (after subtle/active/severe distress trigger)**  
+   Recovery becomes the first-priority branch and pauses normal progression.  
+   - Typical fixed recovery steps are **60s → 120s**.  
+   - Severe triggers can extend to **60s → 120s → 120s**.  
+   - For subtle-trigger recovery, **any calm follow-up session length counts** toward completion.
+
+3. **`recovery_mode_resume` (recovery completed)**  
+   After the required calm recovery sessions, the app emits a cautious resume recommendation once, then returns to normal progression logic.
+
+4. **`repeat_current_duration` (instability hold)**  
+   If recent sessions are unstable, the next target holds around the latest reference duration (with possible gap-based trimming).
+
+5. **`keep_same_duration` (steady progression path)**  
+   Outside recovery/instability states, targets follow the recent calm baseline with bounded step changes and smoothing.
+
+6. **`departure_cues_first` (cue sensitivity override)**  
+   When cue/pattern data suggests strong trigger sensitivity, recommendation type is relabeled to prioritize cue practice before duration expansion.
+
+### Additional context adjustments
+
+- **Walk context trim:** when recent walks are mostly intense and stability is low, the final recommended duration can be trimmed by ~5%.
+- **Risk/stability signals:** safe-alone estimate, calm streak, stability score, and relapse risk are always included in the explanation factors.
+
+In short: progression is state-driven, with recovery state machine decisions taking precedence over normal duration growth.
 
 ---
 

--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -57,9 +57,7 @@ export default function HomeScreen(props) {
   const recommendationType = recommendation?.details?.recommendationType;
   const recoveryModalTitle = (() => {
     if (!recoveryMode?.active) return "Recovery plan";
-    if (recommendationType === "stabilization_block") return "Recovery rebuild sessions";
-    if (recommendationType === "reduce_duration") return "Recovery support sessions";
-    if (recommendationType === "repeat_current_duration" || recommendationType === "subtle_recovery_mode") return "Recovery reset sessions";
+    if (recommendationType === "recovery_mode_active") return "Recovery reset sessions";
     return "Recovery sessions active";
   })();
   const recoveryModalCopy = recoveryMode?.planCopy

--- a/src/features/settings/SettingsScreen.jsx
+++ b/src/features/settings/SettingsScreen.jsx
@@ -75,6 +75,8 @@ export default function SettingsScreen(props) {
   } = props;
 
   const reminderSummary = notifEnabled ? `On · ${notifTime}` : "Off";
+  const recommendationType = recommendation?.details?.recommendationType || "baseline_start";
+  const recommendationSummary = recommendation?.details?.summary || recommendation?.explanation;
 
   return (
     <>
@@ -218,8 +220,9 @@ export default function SettingsScreen(props) {
             <div className="settings-modal-stack">
               <div className="proto-section u-mt-none"><div className="proto-title">Sync devices</div><div className="proto-row">Share your Dog ID, then join with the same ID on the other device.</div></div>
               <div className="proto-section"><div className="proto-title">Session flow</div><div className="proto-row">Start a session, return before distress escalates, then rate how {name} did.</div></div>
-              <div className="proto-section"><div className="proto-title">Next target</div><div className="proto-row">{recommendation?.explanation} It currently weighs {(recommendation?.details?.factors || []).join(" ")}</div></div>
-              <div className="proto-section"><div className="proto-title">Subtle recovery</div><div className="proto-row">After a subtle-distress trigger, any calm follow-up session counts toward recovery completion, even if the duration is longer than the suggested step.</div></div>
+              <div className="proto-section"><div className="proto-title">Current recommendation state</div><div className="proto-row">Now: <strong>{recommendationType}</strong>. {recommendationSummary} It currently weighs {(recommendation?.details?.factors || []).join(" ")}</div></div>
+              <div className="proto-section"><div className="proto-title">Recommendation states emitted</div><div className="proto-row">baseline_start, keep_same_duration, repeat_current_duration, departure_cues_first, recovery_mode_active, recovery_mode_resume.</div></div>
+              <div className="proto-section"><div className="proto-title">Recovery behavior</div><div className="proto-row">Any subtle/active/severe distress can activate recovery. While recovery_mode_active, targets use short fixed steps (typically 60s then 120s; severe can add a third 120s step). Subtle recovery accepts any calm follow-up duration; active/severe count calm sessions at short recovery lengths. After enough calm sessions, recovery_mode_resume emits once, then normal progression continues.</div></div>
               <div className="proto-section"><div className="proto-title">Daily rhythm</div><div className="proto-row">Aim for up to {activeProto.sessionsPerDayMax} sessions, {activeProto.maxDailyAloneMinutes} min/day, and {pattern.recMin}–{pattern.recMax} pattern breaks.</div></div>
             </div>
           </div>


### PR DESCRIPTION
### Motivation

- Ensure in-app Help and README accurately describe the recommendation states emitted by the progression engine and the app's recovery/resume behavior.  
- Remove or replace references to inactive recommendation-type labels so UI text matches runtime decision logic.  
- Provide clearer documentation for users and maintainers about how recovery mode is triggered and how calm sessions count toward recovery.

### Description

- In `src/features/settings/SettingsScreen.jsx` added display of the current `recommendationType`, a summary explanation, an enumerated list of currently emitted recommendation states, and a concise explanation of recovery behavior and acceptance rules.  
- In `src/features/home/HomeScreen.jsx` simplified recovery modal title mapping to avoid references to inactive recommendation-type strings and map active recovery to `recovery_mode_active` with a sensible fallback.  
- Rewrote the README `Progression logic` section to list the emitted recommendation states (`baseline_start`, `keep_same_duration`, `repeat_current_duration`, `departure_cues_first`, `recovery_mode_active`, `recovery_mode_resume`) and document the recovery state machine and context-based adjustments.

### Testing

- Ran a production build with `npm run build`, which completed successfully (build artifacts generated).  
- Verified repository state with `git status` and committed the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded7ec81c0833283c9ea0e2064ab5f)