### PR TITLE
Fix PT-LOGIC-002: reconcile and persist recoveryState across history mutations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,11 @@ const SYNC_STATE = {
   SYNCED: "synced",
   ERROR: "error",
 };
+
+function recoveryStateEqual(a, b) {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+
 export default function PawTimer() {
   const [dogs, setDogs] = useState(() => ensureArray(load(DOGS_KEY, [])));
   const [activeDogId, setActiveDogId] = useState(() => canonicalDogId(load(ACTIVE_DOG_KEY, null)));
@@ -587,15 +592,6 @@ export default function PawTimer() {
     } finally { setSyncDiagRunning(false); }
   };
 
-  const persistRecoveryState = useCallback((nextRecoveryState) => {
-    if (!activeDogId) return;
-    setDogs((prev) => prev.map((dog) => (
-      canonicalDogId(dog?.id) === canonicalDogId(activeDogId)
-        ? { ...dog, recoveryState: nextRecoveryState ?? null }
-        : dog
-    )));
-  }, [activeDogId]);
-
   const recordResult = (distressLevelInput, options = {}) => {
     const distressLevel = normalizeDistressLevel(distressLevelInput);
     const dog = appData.dog;
@@ -610,7 +606,6 @@ export default function PawTimer() {
     const updated = commitSessions((prev) => [...prev, session]);
     pushWithSyncStatus("session", session).then(({ ok, error }) => { if (!ok) showToast(`Sync failed: ${error}`); });
     const nextRecommendation = deriveRecommendation(updated, walks, patterns, dog);
-    persistRecoveryState(nextRecommendation?.details?.recoveryState ?? null);
     const next = nextRecommendation.duration;
     cancelSession();
     const n = dog?.dogName ?? "your dog";
@@ -649,6 +644,21 @@ export default function PawTimer() {
   const handlePhotoUpload = (e) => { const file = e.target.files?.[0]; if (!file) return; const reader = new FileReader(); reader.onload = (ev) => setDogPhoto(ev.target.result); reader.readAsDataURL(file); };
 
   const historyActions = useHistoryEditing({ sessions, walks, patterns, feedings, patLabels, showToast, pushWithSyncStatus, syncDelete, syncDeleteSessionsForDog, commitSessions, setWalks: commitWalks, setPatterns: commitPatterns, setFeedings: commitFeedings, activeDogId, stampLocalEntry });
+
+  useEffect(() => {
+    if (!activeDogId) return;
+    const nextRecoveryState = recommendation?.details?.recoveryState ?? null;
+    setDogs((prev) => {
+      let changed = false;
+      const updated = prev.map((dog) => {
+        if (canonicalDogId(dog?.id) !== canonicalDogId(activeDogId)) return dog;
+        if (recoveryStateEqual(dog?.recoveryState, nextRecoveryState)) return dog;
+        changed = true;
+        return { ...dog, recoveryState: nextRecoveryState };
+      });
+      return changed ? updated : prev;
+    });
+  }, [activeDogId, recommendation?.details?.recoveryState]);
 
   const syncSummary = useMemo(() => {
     const allEntries = [...sessions, ...walks, ...patterns, ...feedings];

--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -671,6 +671,19 @@ function normalizeRecoveryState(state = null) {
   };
 }
 
+function clearRecoveryState(state = null) {
+  const normalized = normalizeRecoveryState(state);
+  if (!normalized) return null;
+  return {
+    ...normalized,
+    active: false,
+    triggerSessionId: null,
+    triggerSessionDate: null,
+    anchorDuration: null,
+    consecutiveCalm: 0,
+  };
+}
+
 function buildRecoveryStateFromTrigger(trainingSessions = [], triggerIndex = -1, existingState = null) {
   if (triggerIndex < 0) return normalizeRecoveryState(existingState);
   const triggerSession = trainingSessions[triggerIndex] || null;
@@ -692,7 +705,18 @@ function buildRecoveryStateFromTrigger(trainingSessions = [], triggerIndex = -1,
 
 function resolveRecoveryState(trainingSessions = [], recoveryState = null) {
   const normalized = normalizeRecoveryState(recoveryState);
-  if (normalized?.active) return normalized;
+  if (normalized?.active) {
+    const persistedTriggerIndex = trainingSessions.findIndex((session) => (
+      (normalized.triggerSessionId && session.id && session.id === normalized.triggerSessionId)
+      || (normalized.triggerSessionDate && session.date === normalized.triggerSessionDate)
+    ));
+    if (persistedTriggerIndex >= 0) {
+      const persistedTrigger = trainingSessions[persistedTriggerIndex];
+      if ([DISTRESS_LEVELS.SUBTLE, DISTRESS_LEVELS.ACTIVE, DISTRESS_LEVELS.SEVERE].includes(persistedTrigger?.distressLevel)) {
+        return buildRecoveryStateFromTrigger(trainingSessions, persistedTriggerIndex, normalized);
+      }
+    }
+  }
 
   for (let i = trainingSessions.length - 1; i >= 0; i -= 1) {
     if ([DISTRESS_LEVELS.SUBTLE, DISTRESS_LEVELS.ACTIVE, DISTRESS_LEVELS.SEVERE].includes(trainingSessions[i]?.distressLevel)) {
@@ -704,7 +728,7 @@ function resolveRecoveryState(trainingSessions = [], recoveryState = null) {
     }
   }
 
-  return normalized;
+  return clearRecoveryState(normalized);
 }
 
 function evaluatePersistentRecoveryMode(
@@ -909,6 +933,7 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
         recoveryDuration: null,
         postRecoveryDuration: null,
       },
+      recoveryState: existingRecoveryState,
     };
   }
 
@@ -936,6 +961,7 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
       recoveryDuration: null,
       postRecoveryDuration: null,
     },
+    recoveryState: existingRecoveryState,
   };
 }
 
@@ -980,7 +1006,7 @@ export function buildRecommendation(sessions = [], options = {}) {
     recommendationType: focusArea,
     stabilizationMode: stats.relapseRisk >= 0.72,
     recoveryMode: nextTarget.recoveryMode,
-    recoveryState: nextTarget.recoveryState ?? normalizeRecoveryState(options.recoveryState),
+    recoveryState: nextTarget.recoveryState ?? null,
     stats,
     warnings,
     safeAbsenceAlert: Number(options.plannedRealAbsenceSeconds || 0) > safeAlone,

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -466,6 +466,45 @@ describe("recommendation engine", () => {
     expect(twoCalm.recommendationType).toBe("recovery_mode_resume");
     expect(twoCalm.recoveryState?.active).toBe(false);
   });
+
+  it("clears stale persisted active recovery when trigger session no longer exists", () => {
+    const staleRecoveryState = {
+      active: true,
+      triggerSessionId: "deleted-trigger",
+      triggerSessionDate: daysAgo(2),
+      anchorDuration: 900,
+      fixedDuration: 60,
+      consecutiveCalm: 1,
+    };
+    const sessions = [
+      { id: "c1", date: daysAgo(1), plannedDuration: 700, actualDuration: 700, distressLevel: "none", belowThreshold: true },
+      { id: "c2", date: daysAgo(0), plannedDuration: 760, actualDuration: 760, distressLevel: "none", belowThreshold: true },
+    ];
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600, recoveryState: staleRecoveryState });
+    expect(rec.recommendationType).toBe("keep_same_duration");
+    expect(rec.recoveryMode.active).toBe(false);
+    expect(rec.recoveryState?.active).toBe(false);
+    expect(rec.recoveryState?.triggerSessionId).toBe(null);
+  });
+
+  it("reconciles persisted active recovery to latest valid stress session when trigger was edited", () => {
+    const persistedForOldTrigger = {
+      active: true,
+      triggerSessionId: "s-old",
+      triggerSessionDate: daysAgo(3),
+      anchorDuration: 600,
+      fixedDuration: 60,
+      consecutiveCalm: 0,
+    };
+    const sessions = [
+      { id: "s-old", date: daysAgo(3), plannedDuration: 600, actualDuration: 600, distressLevel: "none", belowThreshold: true },
+      { id: "s-new", date: daysAgo(1), plannedDuration: 900, actualDuration: 400, distressLevel: "active", belowThreshold: false },
+    ];
+    const rec = computeNextTarget(sessions, { goalSeconds: 3600, recoveryState: persistedForOldTrigger });
+    expect(rec.recommendationType).toBe("recovery_mode_active");
+    expect(rec.recoveryState?.active).toBe(true);
+    expect(rec.recoveryState?.triggerSessionId).toBe("s-new");
+  });
 });
 
 describe("public compatibility APIs", () => {


### PR DESCRIPTION
### Motivation
- Persisted `recoveryState` could drift from actual session history after non-session mutations (edits, deletes, sync merges, hydration), causing recommendations to contradict current history. 
- Recovery reconciliation and persistence were only applied in the result-recording path, so other recompute paths could reuse stale dog state. 

### Description
- Added `clearRecoveryState` and strengthened `resolveRecoveryState` so an active persisted recovery is only reused if its trigger still exists and remains a distress event, otherwise it is rebuilt or cleared. 
- Updated `computeNextTarget` to consistently include the reconciled `recoveryState` on non-recovery branches so recompute outputs never silently omit or rely on stale persisted state. 
- Changed `buildRecommendation` to stop falling back to `options.recoveryState` when history no longer supports it and instead surface the reconciled state from `computeNextTarget`. 
- Moved dog-level persistence of `recoveryState` into a recommendation-driven `useEffect` in `src/App.jsx` (replacing the one-off persist in the result-recording flow) so edits, deletes, sync merges, hydration and other recomputes persist reconciled recovery state uniformly. 
- Files changed: `src/lib/protocol.js` (recovery reconciliation logic), `src/App.jsx` (centralized persistence effect), and `tests/protocol.test.js` (new/updated tests validating reconciliation). 

### Testing
- Added tests in `tests/protocol.test.js` to cover clearing stale persisted active recovery when the trigger session no longer exists and reconciling a persisted active recovery to a newer valid stress session when the original trigger was edited. 
- Ran the test suite with `npm test` and all tests passed (`Test Files 10 passed`, `Tests 93 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df544903688332a2919be446cd067d)