### PR TITLE
Integrate relapse-risk multiplier into computeNextTarget and add deterministic tests

### DIFF
--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -913,7 +913,8 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
   }
 
   const stepped = computeProgressiveIncrease(anchorDuration, calmStreak);
-  let smoothed = clampRateChange(stepped, lastReferenceDuration);
+  const riskAdjustedStep = Math.round(stepped * getStepMultiplier(relapseRisk));
+  let smoothed = clampRateChange(riskAdjustedStep, lastReferenceDuration);
 
   if (hasConsecutivePostSubtleIncrease(recentWindow) && smoothed > lastReferenceDuration) {
     smoothed = lastReferenceDuration;
@@ -938,17 +939,10 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
   };
 }
 
-function getStepMultiplier(stats, latestSessions = [], allSessions = []) {
-  const calmStreak = countStreak(latestSessions, (s) => s.belowThreshold);
-
-  if (stats.relapseRisk >= 0.72) return -0.25;
-  if (!hasPriorStressEvent(allSessions) && calmStreak >= 1) return 0.2;
-  if (calmStreak >= 4 && stats.stabilityScore >= PROTOCOL.largeStepStabilityGate && stats.subtleDistressRate <= 0.15) {
-    return 0.2;
-  }
-  if (calmStreak >= 2 && stats.stabilityScore >= 0.62) return 0.08;
-  if (stats.subtleDistressRate > 0.25) return 0;
-  return 0.03;
+function getStepMultiplier(relapseRisk = 0) {
+  if (relapseRisk >= 0.72) return 0.85;
+  if (relapseRisk >= 0.58) return 0.95;
+  return 1;
 }
 
 export function buildRecommendation(sessions = [], options = {}) {

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -3,6 +3,7 @@ import {
   PROTOCOL,
   calculateTrainingStats,
   buildRecommendation,
+  computeNextTarget,
   explainNextTarget,
   mapLegacySession,
   suggestNext,
@@ -215,6 +216,22 @@ describe("recommendation engine", () => {
     ];
     const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
     expect(rec.recommendedDuration).toBe(630);
+  });
+
+  it("applies deterministic high/medium/low risk step multipliers in computeNextTarget", () => {
+    const sessions = [
+      { date: hoursAgo(1), plannedDuration: 300, actualDuration: 300, distressLevel: "none", belowThreshold: true },
+    ];
+
+    const highRisk = computeNextTarget(sessions, { goalSeconds: 3600, relapseRisk: 0.8 });
+    const mediumRisk = computeNextTarget(sessions, { goalSeconds: 3600, relapseRisk: 0.6 });
+    const lowRisk = computeNextTarget(sessions, { goalSeconds: 3600, relapseRisk: 0.2 });
+
+    expect(highRisk.recommendedDuration).toBe(291);
+    expect(mediumRisk.recommendedDuration).toBe(325);
+    expect(lowRisk.recommendedDuration).toBe(342);
+    expect(highRisk.recommendedDuration).toBeLessThan(mediumRisk.recommendedDuration);
+    expect(mediumRisk.recommendedDuration).toBeLessThan(lowRisk.recommendedDuration);
   });
 
   it("does not chain more than one consecutive increase after subtle stress", () => {


### PR DESCRIPTION
### Motivation
- Make progression adjustments explicitly risk-aware by integrating the step multiplier into the next-target calculation rather than keeping an isolated, loosely-used multiplier function. 
- Simplify and make deterministic the multiplier behavior so risk tiers directly and predictably influence computed steps. 

### Description
- Apply a relapse-risk multiplier to the progressive step inside `computeNextTarget` (multiply `computeProgressiveIncrease` by `getStepMultiplier(relapseRisk)` before `clampRateChange`).
- Replace the previous multi-argument `getStepMultiplier(stats, latestSessions, allSessions)` heuristic with a simpler deterministic tier function `getStepMultiplier(relapseRisk)` returning `0.85` for high (>=0.72), `0.95` for medium (>=0.58), and `1.0` for low (<0.58) risk.
- Remove the old calm-streak / stability-based branching from the multiplier and fold risk-adjustment into the progression path so smoothing and gap reductions still apply normally.
- Add a unit test that calls `computeNextTarget` for high/medium/low relapse-risk inputs and asserts deterministic recommended-duration values and ordering.

### Testing
- Ran the protocol tests with `npm test -- tests/protocol.test.js` and all tests passed (51/51).
- Added and executed the new deterministic test `applies deterministic high/medium/low risk step multipliers in computeNextTarget`, which succeeded.
- Existing recommendation engine tests were run and remain green after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded851dc8c8332ac92ca76e3cde256)