### PR TITLE
Fix PT-LOGIC-001: unify recommendation derivation to prevent duration/details drift

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -163,24 +163,43 @@ export default function PawTimer() {
     () => dogs.find((d) => canonicalDogId(d.id) === canonicalDogId(activeDogId)) ?? null,
     [activeDogId, dogs],
   );
-  const recommendation = useMemo(() => {
-    const sortedSessions = sortByDateAsc(sessions);
-    const nextTargetInfo = explainNextTarget(sortedSessions, walks, patterns, activeDog || {});
+  const deriveRecommendation = useCallback((nextSessions, nextWalks = walks, nextPatterns = patterns, nextDog = activeDog || {}) => {
+    const details = explainNextTarget(nextSessions, nextWalks, nextPatterns, nextDog || {});
+    const recommendedDuration = details?.recommendedDuration
+      ?? (suggestNextWithContext(nextSessions, nextWalks, nextPatterns, nextDog) ?? suggestNext(nextSessions, nextDog));
     return {
-      duration: target,
-      decisionState: nextTargetInfo?.decisionState ?? null,
-      explanation: nextTargetInfo?.summary ?? "",
-      details: nextTargetInfo,
+      duration: recommendedDuration,
+      decisionState: details?.decisionState ?? null,
+      explanation: details?.summary ?? "",
+      details: details ?? {},
     };
-  }, [activeDog, patterns, sessions, target, walks]);
-  const sortedSessions = useMemo(() => sortByDateAsc(sessions), [sessions]);
-  const appData = selectAppData({ dogs, activeDogId, sessions: sortedSessions, walks, patterns, feedings, target, protoOverride, recommendation });
+  }, [activeDog, patterns, walks]);
 
-  const recomputeTarget = useCallback((nextSessions, nextWalks = walks, nextPatterns = patterns, nextDog = appData.dog) => {
-    const nextTarget = suggestNextWithContext(nextSessions, nextWalks, nextPatterns, nextDog) ?? suggestNext(nextSessions, nextDog);
+  const sortedSessions = useMemo(() => sortByDateAsc(sessions), [sessions]);
+  const recommendation = useMemo(() => {
+    return deriveRecommendation(sortedSessions, walks, patterns, activeDog || {});
+  }, [activeDog, deriveRecommendation, patterns, sortedSessions, walks]);
+  const appData = selectAppData({
+    dogs,
+    activeDogId,
+    sessions: sortedSessions,
+    walks,
+    patterns,
+    feedings,
+    target: recommendation.duration,
+    protoOverride,
+    recommendation,
+  });
+
+  const recomputeTarget = useCallback((nextSessions, nextWalks = walks, nextPatterns = patterns, nextDog = activeDog || {}) => {
+    const nextTarget = deriveRecommendation(nextSessions, nextWalks, nextPatterns, nextDog).duration;
     setTarget(nextTarget);
     return nextTarget;
-  }, [appData.dog, patterns, walks]);
+  }, [activeDog, deriveRecommendation, patterns, walks]);
+
+  useEffect(() => {
+    setTarget((prev) => (prev === recommendation.duration ? prev : recommendation.duration));
+  }, [recommendation.duration]);
 
   const commitSessions = useCallback((updater) => {
     let committed = [];
@@ -200,18 +219,20 @@ export default function PawTimer() {
       const resolved = typeof updater === "function" ? updater(prev) : updater;
       const normalized = sortByDateAsc(ensureArray(resolved).map((item) => ({ ...withHydratedSyncState(item), type: normalizeWalkType(item?.type) })));
       if (activeDogId) save(walkKey(activeDogId), normalized);
+      recomputeTarget(sessions, normalized, patterns, activeDog || {});
       return normalized;
     });
-  }, [activeDogId, withHydratedSyncState]);
+  }, [activeDog, activeDogId, patterns, recomputeTarget, sessions, withHydratedSyncState]);
 
   const commitPatterns = useCallback((updater) => {
     setPatterns((prev) => {
       const resolved = typeof updater === "function" ? updater(prev) : updater;
       const normalized = sortByDateAsc(ensureArray(resolved).map(withHydratedSyncState));
       if (activeDogId) save(patKey(activeDogId), normalized);
+      recomputeTarget(sessions, walks, normalized, activeDog || {});
       return normalized;
     });
-  }, [activeDogId, withHydratedSyncState]);
+  }, [activeDog, activeDogId, recomputeTarget, sessions, walks, withHydratedSyncState]);
 
   const commitFeedings = useCallback((updater) => {
     setFeedings((prev) => {
@@ -264,9 +285,9 @@ export default function PawTimer() {
     setFeedings(hydratedFeedings);
     setPatLabels(local.patLabels);
     setDogPhoto(local.photo);
-    setTarget(suggestNextWithContext(hydratedSessions, hydratedWalks, hydratedPatterns, dog) ?? suggestNext(hydratedSessions, dog));
+    recomputeTarget(hydratedSessions, hydratedWalks, hydratedPatterns, dog);
     setScreen("app");
-  }, [activeDogId, dogs, withHydratedSyncState]);
+  }, [activeDogId, dogs, recomputeTarget, withHydratedSyncState]);
 
   useEffect(() => {
     const savedId = load(ACTIVE_DOG_KEY, null);
@@ -344,7 +365,7 @@ export default function PawTimer() {
         }
 
         const syncDog = remoteDog ?? currentDog;
-        setTarget(suggestNextWithContext(mergedSessions, mergedWalks, mergedPatterns, syncDog) ?? suggestNext(mergedSessions, syncDog));
+        recomputeTarget(mergedSessions, mergedWalks, mergedPatterns, syncDog);
         if (!allPendingFlushed) {
           setSyncError("Some local changes are still waiting for confirmation.");
           setSyncStatus("err");
@@ -360,7 +381,7 @@ export default function PawTimer() {
     sync();
     const timer = setInterval(sync, 15_000);
     return () => { live = false; syncInFlightRef.current = false; clearInterval(timer); };
-  }, [activeDogId, commitFeedings, commitPatterns, commitSessions, commitWalks, mergeSyncedCollection, setEntrySyncState]);
+  }, [activeDogId, commitFeedings, commitPatterns, commitSessions, commitWalks, mergeSyncedCollection, recomputeTarget, setEntrySyncState]);
 
   useEffect(() => {
     if (!SYNC_ENABLED || !activeDogId) return;
@@ -588,9 +609,9 @@ export default function PawTimer() {
     const session = stampLocalEntry(rawSession);
     const updated = commitSessions((prev) => [...prev, session]);
     pushWithSyncStatus("session", session).then(({ ok, error }) => { if (!ok) showToast(`Sync failed: ${error}`); });
-    const nextTarget = explainNextTarget(updated, walks, patterns, dog);
-    persistRecoveryState(nextTarget?.recoveryState ?? null);
-    const next = nextTarget?.recommendedDuration ?? (suggestNextWithContext(updated, walks, patterns, dog) ?? suggestNext(updated, dog));
+    const nextRecommendation = deriveRecommendation(updated, walks, patterns, dog);
+    persistRecoveryState(nextRecommendation?.details?.recoveryState ?? null);
+    const next = nextRecommendation.duration;
     cancelSession();
     const n = dog?.dogName ?? "your dog";
     if (distressLevel === "none") showToast(`${n} was calm. Next: ${fmt(next)}`);
@@ -627,7 +648,7 @@ export default function PawTimer() {
   const copyDogId = () => { navigator.clipboard?.writeText(activeDogId).catch(() => {}); showToast(`ID copied: ${activeDogId}`); };
   const handlePhotoUpload = (e) => { const file = e.target.files?.[0]; if (!file) return; const reader = new FileReader(); reader.onload = (ev) => setDogPhoto(ev.target.result); reader.readAsDataURL(file); };
 
-  const historyActions = useHistoryEditing({ sessions, walks, patterns, feedings, patLabels, showToast, pushWithSyncStatus, syncDelete, syncDeleteSessionsForDog, commitSessions, setWalks: commitWalks, setPatterns: commitPatterns, setFeedings: commitFeedings, recomputeTarget, activeDogId, stampLocalEntry });
+  const historyActions = useHistoryEditing({ sessions, walks, patterns, feedings, patLabels, showToast, pushWithSyncStatus, syncDelete, syncDeleteSessionsForDog, commitSessions, setWalks: commitWalks, setPatterns: commitPatterns, setFeedings: commitFeedings, activeDogId, stampLocalEntry });
 
   const syncSummary = useMemo(() => {
     const allEntries = [...sessions, ...walks, ...patterns, ...feedings];

--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -61,7 +61,6 @@ export function useHistoryEditing({
   setWalks,
   setPatterns,
   setFeedings,
-  recomputeTarget,
   activeDogId,
   stampLocalEntry,
 }) {
@@ -172,14 +171,12 @@ export function useHistoryEditing({
         syncDelete("walk", historyModal.id).then((ok) => {
           if (!ok) showToast("Walk removed locally — remote delete failed");
         });
-        recomputeTarget(sessions, nextWalks, patterns);
       } else if (historyModal.kind === "pattern") {
         const nextPatterns = patterns.filter((item) => item.id !== historyModal.id);
         setPatterns(nextPatterns);
         syncDelete("pattern", historyModal.id).then((ok) => {
           if (!ok) showToast("Pattern break removed locally — remote delete failed");
         });
-        recomputeTarget(sessions, walks, nextPatterns);
       } else if (historyModal.kind === "feeding") {
         setFeedings((prev) => prev.filter((item) => item.id !== historyModal.id));
         syncDelete("feeding", historyModal.id).then((ok) => {

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -671,4 +671,35 @@ describe("public compatibility APIs", () => {
     expect(next.explanation).toBeTruthy();
     expect(next.explanation).toMatch(/Starting with a short first session/i);
   });
+
+  it("keeps recommendation duration and details aligned when walk/pattern context changes without session changes", () => {
+    const sessions = [
+      { date: hoursAgo(30), plannedDuration: 1200, actualDuration: 1200, distressLevel: "none", belowThreshold: true },
+      { date: hoursAgo(24), plannedDuration: 1380, actualDuration: 1380, distressLevel: "none", belowThreshold: true },
+      { date: hoursAgo(8), plannedDuration: 1380, actualDuration: 420, distressLevel: "active", belowThreshold: false },
+    ];
+    const patterns = [{ id: "p-1", date: hoursAgo(7), type: "keys" }];
+    const baseWalks = [{ id: "w-1", date: hoursAgo(7), duration: 1800, type: "regular_walk" }];
+    const dog = { goalSeconds: 3600 };
+
+    const withTrainingWalk = [...baseWalks, { id: "w-2", date: hoursAgo(2), duration: 900, type: "training_walk" }];
+    const editedPattern = [{ ...patterns[0], type: "jacket" }];
+    const deletedWalks = [];
+    const deletedPatterns = [];
+    const scenarios = [
+      { walks: withTrainingWalk, pats: patterns }, // add walk
+      { walks: [{ ...withTrainingWalk[0], duration: 1200 }, withTrainingWalk[1]], pats: patterns }, // edit walk
+      { walks: deletedWalks, pats: patterns }, // delete walk
+      { walks: baseWalks, pats: [...patterns, { id: "p-2", date: hoursAgo(1), type: "shoes" }] }, // add pattern
+      { walks: baseWalks, pats: editedPattern }, // edit pattern
+      { walks: baseWalks, pats: deletedPatterns }, // delete pattern
+    ];
+
+    scenarios.forEach(({ walks, pats }) => {
+      const explained = explainNextTarget(sessions, walks, pats, dog);
+      const suggested = suggestNextWithContext(sessions, walks, pats, dog);
+      expect(explained.recommendedDuration).toBe(suggested);
+      expect(explained.decisionState.targetSeconds).toBe(explained.recommendedDuration);
+    });
+  });
 });


### PR DESCRIPTION
### Motivation
- The app previously kept the displayed recommendation duration in a stateful `target` while recomputing recommendation `details` from `explainNextTarget(...)`, which allowed the duration and rationale to diverge when walks or patterns changed.
- The change aims to make recommendation output deterministic by ensuring both duration and explanation are derived from the same, current logic state whenever sessions, walks, or patterns mutate.

### Description
- Add a single canonical derivation function `deriveRecommendation(...)` in `src/App.jsx` that builds `duration`, `decisionState`, `explanation`, and `details` from `explainNextTarget(...)` and fallback suggestion logic. 
- Make app-level `recommendation` and the `appData` `target` consistently come from the canonical derived recommendation (`recommendation.duration`) instead of an independently-stored `target`. 
- Ensure `commitWalks` and `commitPatterns` call the unified `recomputeTarget(...)` (which uses `deriveRecommendation`) so walk/pattern add/edit/delete always refresh the canonical recommendation; align `recordResult(...)` to reuse the same derivation. 
- Remove redundant manual recompute calls from history delete flows and update `useHistoryEditing` usage so recompute responsibility is centralized; add a new protocol test that exercises walk/pattern add/edit/delete scenarios to assert duration/details alignment. 

### Testing
- Ran the full test suite with `npm test` and all tests passed: `10 files, 91 tests` (no failures). 
- Added `tests/protocol.test.js` coverage asserting that `explainNextTarget(...).recommendedDuration` matches `suggestNextWithContext(...)` and that `decisionState.targetSeconds` equals the recommended duration across walk/pattern add/edit/delete scenarios. 
- Verified runtime behavior paths updated: session commit, sync hydration, sync merge and history editing flows now use the unified recommendation pipeline and keep duration/details in sync.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df526b7b088332967bdd5c0ada0ff4)