### PR TITLE
Make history delete mutations latest-state safe (fix stale-write risk)

### DIFF
--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -179,20 +179,17 @@ export function useHistoryEditing({
     confirmHistoryDelete: (historyModal, setHistoryModal) => {
       if (!historyModal || historyModal.mode !== "delete") return;
       if (historyModal.kind === "session") {
-        const nextSessions = sessions.filter((item) => item.id !== historyModal.id);
-        commitSessions(nextSessions);
+        commitSessions((prev) => prev.filter((item) => item.id !== historyModal.id));
         syncDelete("session", historyModal.id).then((ok) => {
           if (!ok) showToast("Session removed locally — remote delete failed");
         });
       } else if (historyModal.kind === "walk") {
-        const nextWalks = walks.filter((item) => item.id !== historyModal.id);
-        setWalks(nextWalks);
+        setWalks((prev) => prev.filter((item) => item.id !== historyModal.id));
         syncDelete("walk", historyModal.id).then((ok) => {
           if (!ok) showToast("Walk removed locally — remote delete failed");
         });
       } else if (historyModal.kind === "pattern") {
-        const nextPatterns = patterns.filter((item) => item.id !== historyModal.id);
-        setPatterns(nextPatterns);
+        setPatterns((prev) => prev.filter((item) => item.id !== historyModal.id));
         syncDelete("pattern", historyModal.id).then((ok) => {
           if (!ok) showToast("Pattern break removed locally — remote delete failed");
         });

--- a/tests/historyDeleteMutations.test.js
+++ b/tests/historyDeleteMutations.test.js
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from "vitest";
+import { suggestNextWithContext } from "../src/lib/protocol";
+import { useHistoryEditing } from "../src/features/history/HistoryFeature";
+
+const makeIso = (value) => new Date(value).toISOString();
+
+const baseSession = {
+  id: "sess-1",
+  date: makeIso("2026-04-10T10:00:00Z"),
+  plannedDuration: 120,
+  actualDuration: 120,
+  distressLevel: "none",
+  belowThreshold: true,
+  latencyToFirstDistress: 120,
+  result: "success",
+};
+
+const buildDeleteActions = ({
+  sessions = [baseSession],
+  walks = [{ id: "walk-1", date: makeIso("2026-04-10T11:00:00Z"), duration: 300, type: "exercise" }],
+  patterns = [{ id: "pat-1", date: makeIso("2026-04-10T12:00:00Z"), type: "phone" }],
+  feedings = [{ id: "feed-1", date: makeIso("2026-04-10T13:00:00Z"), foodType: "meal", amount: "small" }],
+  commitSessions,
+  commitWalks,
+  commitPatterns,
+  commitFeedings,
+  syncDelete = vi.fn(() => Promise.resolve(true)),
+  showToast = vi.fn(),
+} = {}) => {
+  const actions = useHistoryEditing({
+    sessions,
+    walks,
+    patterns,
+    feedings,
+    patLabels: {},
+    showToast,
+    pushWithSyncStatus: vi.fn(() => Promise.resolve({ ok: true })),
+    syncDelete,
+    syncDeleteSessionsForDog: vi.fn(() => Promise.resolve(true)),
+    commitSessions: commitSessions ?? vi.fn(),
+    setWalks: commitWalks ?? vi.fn(),
+    setPatterns: commitPatterns ?? vi.fn(),
+    setFeedings: commitFeedings ?? vi.fn(),
+    activeDogId: "dog-1",
+    stampLocalEntry: (entry) => ({ ...entry }),
+  });
+
+  return {
+    actions,
+    showToast,
+    syncDelete,
+    commitSessions: commitSessions ?? vi.fn(),
+    commitWalks: commitWalks ?? vi.fn(),
+    commitPatterns: commitPatterns ?? vi.fn(),
+    commitFeedings: commitFeedings ?? vi.fn(),
+  };
+};
+
+describe("history delete mutations", () => {
+  it("applies session deletes against latest state after another local mutation", () => {
+    const commitSessions = vi.fn();
+    const { actions } = buildDeleteActions({ commitSessions });
+
+    actions.confirmHistoryDelete({ mode: "delete", kind: "session", id: "sess-1", label: "Training session" }, vi.fn());
+
+    expect(commitSessions).toHaveBeenCalledTimes(1);
+    const deleteUpdater = commitSessions.mock.calls[0][0];
+
+    const stateWithInterveningLocalMutation = [
+      { ...baseSession, actualDuration: 145 },
+      {
+        id: "sess-2",
+        date: makeIso("2026-04-11T10:00:00Z"),
+        plannedDuration: 145,
+        actualDuration: 145,
+        distressLevel: "none",
+        belowThreshold: true,
+        latencyToFirstDistress: 145,
+        result: "success",
+      },
+    ];
+
+    const afterDelete = deleteUpdater(stateWithInterveningLocalMutation);
+    expect(afterDelete.map((session) => session.id)).toEqual(["sess-2"]);
+    expect(afterDelete[0].actualDuration).toBe(145);
+  });
+
+  it("preserves sync-sensitive state changes when deleting walks, patterns, and feedings", () => {
+    const commitWalks = vi.fn();
+    const commitPatterns = vi.fn();
+    const commitFeedings = vi.fn();
+    const { actions } = buildDeleteActions({ commitWalks, commitPatterns, commitFeedings });
+
+    actions.confirmHistoryDelete({ mode: "delete", kind: "walk", id: "walk-1", label: "Exercise walk" }, vi.fn());
+    actions.confirmHistoryDelete({ mode: "delete", kind: "pattern", id: "pat-1", label: "Phone trigger" }, vi.fn());
+    actions.confirmHistoryDelete({ mode: "delete", kind: "feeding", id: "feed-1", label: "Meal feeding" }, vi.fn());
+
+    const walkUpdater = commitWalks.mock.calls[0][0];
+    const patternUpdater = commitPatterns.mock.calls[0][0];
+    const feedingUpdater = commitFeedings.mock.calls[0][0];
+
+    const afterWalkDelete = walkUpdater([
+      { id: "walk-1", date: makeIso("2026-04-10T11:00:00Z"), duration: 300, type: "exercise" },
+      { id: "walk-2", date: makeIso("2026-04-10T11:30:00Z"), duration: 600, type: "potty", revision: 8, syncState: "syncing", pendingSync: true },
+    ]);
+    expect(afterWalkDelete).toEqual([
+      { id: "walk-2", date: makeIso("2026-04-10T11:30:00Z"), duration: 600, type: "potty", revision: 8, syncState: "syncing", pendingSync: true },
+    ]);
+
+    const afterPatternDelete = patternUpdater([
+      { id: "pat-1", date: makeIso("2026-04-10T12:00:00Z"), type: "phone" },
+      { id: "pat-2", date: makeIso("2026-04-10T12:30:00Z"), type: "door", revision: 2, syncState: "error", pendingSync: true, syncError: "network" },
+    ]);
+    expect(afterPatternDelete).toEqual([
+      { id: "pat-2", date: makeIso("2026-04-10T12:30:00Z"), type: "door", revision: 2, syncState: "error", pendingSync: true, syncError: "network" },
+    ]);
+
+    const afterFeedingDelete = feedingUpdater([
+      { id: "feed-1", date: makeIso("2026-04-10T13:00:00Z"), foodType: "meal", amount: "small" },
+      { id: "feed-2", date: makeIso("2026-04-10T13:30:00Z"), foodType: "snack", amount: "tiny", revision: 5, syncState: "syncing", pendingSync: true },
+    ]);
+    expect(afterFeedingDelete).toEqual([
+      { id: "feed-2", date: makeIso("2026-04-10T13:30:00Z"), foodType: "snack", amount: "tiny", revision: 5, syncState: "syncing", pendingSync: true },
+    ]);
+  });
+
+  it("retains non-deleted intervening changes and keeps recommendation recompute inputs correct", () => {
+    const commitSessions = vi.fn();
+    const { actions } = buildDeleteActions({
+      sessions: [
+        {
+          ...baseSession,
+          id: "sess-1",
+          plannedDuration: 90,
+          actualDuration: 90,
+          date: makeIso("2026-04-09T10:00:00Z"),
+        },
+        {
+          ...baseSession,
+          id: "sess-2",
+          plannedDuration: 110,
+          actualDuration: 110,
+          date: makeIso("2026-04-10T10:00:00Z"),
+        },
+      ],
+      commitSessions,
+    });
+
+    actions.confirmHistoryDelete({ mode: "delete", kind: "session", id: "sess-1", label: "Older session" }, vi.fn());
+
+    const deleteUpdater = commitSessions.mock.calls[0][0];
+    const stateBeforeDeleteApplied = [
+      {
+        ...baseSession,
+        id: "sess-1",
+        plannedDuration: 90,
+        actualDuration: 90,
+        date: makeIso("2026-04-09T10:00:00Z"),
+      },
+      {
+        ...baseSession,
+        id: "sess-2",
+        plannedDuration: 140,
+        actualDuration: 140,
+        belowThreshold: false,
+        latencyToFirstDistress: 65,
+        distressLevel: "active",
+        result: "distress",
+        date: makeIso("2026-04-10T10:00:00Z"),
+      },
+    ];
+
+    const afterDelete = deleteUpdater(stateBeforeDeleteApplied);
+    expect(afterDelete).toHaveLength(1);
+    expect(afterDelete[0].id).toBe("sess-2");
+    expect(afterDelete[0].actualDuration).toBe(140);
+    expect(afterDelete[0].result).toBe("distress");
+
+    const recommendationAfterDelete = suggestNextWithContext(afterDelete, [], [], { goalSeconds: 3600 });
+    const recommendationIfInterveningChangeWereDropped = suggestNextWithContext([
+      {
+        ...baseSession,
+        id: "sess-2",
+        plannedDuration: 110,
+        actualDuration: 110,
+        date: makeIso("2026-04-10T10:00:00Z"),
+      },
+    ], [], [], { goalSeconds: 3600 });
+
+    expect(recommendationAfterDelete).not.toBe(recommendationIfInterveningChangeWereDropped);
+  });
+});


### PR DESCRIPTION
### Motivation
- `confirmHistoryDelete` previously built next-state arrays from closure-captured `sessions`, `walks`, and `patterns`, which can overwrite intervening local or sync-driven updates and cause stale-write risk. 
- The intent is to ensure all delete flows are applied against the latest state so concurrent mutations are preserved and recommendation recompute remains correct.

### Description
- Refactored `confirmHistoryDelete` so session, walk, and pattern deletes use functional updaters (`commitSessions((prev) => ...)`, `setWalks((prev) => ...)`, `setPatterns((prev) => ...)`) instead of committing arrays derived from captured props. 
- Kept feeding deletes as a functional updater for consistency; no business-rule changes were made. 
- Added `tests/historyDeleteMutations.test.js` which exercises delete-after-local-mutation, delete-after-sync-sensitive changes, preservation of intervening changes, and recommendation sensitivity after deletes. 
- All recompute calls remain on the existing `commit*` pathways so recommendation correctness is preserved.

### Testing
- Ran `npm test -- tests/historyDeleteMutations.test.js tests/historyDurationEditing.test.js` and the targeted tests passed. 
- Ran the full test suite with `npm test` and all tests passed (110 tests). 
- The new tests are `tests/historyDeleteMutations.test.js` and existing history-duration tests were re-run to confirm no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8c56601c8332b698e3b59ea2879f)