### PR TITLE
Fix PT-LOGIC-005: use functional updaters for history edit saves to avoid stale closures

### DIFF
--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -106,10 +106,14 @@ export function useHistoryEditing({
         return;
       }
       if (historyModal.kind === "walk") {
-        const currentWalk = walks.find((w) => w.id === historyModal.id);
-        if (!currentWalk) return;
-        const updatedWalk = stampLocalEntry({ ...currentWalk, date: updatedIso }, currentWalk);
-        setWalks((prev) => sortByDateAsc(prev.map((w) => (w.id === historyModal.id ? updatedWalk : w))));
+        let updatedWalk = null;
+        setWalks((prev) => {
+          const currentWalk = prev.find((w) => w.id === historyModal.id);
+          if (!currentWalk) return prev;
+          updatedWalk = stampLocalEntry({ ...currentWalk, date: updatedIso }, currentWalk);
+          return sortByDateAsc(prev.map((w) => (w.id === historyModal.id ? updatedWalk : w)));
+        });
+        if (!updatedWalk) return;
         pushWithSyncStatus("walk", updatedWalk).then(({ ok, error }) => {
           if (!ok) showToast(`Sync failed: ${error}`);
         });
@@ -117,10 +121,14 @@ export function useHistoryEditing({
         setHistoryModal(null);
         return;
       }
-      const currentSession = sessions.find((s) => s.id === historyModal.id);
-      if (!currentSession) return;
-      const updatedSession = stampLocalEntry(normalizeSession({ ...currentSession, date: updatedIso }), currentSession);
-      commitSessions(sortByDateAsc(sessions.map((s) => (s.id === historyModal.id ? updatedSession : s))));
+      let updatedSession = null;
+      commitSessions((prev) => {
+        const currentSession = prev.find((s) => s.id === historyModal.id);
+        if (!currentSession) return prev;
+        updatedSession = stampLocalEntry(normalizeSession({ ...currentSession, date: updatedIso }), currentSession);
+        return sortByDateAsc(prev.map((s) => (s.id === historyModal.id ? updatedSession : s)));
+      });
+      if (!updatedSession) return;
       pushWithSyncStatus("session", updatedSession).then(({ ok, error }) => {
         if (!ok) showToast(`Sync failed: ${error}`);
       });
@@ -136,10 +144,14 @@ export function useHistoryEditing({
         return;
       }
       if (historyModal.kind === "walk") {
-        const currentWalk = walks.find((w) => w.id === historyModal.id);
-        if (!currentWalk) return;
-        const updatedWalk = stampLocalEntry({ ...currentWalk, duration: parsedDuration }, currentWalk);
-        setWalks((prev) => prev.map((w) => (w.id === historyModal.id ? updatedWalk : w)));
+        let updatedWalk = null;
+        setWalks((prev) => {
+          const currentWalk = prev.find((w) => w.id === historyModal.id);
+          if (!currentWalk) return prev;
+          updatedWalk = stampLocalEntry({ ...currentWalk, duration: parsedDuration }, currentWalk);
+          return prev.map((w) => (w.id === historyModal.id ? updatedWalk : w));
+        });
+        if (!updatedWalk) return;
         pushWithSyncStatus("walk", updatedWalk).then(({ ok, error }) => {
           if (!ok) showToast(`Sync failed: ${error}`);
         });
@@ -147,10 +159,17 @@ export function useHistoryEditing({
         setHistoryModal(null);
         return;
       }
-      const currentSession = sessions.find((s) => s.id === historyModal.id);
-      if (!currentSession) return;
-      const updatedSession = stampLocalEntry(mergeSessionWithDerivedFields(currentSession, { actualDuration: parsedDuration }), currentSession);
-      commitSessions(sessions.map((s) => (s.id === historyModal.id ? updatedSession : s)));
+      let updatedSession = null;
+      commitSessions((prev) => {
+        const currentSession = prev.find((s) => s.id === historyModal.id);
+        if (!currentSession) return prev;
+        updatedSession = stampLocalEntry(
+          mergeSessionWithDerivedFields(currentSession, { actualDuration: parsedDuration }),
+          currentSession,
+        );
+        return prev.map((s) => (s.id === historyModal.id ? updatedSession : s));
+      });
+      if (!updatedSession) return;
       pushWithSyncStatus("session", updatedSession).then(({ ok, error }) => {
         if (!ok) showToast(`Sync failed: ${error}`);
       });

--- a/tests/historyDurationEditing.test.js
+++ b/tests/historyDurationEditing.test.js
@@ -13,7 +13,12 @@ const baseSession = {
   result: "success",
 };
 
-const buildHistoryActions = (sessions, { commitSessions = vi.fn(), showToast = vi.fn() } = {}) => {
+const buildHistoryActions = (sessions, { commitSessions, showToast = vi.fn() } = {}) => {
+  let state = [...sessions];
+  const commitSessionsSpy = commitSessions ?? vi.fn((updater) => {
+    state = typeof updater === "function" ? updater(state) : updater;
+    return state;
+  });
   const pushWithSyncStatus = vi.fn(() => Promise.resolve({ ok: true }));
   const stampLocalEntry = (entry) => ({ ...entry });
   const actions = useHistoryEditing({
@@ -26,7 +31,7 @@ const buildHistoryActions = (sessions, { commitSessions = vi.fn(), showToast = v
     pushWithSyncStatus,
     syncDelete: vi.fn(),
     syncDeleteSessionsForDog: vi.fn(),
-    commitSessions,
+    commitSessions: commitSessionsSpy,
     setWalks: vi.fn(),
     setPatterns: vi.fn(),
     setFeedings: vi.fn(),
@@ -34,7 +39,7 @@ const buildHistoryActions = (sessions, { commitSessions = vi.fn(), showToast = v
     activeDogId: "dog-1",
     stampLocalEntry,
   });
-  return { actions, commitSessions, showToast };
+  return { actions, commitSessions: commitSessionsSpy, showToast };
 };
 
 describe("duration parser for history editing", () => {
@@ -56,15 +61,15 @@ describe("session duration edits in history", () => {
     const { actions, commitSessions, showToast } = buildHistoryActions([baseSession]);
 
     actions.saveEditedActivityDuration({ mode: "duration", kind: "session", id: "sess-1", value: "1:37" }, vi.fn());
-    const editedFromClock = commitSessions.mock.calls[0][0].find((session) => session.id === "sess-1");
+    const editedFromClock = commitSessions.mock.calls[0][0]([baseSession]).find((session) => session.id === "sess-1");
     expect(editedFromClock.actualDuration).toBe(97);
 
     actions.saveEditedActivityDuration({ mode: "duration", kind: "session", id: "sess-1", value: "22:57" }, vi.fn());
-    const editedFromMinutes = commitSessions.mock.calls[1][0].find((session) => session.id === "sess-1");
+    const editedFromMinutes = commitSessions.mock.calls[1][0]([baseSession]).find((session) => session.id === "sess-1");
     expect(editedFromMinutes.actualDuration).toBe(1377);
 
     actions.saveEditedActivityDuration({ mode: "duration", kind: "session", id: "sess-1", value: "90" }, vi.fn());
-    const editedFromSeconds = commitSessions.mock.calls[2][0].find((session) => session.id === "sess-1");
+    const editedFromSeconds = commitSessions.mock.calls[2][0]([baseSession]).find((session) => session.id === "sess-1");
     expect(editedFromSeconds.actualDuration).toBe(90);
 
     expect(showToast).toHaveBeenCalledWith("Session updated to 1m 37s");
@@ -78,5 +83,62 @@ describe("session duration edits in history", () => {
     expect(commitSessions).not.toHaveBeenCalled();
     expect(showToast).toHaveBeenNthCalledWith(1, "Invalid duration. Use a positive value (seconds, m:ss, or h:mm:ss)");
     expect(showToast).toHaveBeenNthCalledWith(2, "Invalid duration. Use a positive value (seconds, m:ss, or h:mm:ss)");
+  });
+
+  it("applies rapid sequential edits against latest session state without dropping intervening changes", () => {
+    const { actions, commitSessions } = buildHistoryActions([baseSession]);
+    const dismissModal = vi.fn();
+
+    actions.saveEditedActivityDuration({ mode: "duration", kind: "session", id: "sess-1", value: "1:37" }, dismissModal);
+    actions.saveEditedActivityDuration({ mode: "duration", kind: "session", id: "sess-1", value: "2:30" }, dismissModal);
+
+    const firstUpdater = commitSessions.mock.calls[0][0];
+    const secondUpdater = commitSessions.mock.calls[1][0];
+
+    const afterFirstEdit = firstUpdater([baseSession]);
+    expect(afterFirstEdit[0].actualDuration).toBe(97);
+
+    const stateWithInterveningUpdate = [{
+      ...afterFirstEdit[0],
+      plannedDuration: 240,
+      syncState: "syncing",
+      pendingSync: true,
+      syncError: "transient",
+    }];
+    const afterSecondEdit = secondUpdater(stateWithInterveningUpdate);
+
+    expect(afterSecondEdit[0].actualDuration).toBe(150);
+    expect(afterSecondEdit[0].plannedDuration).toBe(240);
+    expect(afterSecondEdit[0].syncState).toBe("syncing");
+    expect(afterSecondEdit[0].pendingSync).toBe(true);
+    expect(afterSecondEdit[0].syncError).toBe("transient");
+  });
+
+  it("keeps sync-sensitive fields when editing time after an intervening state update", () => {
+    const { actions, commitSessions } = buildHistoryActions([baseSession]);
+
+    actions.saveEditedActivityTime({
+      mode: "datetime",
+      kind: "session",
+      id: "sess-1",
+      date: "2026-04-11",
+      time: "11:30",
+    }, vi.fn());
+
+    const timeUpdater = commitSessions.mock.calls[0][0];
+    const stateWithSyncMetadata = [{
+      ...baseSession,
+      revision: 4,
+      syncState: "error",
+      pendingSync: true,
+      syncError: "network",
+    }];
+    const afterTimeEdit = timeUpdater(stateWithSyncMetadata);
+
+    expect(afterTimeEdit[0].date).toBe("2026-04-11T11:30:00.000Z");
+    expect(afterTimeEdit[0].revision).toBe(4);
+    expect(afterTimeEdit[0].syncState).toBe("error");
+    expect(afterTimeEdit[0].pendingSync).toBe(true);
+    expect(afterTimeEdit[0].syncError).toBe("network");
   });
 });


### PR DESCRIPTION
### Motivation
- History edit handlers used closed-over `sessions`/`walks` snapshots when building updated records, creating a stale-write/hidden-overwrite risk under rapid edits or concurrent sync activity. 
- The goal is to make history time/duration edits merge against the latest collection state while keeping existing business rules, recompute behavior, and sync semantics unchanged.

### Description
- Refactored `saveEditedActivityTime` and `saveEditedActivityDuration` to compute updates inside functional state updaters (`commitSessions((prev)=>...)` and `setWalks((prev)=>...)`) so the current record is resolved from `prev` at commit time instead of from closed-over snapshots. 
- Preserved normalization and derived-field recomputation by still calling `normalizeSession` / `mergeSessionWithDerivedFields` and by routing session writes through `commitSessions` (which triggers recompute). 
- Added local guards so `pushWithSyncStatus` and `showToast` run only when the target `updatedSession`/`updatedWalk` was actually produced by the updater, avoiding false sync attempts when the item no longer exists. 
- Updated the test harness and tests: the `buildHistoryActions` helper now supplies a spy `commitSessions` that executes functional updaters, and regression tests were added for rapid sequential edits and for edits that follow sync-sensitive intervening updates.

### Testing
- Ran `npx vitest run tests/historyDurationEditing.test.js` which initially surfaced a failing assertion while adapting tests; after fixing the test harness and code the test file passed. 
- Ran `npx vitest run tests/sessionEditing.test.js tests/historyDurationEditing.test.js` and both test files passed (all tests green). 
- The added regression tests verify `rapid sequential edits` and `edit after sync-sensitive intervening update` scenarios and are passing under the unit test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df87131664833298f2475de0c603c6)