### PR TITLE
Preserve target for short-but-calm sessions and refine instability detection

### DIFF
--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -583,7 +583,11 @@ function getHoursSinceLastSession(lastSession) {
 function isUnstableSession(session = null) {
   if (!session) return false;
   const distress = normalizeDistressLevel(session.distressLevel);
-  return distress !== DISTRESS_LEVELS.NONE || session.belowThreshold === false;
+  if (distress !== DISTRESS_LEVELS.NONE) return true;
+  if (!session.belowThreshold) {
+    return isCalmVeryShortSession(session);
+  }
+  return false;
 }
 
 function hasThreeSessionInstability(window = []) {
@@ -616,6 +620,36 @@ function hasConsecutivePostSubtleIncrease(window = []) {
   const second = getSessionDurationAnchor(postSubtle[postSubtle.length - 1]);
   if (!Number.isFinite(first) || !Number.isFinite(second)) return false;
   return second > first;
+}
+
+function getCompletionRatio(session = null) {
+  if (!session) return 0;
+  const planned = Number(session.plannedDuration);
+  const actual = Number(session.actualDuration);
+  if (!Number.isFinite(planned) || planned <= 0 || !Number.isFinite(actual) || actual < 0) return 0;
+  return clamp01(actual / planned);
+}
+
+function isCalmShortSession(session = null) {
+  if (!session) return false;
+  if (normalizeDistressLevel(session.distressLevel) !== DISTRESS_LEVELS.NONE) return false;
+  return getCompletionRatio(session) < 0.85;
+}
+
+function isCalmVeryShortSession(session = null) {
+  if (!session) return false;
+  if (normalizeDistressLevel(session.distressLevel) !== DISTRESS_LEVELS.NONE) return false;
+  return getCompletionRatio(session) < 0.5;
+}
+
+function getProgressionReferenceDuration(session = null) {
+  if (!session) return null;
+  const planned = Number(session.plannedDuration);
+  const anchor = getSessionDurationAnchor(session);
+  if (isCalmShortSession(session) && Number.isFinite(planned) && planned > 0) {
+    return planned;
+  }
+  return anchor;
 }
 
 function clampRateChange(nextDuration, referenceDuration) {
@@ -927,9 +961,10 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
 
   const gapHours = getHoursSinceLastSession(lastSession);
   const gapReduction = gapHours > 48 ? 0.12 : 0;
+  const trailingCalmShortStreak = countStreak(recentWindow, isCalmShortSession);
 
   if (hasThreeSessionInstability(recentWindow)) {
-    const lastReferenceDuration = getSessionDurationAnchor(lastSession) ?? PROTOCOL.startDurationSeconds;
+    const lastReferenceDuration = getProgressionReferenceDuration(lastSession) ?? PROTOCOL.startDurationSeconds;
     const heldDuration = gapReduction > 0
       ? Math.round(lastReferenceDuration * (1 - gapReduction))
       : lastReferenceDuration;
@@ -949,10 +984,33 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
     };
   }
 
+  if (trailingCalmShortStreak >= 1) {
+    const holdBase = getProgressionReferenceDuration(lastSession)
+      ?? getSessionDurationAnchor(lastSession)
+      ?? PROTOCOL.startDurationSeconds;
+    const adjustedForGap = gapReduction > 0
+      ? Math.round(holdBase * (1 - gapReduction))
+      : holdBase;
+    return {
+      recommendedDuration: clamp(adjustedForGap, PROTOCOL.minDurationSeconds, goalSeconds),
+      recommendationType: 'keep_same_duration',
+      recoveryMode: {
+        active: false,
+        remainingSessions: 0,
+        ...buildRecoveryModeDetails({ step: 0 }),
+        anchorSessionDate: lastSession?.date || null,
+        anchorDuration: getProgressionReferenceDuration(lastSession) ?? null,
+        recoveryDuration: null,
+        postRecoveryDuration: null,
+      },
+      recoveryState: existingRecoveryState,
+    };
+  }
+
   const calmStreak = countStreak(recentWindow, (session) => session.distressLevel === DISTRESS_LEVELS.NONE);
   const lastCalmSession = getLastCalmSession(recentWindow);
-  const anchorDuration = getSessionDurationAnchor(lastCalmSession) ?? PROTOCOL.startDurationSeconds;
-  const lastReferenceDuration = getSessionDurationAnchor(lastSession) ?? anchorDuration;
+  const anchorDuration = getProgressionReferenceDuration(lastCalmSession) ?? PROTOCOL.startDurationSeconds;
+  const lastReferenceDuration = getProgressionReferenceDuration(lastSession) ?? anchorDuration;
 
   const plateauDuration = getPlateauDuration(recentWindow);
   if (Number.isFinite(plateauDuration) && plateauDuration > 0) {

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -232,6 +232,59 @@ describe("recommendation engine", () => {
     expect(rec.recommendationType).toBe("recovery_mode_active");
   });
 
+  it("holds the target after a single short but calm session", () => {
+    const sessions = [
+      { date: daysAgo(1), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(0), plannedDuration: 900, actualDuration: 300, distressLevel: "none", belowThreshold: false },
+    ];
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recommendedDuration).toBe(900);
+    expect(rec.recommendationType).toBe("keep_same_duration");
+  });
+
+  it("holds instead of regressing across repeated short calm sessions", () => {
+    const sessions = [
+      { date: daysAgo(2), plannedDuration: 900, actualDuration: 300, distressLevel: "none", belowThreshold: false },
+      { date: daysAgo(1), plannedDuration: 900, actualDuration: 300, distressLevel: "none", belowThreshold: false },
+      { date: daysAgo(0), plannedDuration: 900, actualDuration: 300, distressLevel: "none", belowThreshold: false },
+    ];
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recommendedDuration).toBe(900);
+    expect(rec.recommendationType).toBe("repeat_current_duration");
+  });
+
+  it("keeps distress-driven recovery for short sessions with distress", () => {
+    const sessions = [
+      { date: daysAgo(1), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(0), plannedDuration: 900, actualDuration: 300, distressLevel: "active", belowThreshold: false },
+    ];
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recommendationType).toBe("recovery_mode_active");
+    expect(rec.recommendedDuration).toBe(60);
+  });
+
+  it("still progresses after a full calm session at target", () => {
+    const sessions = [
+      { date: daysAgo(1), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(0), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
+    ];
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recommendedDuration).toBeGreaterThan(900);
+    expect(rec.recommendationType).toBe("keep_same_duration");
+  });
+
+  it("does not let one short calm session erase prior calm history", () => {
+    const sessions = [
+      { date: daysAgo(3), plannedDuration: 720, actualDuration: 720, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(2), plannedDuration: 840, actualDuration: 840, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(1), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(0), plannedDuration: 900, actualDuration: 300, distressLevel: "none", belowThreshold: false },
+    ];
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recommendedDuration).toBe(900);
+    expect(rec.recommendationType).toBe("keep_same_duration");
+  });
+
   it("recovery step progression follows 1min then 2min after subtle stress", () => {
     const subtle = { date: daysAgo(2), plannedDuration: 1200, actualDuration: 1200, distressLevel: "subtle", belowThreshold: false };
     const step1 = buildRecommendation([subtle], { goalSeconds: 3600 });
@@ -594,9 +647,9 @@ describe("public compatibility APIs", () => {
     expect(keepSameDuration.recommendationType).toBe("keep_same_duration");
 
     const repeatCurrent = explainNextTarget([
-      { date: daysAgo(2), plannedDuration: 300, actualDuration: 260, distressLevel: "none", belowThreshold: false },
-      { date: daysAgo(1), plannedDuration: 300, actualDuration: 250, distressLevel: "none", belowThreshold: false },
-      { date: hoursAgo(2), plannedDuration: 300, actualDuration: 240, distressLevel: "none", belowThreshold: false },
+      { date: daysAgo(2), plannedDuration: 300, actualDuration: 120, distressLevel: "none", belowThreshold: false },
+      { date: daysAgo(1), plannedDuration: 300, actualDuration: 110, distressLevel: "none", belowThreshold: false },
+      { date: hoursAgo(2), plannedDuration: 300, actualDuration: 100, distressLevel: "none", belowThreshold: false },
     ], [], [], { goalSeconds: 3600 });
     expect(repeatCurrent.recommendationType).toBe("repeat_current_duration");
 


### PR DESCRIPTION
### Motivation
- Short calm sessions (owner ended early) were being treated as instability and could collapse the next recommended duration to the short actual time. 
- The progression pipeline needed to distinguish short-but-successful calm sessions from real failure/distress while still keeping conservative behaviour for true distress.

### Description
- Added helpers to measure completion and classify short calm sessions: `getCompletionRatio`, `isCalmShortSession` (<85%), and `isCalmVeryShortSession` (<50%).
- Introduced `getProgressionReferenceDuration` so short-but-calm sessions use the planned duration as the progression anchor rather than their short actual duration.
- Tightened instability detection in `isUnstableSession` so calm rows only count as instability when they are very short, while any non-`none` distress still counts as instability.
- In `computeNextTarget` added a trailing short-calm hold path that returns a `keep_same_duration` recommendation (preserving the current target) and switched anchor/reference selection to use `getProgressionReferenceDuration` where appropriate.
- Updated tests in `tests/protocol.test.js` to cover single short calm, repeated short calm, short-with-distress, full calm progression, and mixed-history scenarios.

### Testing
- Ran unit tests `tests/protocol.test.js` and `tests/statusSemantics.test.js` using `npm test`; both test files passed (all tests green).
- New/updated tests include: single short calm hold, repeated short calm hold/repeat behavior, short session with distress triggers recovery, full-target calm continues progression, and mixed-history hold behavior; all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8f2a8a2c8332a077f9489969ed50)