### PR TITLE
Fix ISSUE-002: strict explicit belowThreshold parsing (prevent malformed truthy coercion)

### DIFF
--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -111,13 +111,18 @@ export function inferBelowThreshold(session = {}) {
   const toExplicitBool = (value) => {
     if (value == null) return null;
     if (typeof value === "boolean") return value;
-    if (typeof value === "number") return value !== 0;
+    if (typeof value === "number") {
+      if (value === 1) return true;
+      if (value === 0) return false;
+      return null;
+    }
     if (typeof value === "string") {
       const normalized = value.trim().toLowerCase();
       if (["true", "1", "yes"].includes(normalized)) return true;
       if (["false", "0", "no"].includes(normalized)) return false;
+      return null;
     }
-    return Boolean(value);
+    return null;
   };
 
   const explicit = toExplicitBool(

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -63,6 +63,45 @@ describe("below-threshold inference", () => {
       belowThreshold: true,
     })).toBe(true);
   });
+
+  it("accepts supported canonical explicit string values", () => {
+    expect(inferBelowThreshold({
+      distressLevel: "none",
+      plannedDuration: 600,
+      actualDuration: 590,
+      belowThreshold: "true",
+    })).toBe(true);
+    expect(inferBelowThreshold({
+      distressLevel: "none",
+      plannedDuration: 600,
+      actualDuration: 610,
+      belowThreshold: "false",
+    })).toBe(false);
+  });
+
+  it("falls back to inference when explicit value is malformed", () => {
+    expect(inferBelowThreshold({
+      distressLevel: "none",
+      plannedDuration: 600,
+      actualDuration: 590,
+      belowThreshold: "maybe",
+    })).toBe(false);
+  });
+
+  it("falls back to inference when explicit below-threshold is nullish", () => {
+    expect(inferBelowThreshold({
+      distressLevel: "none",
+      plannedDuration: 600,
+      actualDuration: 610,
+      belowThreshold: null,
+    })).toBe(true);
+    expect(inferBelowThreshold({
+      distressLevel: "none",
+      plannedDuration: 600,
+      actualDuration: 590,
+      belowThreshold: undefined,
+    })).toBe(false);
+  });
 });
 
 describe("training stats", () => {

--- a/tests/sessionEditing.test.js
+++ b/tests/sessionEditing.test.js
@@ -47,6 +47,21 @@ describe("mergeSessionWithDerivedFields", () => {
     expect(updated.distressSeverity).toBe("active");
     expect(updated.distressType).toBe("barking");
   });
+
+  it("recomputes below-threshold from canonical inference when stored explicit value is malformed", () => {
+    const updated = mergeSessionWithDerivedFields({
+      id: "sess-3",
+      date: daysAgo(0),
+      plannedDuration: 60,
+      actualDuration: 30,
+      distressLevel: "none",
+      belowThreshold: "maybe",
+      result: "success",
+      distressType: "none",
+    }, {});
+
+    expect(updated.belowThreshold).toBe(false);
+  });
 });
 
 describe("edited sessions and target recomputation", () => {

--- a/tests/storageNormalization.test.js
+++ b/tests/storageNormalization.test.js
@@ -102,4 +102,36 @@ describe("storage normalization", () => {
 
     expect(session.distressLevel).toBe("severe");
   });
+
+  it("does not allow malformed explicit below-threshold values to override inference", () => {
+    const session = normalizeSession({
+      id: "s-invalid-below-threshold",
+      plannedDuration: 120,
+      actualDuration: 90,
+      distressLevel: "none",
+      below_threshold: "maybe",
+    });
+
+    expect(session.belowThreshold).toBe(false);
+  });
+
+  it("accepts canonical explicit below-threshold string values", () => {
+    const trueSession = normalizeSession({
+      id: "s-string-true",
+      plannedDuration: 120,
+      actualDuration: 90,
+      distressLevel: "none",
+      below_threshold: "true",
+    });
+    const falseSession = normalizeSession({
+      id: "s-string-false",
+      plannedDuration: 120,
+      actualDuration: 120,
+      distressLevel: "none",
+      below_threshold: "false",
+    });
+
+    expect(trueSession.belowThreshold).toBe(true);
+    expect(falseSession.belowThreshold).toBe(false);
+  });
 });


### PR DESCRIPTION
### Motivation
- The previous `inferBelowThreshold` path used a permissive coercion that allowed non-empty malformed values (e.g. "maybe") to coerce truthily and override canonical inference, corrupting calm/stability/threshold logic. 
- The goal is to make explicit `belowThreshold` parsing strict so only canonical explicit values are accepted and invalid explicit values fall back to canonical inference.

### Description
- Tightened the explicit parsing in `inferBelowThreshold` by replacing the permissive `toExplicitBool` fallback with strict handling so that only booleans, numeric `1`/`0`, and supported canonical strings (`"true"`, `"false"`, `"1"`, `"0"`, `"yes"`, `"no"`) are accepted. 
- Numeric values other than `1` or `0` and unsupported strings now return `null` (treated as invalid explicit), ensuring the function falls back to canonical inference (distress level + duration) instead of using a coerced truthy value. 
- Removed the previous generic `Boolean(value)` fallback that turned arbitrary non-empty strings into `true`. 
- Added/updated tests to cover: canonical boolean handling, canonical string forms, malformed strings like `"maybe"`, null/undefined explicit values, and the merge/storage flows where explicit values could have overridden inference.

### Testing
- Ran the targeted test suite with `npm test -- tests/protocol.test.js tests/storageNormalization.test.js tests/sessionEditing.test.js` and all tests passed. 
- Test run summary: 3 test files executed and all tests succeeded (78 tests passed). 
- New/updated tests include checks in `tests/protocol.test.js`, `tests/storageNormalization.test.js`, and `tests/sessionEditing.test.js` verifying strict parsing and correct fallback to inference.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8db3390883329ba3ec0e1e3318c0)