### PR TITLE
Safe session normalization: avoid defaulting malformed rows to distress

### DIFF
--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -258,6 +258,35 @@ const resolveDurationSeconds = (row = {}, config = {}) => {
   return null;
 };
 
+const EXPLICIT_DISTRESS_RESULT_ALIASES = new Set([
+  "distress",
+  "subtle",
+  "mild",
+  "passive",
+  "active",
+  "strong",
+  "severe",
+  "panic",
+]);
+
+const normalizeRawToken = (value) => {
+  if (value == null) return null;
+  const normalized = String(value).trim().toLowerCase();
+  return normalized || null;
+};
+
+const inferDistressLevelFromRow = (row = {}) => {
+  const explicitDistressLevel = normalizeRawToken(row.distressLevel ?? row.distress_level);
+  if (explicitDistressLevel) return explicitDistressLevel;
+
+  const normalizedResult = normalizeRawToken(row.result);
+  if (normalizedResult === "success") return "none";
+  if (normalizedResult && EXPLICIT_DISTRESS_RESULT_ALIASES.has(normalizedResult)) {
+    return normalizedResult === "distress" ? "strong" : normalizedResult;
+  }
+  return null;
+};
+
 export const normalizeSession = (row = {}) => {
   const context = row.context ?? {};
   const symptoms = row.symptoms ?? {};
@@ -266,7 +295,7 @@ export const normalizeSession = (row = {}) => {
   const normalizedDistressType = row.distressType ?? row.distress_type ?? null;
   const normalizedDistressSeverity = row.distressSeverity ?? row.distress_severity ?? null;
   const restoredLegacyDistress = decodeLegacyDistressFields({
-    distressLevel: row.distressLevel ?? row.distress_level ?? (row.result === "success" ? "none" : "strong"),
+    distressLevel: inferDistressLevelFromRow(row),
     distressType: normalizedDistressType,
     distressSeverity: normalizedDistressSeverity,
   });

--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -299,7 +299,10 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
           ) : timeline.map((item) => {
             if (item.kind === "session") {
               const s = item.data;
-              const lv = normalizeDistressLevel(s.distressLevel ?? (s.result === "success" ? "none" : "strong"));
+              const lv = normalizeDistressLevel(
+                s.distressLevel
+                ?? (s.result === "success" ? "none" : (s.result === "distress" ? "strong" : null)),
+              );
               const detailBadges = sessionDetailBadges(s);
               return renderHistoryCard({
                 itemKey: `s-${s.id}`,

--- a/tests/storageNormalization.test.js
+++ b/tests/storageNormalization.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeFeedings, normalizePatterns } from "../src/features/app/storage";
+import { normalizeFeedings, normalizePatterns, normalizeSession } from "../src/features/app/storage";
 
 describe("storage normalization", () => {
   it("keeps feeding revision/updatedAt non-null when provided", () => {
@@ -29,5 +29,77 @@ describe("storage normalization", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].revision).toBe(7);
     expect(rows[0].updatedAt).toBe("2026-04-01T08:30:00.000Z");
+  });
+
+  it("does not default to distress when distress metadata is missing", () => {
+    const session = normalizeSession({
+      id: "s-missing-distress",
+      result: "success",
+      plannedDuration: 120,
+      actualDuration: 120,
+    });
+
+    expect(session.distressLevel).toBe("none");
+  });
+
+  it("normalizes explicit distress result when distress level is missing", () => {
+    const session = normalizeSession({
+      id: "s-missing-level",
+      result: "distress",
+      plannedDuration: 120,
+      actualDuration: 60,
+    });
+
+    expect(session.distressLevel).toBe("active");
+  });
+
+  it("defaults malformed rows with missing result and distress metadata to neutral", () => {
+    const session = normalizeSession({
+      id: "s-missing-both",
+      plannedDuration: 120,
+      actualDuration: 60,
+    });
+
+    expect(session.distressLevel).toBe("none");
+  });
+
+  it("keeps explicit known distress levels", () => {
+    const session = normalizeSession({
+      id: "s-explicit-severe",
+      distressLevel: "severe",
+      result: "distress",
+    });
+
+    expect(session.distressLevel).toBe("severe");
+  });
+
+  it("normalizes known legacy distress aliases", () => {
+    const session = normalizeSession({
+      id: "s-legacy-strong",
+      distress_level: "strong",
+      result: "distress",
+    });
+
+    expect(session.distressLevel).toBe("active");
+  });
+
+  it("keeps known success rows calm", () => {
+    const session = normalizeSession({
+      id: "s-success",
+      result: "success",
+      distressLevel: "none",
+    });
+
+    expect(session.distressLevel).toBe("none");
+  });
+
+  it("uses explicit distress metadata when result contradicts it", () => {
+    const session = normalizeSession({
+      id: "s-contradict",
+      distressLevel: "severe",
+      result: "success",
+    });
+
+    expect(session.distressLevel).toBe("severe");
   });
 });


### PR DESCRIPTION
### Motivation
- `normalizeSession` previously inferred distress via `row.distressLevel ?? row.distress_level ?? (row.result === "success" ? "none" : "strong")`, causing malformed/partial rows to default to a distress-like value and corrupt downstream logic. 
- The change ensures unknown or incomplete session data does not silently become distress, protecting recommendation/recovery calculations from inflation by malformed rows.

### Description
- Added deterministic inference helpers: `normalizeRawToken`, an `EXPLICIT_DISTRESS_RESULT_ALIASES` set, and `inferDistressLevelFromRow` to resolve distress level explicitly from `distressLevel`/`distress_level` first, then `result`, and otherwise return `null` (neutral). 
- Updated `normalizeSession` to call `inferDistressLevelFromRow(row)` and pass the safer inferred value into `decodeLegacyDistressFields` instead of defaulting to `"strong"` when metadata is missing. 
- Hardened a UI/display fallback in `HistoryFeature.jsx` so history badges also avoid treating unknown/missing `result` as distress. 
- Added unit tests in `tests/storageNormalization.test.js` to cover missing distress only, missing result only, both missing, explicit known distress, legacy alias normalization, success rows, and contradictory combinations.

### Testing
- Ran `npm test -- tests/storageNormalization.test.js` and observed `9 tests` passed (all tests in that file succeeded). 
- Ran `npm test -- tests/syncFetchRuntime.test.js tests/sessionEditing.test.js` and observed both files passed (total `10 tests` passed), confirming no regressions in sync/fallback and session editing flows. 
- All automated tests executed in this environment succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8b4d8a2c8332bba0bb2db7b7d0cf)