### PR TITLE
Durable tombstones for sync deletions (PT-LOGIC-001)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import { useRegisterSW } from "virtual:pwa-register/react";
 import { PROTOCOL, explainNextTarget, normalizeDistressLevel, suggestNext, suggestNextWithContext } from "./lib/protocol";
 import { sortByDateAsc } from "./lib/activityDateTime";
 import { selectAppData } from "./features/app/selectors";
-import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeById, mergeSessionWithDerivedFields, normalizeFeedings, normalizeSessions, patKey, patLblKey, photoKey, save, sessKey, syncDelete, syncDeleteSessionsForDog, syncFetch, syncPush, syncUpsertDog, toDateTimeLocalValue, walkKey } from "./features/app/storage";
+import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeById, mergeSessionWithDerivedFields, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, save, sessKey, syncDelete, syncDeleteSessionsForDog, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
 import { fmt, fmtClock, getOutcomeTone, normalizeWalkType, walkTypeLabel } from "./features/app/helpers";
 import { CameraIcon, ChartIcon, HistoryIcon, HomeIcon, PawIcon, SettingsIcon } from "./features/app/ui.jsx";
 import { DogSelect, Onboarding } from "./features/setup/SetupScreens";
@@ -35,6 +35,7 @@ export default function PawTimer() {
   const [walks, setWalks] = useState([]);
   const [patterns, setPatterns] = useState([]);
   const [feedings, setFeedings] = useState([]);
+  const [tombstones, setTombstones] = useState([]);
   const [tab, setTab] = useState("home");
   const [onboardingState, setOnboardingState] = useState(null);
   const [phase, setPhase] = useState("idle");
@@ -89,7 +90,7 @@ export default function PawTimer() {
   const timerRef = useRef(null);
   const startRef = useRef(null);
   const syncInFlightRef = useRef(false);
-  const syncSnapshotRef = useRef({ dogs: [], sessions: [], walks: [], patterns: [], feedings: [] });
+  const syncSnapshotRef = useRef({ dogs: [], sessions: [], walks: [], patterns: [], feedings: [], tombstones: [] });
   const syncHelpersRef = useRef({
     commitSessions: null,
     commitWalks: null,
@@ -153,14 +154,33 @@ export default function PawTimer() {
     };
   }, []);
 
+  const makeLocalTombstone = useCallback((kind, entry, previousTombstone = null, syncState = SYNC_STATE.LOCAL, syncErrorMessage = "") => {
+    const deletedAt = new Date().toISOString();
+    const previousRevision = Number.isFinite(previousTombstone?.revision)
+      ? previousTombstone.revision
+      : Number.isFinite(entry?.revision)
+        ? entry.revision
+        : 0;
+    return {
+      id: String(entry?.id || ""),
+      kind,
+      deletedAt,
+      updatedAt: deletedAt,
+      revision: previousRevision + 1,
+      pendingSync: syncState !== SYNC_STATE.SYNCED,
+      syncState,
+      syncError: syncState === SYNC_STATE.ERROR ? syncErrorMessage : "",
+    };
+  }, []);
+
   const mergeSyncedCollection = useCallback((localItems, remoteItems) => mergeById(
     ensureArray(localItems).map(withHydratedSyncState),
     ensureArray(remoteItems).map(markRemoteEntryConfirmed),
   ), [markRemoteEntryConfirmed, withHydratedSyncState]);
 
   useEffect(() => {
-    syncSnapshotRef.current = { dogs, sessions, walks, patterns, feedings };
-  }, [dogs, sessions, walks, patterns, feedings]);
+    syncSnapshotRef.current = { dogs, sessions, walks, patterns, feedings, tombstones };
+  }, [dogs, sessions, walks, patterns, feedings, tombstones]);
 
   useEffect(() => { save(DOGS_KEY, dogs); }, [dogs]);
   useEffect(() => { save(ACTIVE_DOG_KEY, canonicalDogId(activeDogId)); }, [activeDogId]);
@@ -168,6 +188,7 @@ export default function PawTimer() {
   useEffect(() => { if (activeDogId) save(walkKey(activeDogId), walks); }, [walks, activeDogId]);
   useEffect(() => { if (activeDogId) save(patKey(activeDogId), patterns); }, [patterns, activeDogId]);
   useEffect(() => { if (activeDogId) save(feedingKey(activeDogId), feedings); }, [feedings, activeDogId]);
+  useEffect(() => { if (activeDogId) save(tombKey(activeDogId), tombstones); }, [tombstones, activeDogId]);
   useEffect(() => { if (activeDogId) save(patLblKey(activeDogId), patLabels); }, [patLabels, activeDogId]);
   useEffect(() => { if (activeDogId) save(photoKey(activeDogId), dogPhoto); }, [dogPhoto, activeDogId]);
   useEffect(() => { save("pawtimer_notif_time", notifTime); }, [notifTime]);
@@ -257,6 +278,38 @@ export default function PawTimer() {
     });
   }, [activeDogId, withHydratedSyncState]);
 
+  const commitTombstones = useCallback((updater) => {
+    setTombstones((prev) => {
+      const resolved = typeof updater === "function" ? updater(prev) : updater;
+      const normalized = normalizeTombstones(ensureArray(resolved)).map(withHydratedSyncState);
+      if (activeDogId) save(tombKey(activeDogId), normalized);
+      return normalized;
+    });
+  }, [activeDogId, withHydratedSyncState]);
+
+  const addTombstone = useCallback((kind, entry) => {
+    if (!entry?.id) return null;
+    let created = null;
+    commitTombstones((prev) => {
+      const existing = prev.find((row) => row.id === entry.id && row.kind === kind) ?? null;
+      created = makeLocalTombstone(kind, entry, existing);
+      return mergeById(prev, [created]);
+    });
+    return created;
+  }, [commitTombstones, makeLocalTombstone]);
+
+  const setTombstoneSyncState = useCallback((entryId, kind, nextSyncState, errorMessage = "") => {
+    commitTombstones((prev) => prev.map((row) => {
+      if (row.id !== entryId || row.kind !== kind) return row;
+      return {
+        ...row,
+        pendingSync: nextSyncState !== SYNC_STATE.SYNCED,
+        syncState: nextSyncState,
+        syncError: nextSyncState === SYNC_STATE.ERROR ? errorMessage : "",
+      };
+    }));
+  }, [commitTombstones]);
+
   const updateCollectionEntry = useCallback((kind, entryId, updater) => {
     const updateItems = (items) => items.map((item) => (item.id === entryId ? updater(item) : item));
     if (kind === "session") {
@@ -301,17 +354,24 @@ export default function PawTimer() {
     const dog = dogs.find((d) => canonicalDogId(d.id) === normalizedId) ?? ensureArray(load(DOGS_KEY, [])).find((d) => canonicalDogId(d.id) === normalizedId);
     if (!dog) { setScreen("select"); return; }
     const local = hydrateDogFromLocal(normalizedId);
+    const hydratedTombstones = normalizeTombstones(local.tombstones).map(withHydratedSyncState);
     const hydratedSessions = sortByDateAsc(normalizeSessions(local.sessions).map(withHydratedSyncState));
     const hydratedWalks = sortByDateAsc(ensureArray(local.walks).map((item) => ({ ...withHydratedSyncState(item), type: normalizeWalkType(item?.type) })));
     const hydratedPatterns = sortByDateAsc(ensureArray(local.patterns).map(withHydratedSyncState));
     const hydratedFeedings = normalizeFeedings(local.feedings).map(withHydratedSyncState);
-    setSessions(hydratedSessions);
-    setWalks(hydratedWalks);
-    setPatterns(hydratedPatterns);
-    setFeedings(hydratedFeedings);
+    setTombstones(hydratedTombstones);
+    setSessions(applyTombstonesToCollection(hydratedSessions, hydratedTombstones, "session"));
+    setWalks(applyTombstonesToCollection(hydratedWalks, hydratedTombstones, "walk"));
+    setPatterns(applyTombstonesToCollection(hydratedPatterns, hydratedTombstones, "pattern"));
+    setFeedings(applyTombstonesToCollection(hydratedFeedings, hydratedTombstones, "feeding"));
     setPatLabels(local.patLabels);
     setDogPhoto(local.photo);
-    recomputeTarget(hydratedSessions, hydratedWalks, hydratedPatterns, dog);
+    recomputeTarget(
+      applyTombstonesToCollection(hydratedSessions, hydratedTombstones, "session"),
+      applyTombstonesToCollection(hydratedWalks, hydratedTombstones, "walk"),
+      applyTombstonesToCollection(hydratedPatterns, hydratedTombstones, "pattern"),
+      dog,
+    );
     setScreen("app");
   }, [activeDogId, dogs, recomputeTarget, withHydratedSyncState]);
 
@@ -337,6 +397,20 @@ export default function PawTimer() {
         return true;
       }
       syncHelpersRef.current.setEntrySyncState(kind, entry.id, SYNC_STATE.ERROR, error || "Push failed");
+      return false;
+    };
+
+    const pushPendingTombstone = async (entry, dogSettings) => {
+      if (!entry?.pendingSync || !entry?.id || !entry?.kind) return true;
+      setTombstoneSyncState(entry.id, entry.kind, SYNC_STATE.SYNCING);
+      const { ok, error } = await syncPushTombstone(canonicalDogId(activeDogId), entry, dogSettings);
+      setSyncDegradation(getSyncDegradationState());
+      if (!live) return ok;
+      if (ok) {
+        setTombstoneSyncState(entry.id, entry.kind, SYNC_STATE.SYNCED);
+        return true;
+      }
+      setTombstoneSyncState(entry.id, entry.kind, SYNC_STATE.ERROR, error || "Delete marker push failed");
       return false;
     };
 
@@ -366,11 +440,32 @@ export default function PawTimer() {
         const remotePatterns = ensureArray(remote.patterns);
         const remoteFeedings = normalizeFeedings(remote.feedings);
 
-        const mergedSessions = syncHelpersRef.current.mergeSyncedCollection(snapshot.sessions, remoteSessions);
-        const mergedWalks = syncHelpersRef.current.mergeSyncedCollection(snapshot.walks, remoteWalks);
-        const mergedPatterns = syncHelpersRef.current.mergeSyncedCollection(snapshot.patterns, remotePatterns);
-        const mergedFeedings = syncHelpersRef.current.mergeSyncedCollection(snapshot.feedings, remoteFeedings);
+        const mergedTombstones = mergeById(
+          normalizeTombstones(snapshot.tombstones).map(withHydratedSyncState),
+          normalizeTombstones(remote.tombstones).map(markRemoteEntryConfirmed),
+        );
+        const mergedSessions = applyTombstonesToCollection(
+          syncHelpersRef.current.mergeSyncedCollection(snapshot.sessions, remoteSessions),
+          mergedTombstones,
+          "session",
+        );
+        const mergedWalks = applyTombstonesToCollection(
+          syncHelpersRef.current.mergeSyncedCollection(snapshot.walks, remoteWalks),
+          mergedTombstones,
+          "walk",
+        );
+        const mergedPatterns = applyTombstonesToCollection(
+          syncHelpersRef.current.mergeSyncedCollection(snapshot.patterns, remotePatterns),
+          mergedTombstones,
+          "pattern",
+        );
+        const mergedFeedings = applyTombstonesToCollection(
+          syncHelpersRef.current.mergeSyncedCollection(snapshot.feedings, remoteFeedings),
+          mergedTombstones,
+          "feeding",
+        );
 
+        commitTombstones(mergedTombstones);
         syncHelpersRef.current.commitSessions(mergedSessions);
         syncHelpersRef.current.commitWalks(mergedWalks);
         syncHelpersRef.current.commitPatterns(mergedPatterns);
@@ -388,6 +483,10 @@ export default function PawTimer() {
         let allPendingFlushed = true;
         for (const { kind, entry } of pendingEntries) {
           const pushed = await pushPendingEntry(kind, entry, dogSettings);
+          allPendingFlushed = allPendingFlushed && pushed;
+        }
+        for (const tombstone of mergedTombstones.filter((entry) => entry.pendingSync)) {
+          const pushed = await pushPendingTombstone(tombstone, dogSettings);
           allPendingFlushed = allPendingFlushed && pushed;
         }
 
@@ -408,7 +507,7 @@ export default function PawTimer() {
     sync();
     const timer = setInterval(sync, 15_000);
     return () => { live = false; syncInFlightRef.current = false; clearInterval(timer); };
-  }, [activeDogId]);
+  }, [activeDogId, commitTombstones, markRemoteEntryConfirmed, setTombstoneSyncState, withHydratedSyncState]);
 
   useEffect(() => {
     if (!SYNC_ENABLED || !activeDogId) return;
@@ -510,12 +609,14 @@ export default function PawTimer() {
     save(walkKey(normalizedId), []);
     save(patKey(normalizedId), []);
     save(feedingKey(normalizedId), []);
+    save(tombKey(normalizedId), []);
     save(patLblKey(normalizedId), {});
     save(photoKey(normalizedId), null);
     setSessions([]);
     setWalks([]);
     setPatterns([]);
     setFeedings([]);
+    setTombstones([]);
     setPatLabels({});
     setDogPhoto(null);
   }, []);
@@ -535,14 +636,21 @@ export default function PawTimer() {
       const joinedWalks = sortByDateAsc(ensureArray(remote.walks).map((item) => markRemoteEntryConfirmed({ ...item, type: normalizeWalkType(item?.type) })));
       const joinedPatterns = sortByDateAsc(ensureArray(remote.patterns).map(markRemoteEntryConfirmed));
       const joinedFeedings = normalizeFeedings(remote.feedings).map(markRemoteEntryConfirmed);
-      setSessions(joinedSessions);
-      setWalks(joinedWalks);
-      setPatterns(joinedPatterns);
-      setFeedings(joinedFeedings);
-      save(sessKey(normalizedId), joinedSessions);
-      save(walkKey(normalizedId), joinedWalks);
-      save(patKey(normalizedId), joinedPatterns);
-      save(feedingKey(normalizedId), joinedFeedings);
+      const joinedTombstones = normalizeTombstones(remote.tombstones).map(markRemoteEntryConfirmed);
+      const visibleJoinedSessions = applyTombstonesToCollection(joinedSessions, joinedTombstones, "session");
+      const visibleJoinedWalks = applyTombstonesToCollection(joinedWalks, joinedTombstones, "walk");
+      const visibleJoinedPatterns = applyTombstonesToCollection(joinedPatterns, joinedTombstones, "pattern");
+      const visibleJoinedFeedings = applyTombstonesToCollection(joinedFeedings, joinedTombstones, "feeding");
+      setTombstones(joinedTombstones);
+      setSessions(visibleJoinedSessions);
+      setWalks(visibleJoinedWalks);
+      setPatterns(visibleJoinedPatterns);
+      setFeedings(visibleJoinedFeedings);
+      save(sessKey(normalizedId), visibleJoinedSessions);
+      save(walkKey(normalizedId), visibleJoinedWalks);
+      save(patKey(normalizedId), visibleJoinedPatterns);
+      save(feedingKey(normalizedId), visibleJoinedFeedings);
+      save(tombKey(normalizedId), joinedTombstones);
       if (error) { setSyncStatus("err"); setSyncError(error); showToast(`Joined ${normalizedId}, but related history failed to load.`); }
       else { setSyncError(""); setSyncStatus("ok"); showToast(`Joined shared profile ${normalizedId}.`); }
       openDog(sharedDog);
@@ -665,7 +773,24 @@ export default function PawTimer() {
   const copyDogId = () => { navigator.clipboard?.writeText(activeDogId).catch(() => {}); showToast(`ID copied: ${activeDogId}`); };
   const handlePhotoUpload = (e) => { const file = e.target.files?.[0]; if (!file) return; const reader = new FileReader(); reader.onload = (ev) => setDogPhoto(ev.target.result); reader.readAsDataURL(file); };
 
-  const historyActions = useHistoryEditing({ sessions, walks, patterns, feedings, patLabels, showToast, pushWithSyncStatus, syncDelete, syncDeleteSessionsForDog, commitSessions, setWalks: commitWalks, setPatterns: commitPatterns, setFeedings: commitFeedings, activeDogId, stampLocalEntry });
+  const historyActions = useHistoryEditing({
+    sessions,
+    walks,
+    patterns,
+    feedings,
+    patLabels,
+    showToast,
+    pushWithSyncStatus,
+    syncDelete,
+    syncDeleteSessionsForDog,
+    addTombstone,
+    commitSessions,
+    setWalks: commitWalks,
+    setPatterns: commitPatterns,
+    setFeedings: commitFeedings,
+    activeDogId,
+    stampLocalEntry,
+  });
 
   useEffect(() => {
     if (!activeDogId) return;

--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -13,6 +13,7 @@ const legacyWalkKey = (id) => `pawtimer_walk_v3_${id}`;
 export const walkKey    = (id) => `pawtimer_walk_v4_${id}`;
 export const feedingKey = (id) => `pawtimer_feed_v1_${id}`;
 export const patKey     = (id) => `pawtimer_pat_v3_${id}`;
+export const tombKey    = (id) => `pawtimer_tomb_v1_${id}`;
 export const patLblKey  = (id) => `pawtimer_patlbl_v3_${id}`;  // custom pattern labels
 export const photoKey   = (id) => `pawtimer_photo_v3_${id}`;   // dog photo (base64)
 
@@ -181,13 +182,22 @@ const getRecordRevision = (item = {}) => {
 };
 
 const getRecordUpdatedAt = (item = {}) => item.updatedAt ?? item.updated_at ?? item.localUpdatedAt ?? item.local_updated_at ?? null;
+const getRecordDeletedAt = (item = {}) => item.deletedAt ?? item.deleted_at ?? null;
 
 export const resolveSyncConflict = (left = {}, right = {}) => {
+  const leftDeletedAt = toTimestamp(getRecordDeletedAt(left));
+  const rightDeletedAt = toTimestamp(getRecordDeletedAt(right));
   const leftRevision = getRecordRevision(left);
   const rightRevision = getRecordRevision(right);
   if (leftRevision !== null && rightRevision !== null && leftRevision !== rightRevision) {
     return leftRevision > rightRevision ? left : right;
   }
+  if (leftDeletedAt || rightDeletedAt) {
+    if (leftDeletedAt !== rightDeletedAt) return leftDeletedAt > rightDeletedAt ? left : right;
+    if (leftDeletedAt && rightDeletedAt) return leftDeletedAt >= rightDeletedAt ? left : right;
+    return leftDeletedAt ? left : right;
+  }
+
 
   const leftUpdatedAt = toTimestamp(getRecordUpdatedAt(left));
   const rightUpdatedAt = toTimestamp(getRecordUpdatedAt(right));
@@ -475,6 +485,45 @@ export const normalizeFeedings = (rows = []) => ensureArray(rows)
   .filter((row) => row.id)
   .sort((a, b) => new Date(a.date) - new Date(b.date));
 
+const normalizeTombstoneKind = (kind) => {
+  if (kind === "session" || kind === "walk" || kind === "pattern" || kind === "feeding") return kind;
+  return null;
+};
+
+export const normalizeTombstones = (rows = []) => ensureArray(rows)
+  .map((row) => ({
+    id: String(row?.id || ""),
+    kind: normalizeTombstoneKind(row?.kind ?? row?.type),
+    deletedAt: row?.deletedAt ?? row?.deleted_at ?? row?.updatedAt ?? row?.updated_at ?? null,
+    revision: normalizeRevision(row?.revision),
+    updatedAt: normalizeUpdatedAt(row),
+    pendingSync: Boolean(row?.pendingSync),
+    syncState: row?.syncState,
+    syncError: row?.syncError ?? "",
+  }))
+  .filter((row) => row.id && row.kind && row.deletedAt)
+  .sort((a, b) => toTimestamp(a.deletedAt) - toTimestamp(b.deletedAt));
+
+const isEntrySuppressedByTombstone = (entry, tombstone) => {
+  if (!entry?.id || !tombstone?.id || entry.id !== tombstone.id) return false;
+  const winner = resolveSyncConflict(
+    { ...entry, deletedAt: null },
+    { ...tombstone, deletedAt: tombstone.deletedAt, date: entry?.date ?? tombstone.deletedAt },
+  );
+  return winner?.deletedAt != null;
+};
+
+export const applyTombstonesToCollection = (items = [], tombstones = [], kind = "") => {
+  const activeTombstones = normalizeTombstones(tombstones).filter((row) => row.kind === kind);
+  if (!activeTombstones.length) return ensureArray(items);
+  const tombstoneById = new Map(activeTombstones.map((row) => [row.id, row]));
+  return ensureArray(items).filter((entry) => {
+    const tombstone = tombstoneById.get(entry?.id);
+    if (!tombstone) return true;
+    return !isEntrySuppressedByTombstone(entry, tombstone);
+  });
+};
+
 export const SESSION_SYNC_FETCH_FIELD_MAP = {
   plannedDuration: "planned_duration",
   actualDuration: "actual_duration",
@@ -497,6 +546,7 @@ export const SESSION_SYNC_FETCH_SELECT = [
   "dog_id",
   "date",
   ...Object.values(SESSION_SYNC_FETCH_FIELD_MAP),
+  "deleted_at",
 ].join(",");
 
 export const WALKS_SYNC_FETCH_SELECT = [
@@ -507,10 +557,11 @@ export const WALKS_SYNC_FETCH_SELECT = [
   "walk_type",
   "revision",
   "updated_at",
+  "deleted_at",
 ].join(",");
 
-export const PATTERNS_SYNC_FETCH_SELECT = "id,dog_id,date,type,revision,updated_at";
-export const FEEDINGS_SYNC_FETCH_SELECT = "id,dog_id,date,food_type,amount,revision,updated_at";
+export const PATTERNS_SYNC_FETCH_SELECT = "id,dog_id,date,type,revision,updated_at,deleted_at";
+export const FEEDINGS_SYNC_FETCH_SELECT = "id,dog_id,date,food_type,amount,revision,updated_at,deleted_at";
 
 const mapSyncFetchSessionRow = (r) => ({
   id: r.id,
@@ -529,6 +580,7 @@ const mapSyncFetchSessionRow = (r) => ({
   environment: r[SESSION_SYNC_FETCH_FIELD_MAP.environment],
   revision: r[SESSION_SYNC_FETCH_FIELD_MAP.revision],
   updatedAt: r[SESSION_SYNC_FETCH_FIELD_MAP.updatedAt],
+  deletedAt: r.deleted_at ?? null,
 });
 
 export const syncFetch = async (dogId) => {
@@ -677,6 +729,12 @@ export const syncFetch = async (dogId) => {
   const walkRows = Array.isArray(walkRes.data) ? walkRes.data : [];
   const patRows = Array.isArray(patRes.data) ? patRes.data : [];
   const feedingRows = Array.isArray(feedingRes.data) ? feedingRes.data : [];
+  const tombstones = normalizeTombstones([
+    ...sessRows.filter((row) => row?.deleted_at).map((row) => ({ id: row.id, kind: "session", deleted_at: row.deleted_at, revision: row.revision, updated_at: row.updated_at })),
+    ...walkRows.filter((row) => row?.deleted_at).map((row) => ({ id: row.id, kind: "walk", deleted_at: row.deleted_at, revision: row.revision, updated_at: row.updated_at })),
+    ...patRows.filter((row) => row?.deleted_at).map((row) => ({ id: row.id, kind: "pattern", deleted_at: row.deleted_at, revision: row.revision, updated_at: row.updated_at })),
+    ...feedingRows.filter((row) => row?.deleted_at).map((row) => ({ id: row.id, kind: "feeding", deleted_at: row.deleted_at, revision: row.revision, updated_at: row.updated_at })),
+  ]);
 
   return {
     error: relatedErrors.length ? `Related data fetch failed (${relatedErrors.join(" | ")})` : null,
@@ -688,8 +746,9 @@ export const syncFetch = async (dogId) => {
             id: canonicalDogId(matchedDog.id),
           }
         : null,
-      sessions: normalizeSessions(sessRows.map(mapSyncFetchSessionRow)),
-      walks: walkRows.map((r) => ({
+      tombstones,
+      sessions: normalizeSessions(sessRows.filter((row) => !row?.deleted_at).map(mapSyncFetchSessionRow)),
+      walks: walkRows.filter((row) => !row?.deleted_at).map((r) => ({
         id: r.id,
         date: r.date,
         duration: r.duration,
@@ -697,14 +756,14 @@ export const syncFetch = async (dogId) => {
         revision: r.revision,
         updatedAt: r.updated_at,
       })),
-      patterns: normalizePatterns(patRows.map((r) => ({
+      patterns: normalizePatterns(patRows.filter((row) => !row?.deleted_at).map((r) => ({
         id: r.id,
         date: r.date,
         type: r.type,
         revision: r.revision,
         updatedAt: r.updated_at,
       }))),
-      feedings: normalizeFeedings(feedingRows.map((r) => ({
+      feedings: normalizeFeedings(feedingRows.filter((row) => !row?.deleted_at).map((r) => ({
         id: r.id,
         date: r.date,
         food_type: r.food_type,
@@ -873,6 +932,28 @@ export const syncDelete = async (kind, id) => {
   return res.ok;
 };
 
+export const syncPushTombstone = async (dogId, tombstone, dogSettings = null) => {
+  const id = canonicalDogId(dogId);
+  const dogReady = await syncUpsertDog(dogSettings && typeof dogSettings === "object" ? { ...dogSettings, id } : { id });
+  if (!dogReady.ok) return { ok: false, error: dogReady.error };
+  const kind = normalizeTombstoneKind(tombstone?.kind);
+  if (!kind || !tombstone?.id || !tombstone?.deletedAt) return { ok: false, error: "Invalid tombstone payload" };
+  const table = kind === "session" ? "sessions" : kind === "walk" ? "walks" : kind === "pattern" ? "patterns" : "feedings";
+  const payload = {
+    id: String(tombstone.id),
+    dog_id: id,
+    deleted_at: tombstone.deletedAt,
+    revision: tombstone.revision ?? null,
+    updated_at: tombstone.updatedAt ?? tombstone.deletedAt,
+  };
+  const res = await sbReq(table, {
+    method: "POST",
+    body: JSON.stringify(payload),
+    prefer: "resolution=merge-duplicates,return=minimal",
+  });
+  return res.ok ? { ok: true, error: null } : { ok: false, error: `${kind} tombstone push failed: ${res.error}` };
+};
+
 export const syncDeleteSessionsForDog = async (dogId) => {
   const res = await sbReq(`sessions?dog_id=eq.${encodeURIComponent(canonicalDogId(dogId))}`, { method: "DELETE" });
   return res.ok;
@@ -896,6 +977,7 @@ export const hydrateDogFromLocal = (dogId) => {
     walks: ensureArray(load(walkKey(id), load(legacyWalkKey(id), []))).map((w) => ({ ...w, type: normalizeWalkType(w?.type) })),
     patterns: normalizePatterns(load(patKey(id), [])),
     feedings: normalizeFeedings(load(feedingKey(id), [])),
+    tombstones: normalizeTombstones(load(tombKey(id), [])),
     patLabels: ensureObject(load(patLblKey(id), {})),
     photo: load(photoKey(id), null),
   };

--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -57,6 +57,7 @@ export function useHistoryEditing({
   pushWithSyncStatus,
   syncDelete,
   syncDeleteSessionsForDog,
+  addTombstone,
   commitSessions,
   setWalks,
   setPatterns,
@@ -179,24 +180,28 @@ export function useHistoryEditing({
     confirmHistoryDelete: (historyModal, setHistoryModal) => {
       if (!historyModal || historyModal.mode !== "delete") return;
       if (historyModal.kind === "session") {
-        commitSessions((prev) => prev.filter((item) => item.id !== historyModal.id));
-        syncDelete("session", historyModal.id).then((ok) => {
-          if (!ok) showToast("Session removed locally — remote delete failed");
+        commitSessions((prev) => {
+          const existing = prev.find((item) => item.id === historyModal.id);
+          if (existing) addTombstone("session", existing);
+          return prev.filter((item) => item.id !== historyModal.id);
         });
       } else if (historyModal.kind === "walk") {
-        setWalks((prev) => prev.filter((item) => item.id !== historyModal.id));
-        syncDelete("walk", historyModal.id).then((ok) => {
-          if (!ok) showToast("Walk removed locally — remote delete failed");
+        setWalks((prev) => {
+          const existing = prev.find((item) => item.id === historyModal.id);
+          if (existing) addTombstone("walk", existing);
+          return prev.filter((item) => item.id !== historyModal.id);
         });
       } else if (historyModal.kind === "pattern") {
-        setPatterns((prev) => prev.filter((item) => item.id !== historyModal.id));
-        syncDelete("pattern", historyModal.id).then((ok) => {
-          if (!ok) showToast("Pattern break removed locally — remote delete failed");
+        setPatterns((prev) => {
+          const existing = prev.find((item) => item.id === historyModal.id);
+          if (existing) addTombstone("pattern", existing);
+          return prev.filter((item) => item.id !== historyModal.id);
         });
       } else if (historyModal.kind === "feeding") {
-        setFeedings((prev) => prev.filter((item) => item.id !== historyModal.id));
-        syncDelete("feeding", historyModal.id).then((ok) => {
-          if (!ok) showToast("Feeding removed locally — remote delete failed");
+        setFeedings((prev) => {
+          const existing = prev.find((item) => item.id === historyModal.id);
+          if (existing) addTombstone("feeding", existing);
+          return prev.filter((item) => item.id !== historyModal.id);
         });
       }
       showToast(`${historyModal.label} deleted`);
@@ -204,11 +209,12 @@ export function useHistoryEditing({
     },
     clearSessions: () => {
       if (window.confirm("Clear all training sessions?")) {
-        commitSessions([]);
-        syncDeleteSessionsForDog(activeDogId).then((ok) => {
-          if (!ok) showToast("Sessions cleared locally — remote delete failed");
-          else showToast("Sessions cleared");
+        commitSessions((prev) => {
+          prev.forEach((entry) => addTombstone("session", entry));
+          return [];
         });
+        syncDeleteSessionsForDog(activeDogId).then(() => {});
+        showToast("Sessions cleared");
       }
     },
   };

--- a/tests/historyDeleteMutations.test.js
+++ b/tests/historyDeleteMutations.test.js
@@ -25,6 +25,7 @@ const buildDeleteActions = ({
   commitPatterns,
   commitFeedings,
   syncDelete = vi.fn(() => Promise.resolve(true)),
+  addTombstone = vi.fn(),
   showToast = vi.fn(),
 } = {}) => {
   const actions = useHistoryEditing({
@@ -37,6 +38,7 @@ const buildDeleteActions = ({
     pushWithSyncStatus: vi.fn(() => Promise.resolve({ ok: true })),
     syncDelete,
     syncDeleteSessionsForDog: vi.fn(() => Promise.resolve(true)),
+    addTombstone,
     commitSessions: commitSessions ?? vi.fn(),
     setWalks: commitWalks ?? vi.fn(),
     setPatterns: commitPatterns ?? vi.fn(),
@@ -49,6 +51,7 @@ const buildDeleteActions = ({
     actions,
     showToast,
     syncDelete,
+    addTombstone,
     commitSessions: commitSessions ?? vi.fn(),
     commitWalks: commitWalks ?? vi.fn(),
     commitPatterns: commitPatterns ?? vi.fn(),
@@ -57,9 +60,33 @@ const buildDeleteActions = ({
 };
 
 describe("history delete mutations", () => {
+  it("creates tombstones for every session during bulk clear", () => {
+    const commitSessions = vi.fn();
+    const addTombstone = vi.fn();
+    const originalWindow = globalThis.window;
+    globalThis.window = { confirm: vi.fn(() => true) };
+    const { actions } = buildDeleteActions({
+      sessions: [
+        { ...baseSession, id: "sess-1" },
+        { ...baseSession, id: "sess-2", date: makeIso("2026-04-11T10:00:00Z") },
+      ],
+      commitSessions,
+      addTombstone,
+    });
+
+    actions.clearSessions();
+
+    const clearUpdater = commitSessions.mock.calls[0][0];
+    expect(clearUpdater([{ ...baseSession, id: "sess-1" }, { ...baseSession, id: "sess-2" }])).toEqual([]);
+    expect(addTombstone).toHaveBeenCalledTimes(2);
+    expect(addTombstone.mock.calls.map((call) => call[0])).toEqual(["session", "session"]);
+    globalThis.window = originalWindow;
+  });
+
   it("applies session deletes against latest state after another local mutation", () => {
     const commitSessions = vi.fn();
-    const { actions } = buildDeleteActions({ commitSessions });
+    const addTombstone = vi.fn();
+    const { actions } = buildDeleteActions({ commitSessions, addTombstone });
 
     actions.confirmHistoryDelete({ mode: "delete", kind: "session", id: "sess-1", label: "Training session" }, vi.fn());
 
@@ -83,13 +110,15 @@ describe("history delete mutations", () => {
     const afterDelete = deleteUpdater(stateWithInterveningLocalMutation);
     expect(afterDelete.map((session) => session.id)).toEqual(["sess-2"]);
     expect(afterDelete[0].actualDuration).toBe(145);
+    expect(addTombstone).toHaveBeenCalledWith("session", expect.objectContaining({ id: "sess-1" }));
   });
 
   it("preserves sync-sensitive state changes when deleting walks, patterns, and feedings", () => {
     const commitWalks = vi.fn();
     const commitPatterns = vi.fn();
     const commitFeedings = vi.fn();
-    const { actions } = buildDeleteActions({ commitWalks, commitPatterns, commitFeedings });
+    const addTombstone = vi.fn();
+    const { actions } = buildDeleteActions({ commitWalks, commitPatterns, commitFeedings, addTombstone });
 
     actions.confirmHistoryDelete({ mode: "delete", kind: "walk", id: "walk-1", label: "Exercise walk" }, vi.fn());
     actions.confirmHistoryDelete({ mode: "delete", kind: "pattern", id: "pat-1", label: "Phone trigger" }, vi.fn());
@@ -122,6 +151,8 @@ describe("history delete mutations", () => {
     expect(afterFeedingDelete).toEqual([
       { id: "feed-2", date: makeIso("2026-04-10T13:30:00Z"), foodType: "snack", amount: "tiny", revision: 5, syncState: "syncing", pendingSync: true },
     ]);
+    expect(addTombstone).toHaveBeenCalledTimes(3);
+    expect(addTombstone.mock.calls.map((call) => call[0])).toEqual(["walk", "pattern", "feeding"]);
   });
 
   it("retains non-deleted intervening changes and keeps recommendation recompute inputs correct", () => {

--- a/tests/syncConflict.test.js
+++ b/tests/syncConflict.test.js
@@ -17,6 +17,20 @@ describe("resolveSyncConflict", () => {
 
     expect(resolveSyncConflict(local, remote)).toBe(remote);
   });
+
+  it("prefers deletion tombstones over stale updates", () => {
+    const localDelete = { id: "session-1", revision: 6, updatedAt: iso(12), deletedAt: iso(12) };
+    const remoteActive = { id: "session-1", revision: 5, updatedAt: iso(13), result: "success" };
+
+    expect(resolveSyncConflict(localDelete, remoteActive)).toBe(localDelete);
+  });
+
+  it("allows newer updates to win against older tombstones", () => {
+    const localDelete = { id: "session-1", revision: 4, updatedAt: iso(10), deletedAt: iso(10) };
+    const remoteActive = { id: "session-1", revision: 5, updatedAt: iso(11), result: "success" };
+
+    expect(resolveSyncConflict(localDelete, remoteActive)).toBe(remoteActive);
+  });
 });
 
 describe("mergeById concurrent edits", () => {

--- a/tests/syncFetchRuntime.test.js
+++ b/tests/syncFetchRuntime.test.js
@@ -215,4 +215,64 @@ describe("syncFetch runtime fallbacks", () => {
     expect(result.sessions[0].distressLevel).toBe("severe");
     expect(result.sessions[0].distressType).toBe("vocalization");
   });
+
+  it("excludes deleted rows from active payload and returns tombstones", async () => {
+    global.fetch = vi.fn(async (url) => {
+      const { path } = getPathAndParams(url);
+      if (path === "dogs") return jsonResponse(200, [{ id: "DOG5", settings: { dogName: "Poppy" } }]);
+      if (path === "sessions") {
+        return jsonResponse(200, [
+          { id: "s-active", dog_id: "DOG5", date: "2026-04-01T00:00:00.000Z", planned_duration: 120, actual_duration: 120, distress_level: "none", result: "success", revision: 2, updated_at: "2026-04-01T01:00:00.000Z" },
+          { id: "s-deleted", dog_id: "DOG5", date: "2026-04-01T00:00:00.000Z", planned_duration: 120, actual_duration: 50, distress_level: "subtle", result: "distress", revision: 3, updated_at: "2026-04-01T03:00:00.000Z", deleted_at: "2026-04-01T03:00:00.000Z" },
+        ]);
+      }
+      if (path === "walks") return jsonResponse(200, []);
+      if (path === "patterns") return jsonResponse(200, []);
+      if (path === "feedings") return jsonResponse(200, []);
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const { syncFetch } = await setupStorageModule();
+    const { result, error } = await syncFetch("DOG5");
+    expect(error).toBeNull();
+    expect(result.sessions.map((row) => row.id)).toEqual(["s-active"]);
+    expect(result.tombstones).toEqual([
+      expect.objectContaining({ id: "s-deleted", kind: "session", deletedAt: "2026-04-01T03:00:00.000Z" }),
+    ]);
+  });
+
+  it("syncPushTombstone sends deletion markers to remote rows", async () => {
+    const postedBodies = [];
+    global.fetch = vi.fn(async (url, options = {}) => {
+      const { path } = getPathAndParams(url);
+      if (path === "dogs") return jsonResponse(201, {});
+      if (path === "sessions" && (options.method || "GET") === "POST") {
+        postedBodies.push(JSON.parse(options.body || "{}"));
+        return jsonResponse(201, {});
+      }
+      if (path === "sessions") return jsonResponse(200, []);
+      if (path === "walks") return jsonResponse(200, []);
+      if (path === "patterns") return jsonResponse(200, []);
+      if (path === "feedings") return jsonResponse(200, []);
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const { syncPushTombstone } = await setupStorageModule();
+    const result = await syncPushTombstone("DOG6", {
+      id: "session-dead",
+      kind: "session",
+      deletedAt: "2026-04-02T10:00:00.000Z",
+      updatedAt: "2026-04-02T10:00:00.000Z",
+      revision: 9,
+    }, { id: "DOG6", dogName: "June" });
+
+    expect(result.ok).toBe(true);
+    expect(postedBodies).toHaveLength(1);
+    expect(postedBodies[0]).toMatchObject({
+      id: "session-dead",
+      dog_id: "DOG6",
+      deleted_at: "2026-04-02T10:00:00.000Z",
+      revision: 9,
+    });
+  });
 });


### PR DESCRIPTION
### Motivation
- Deleted history items (sessions, walks, patterns, feedings) were removed locally but not represented in sync state, allowing stale remote records to resurrect deletions during later merges. 
- Deletions must be durable and part of the source-of-truth without changing merge-by-id semantics. 

### Description
- Add a tombstone model and local persistence key (`tombKey`) and normalizers (`normalizeTombstones`) to represent deletions as `{ id, kind, deletedAt, revision, updatedAt, ... }` instead of only hard removals. 
- Implement collection-level suppression with `applyTombstonesToCollection` and `isEntrySuppressedByTombstone` so tombstones filter active datasets without breaking `mergeById`. 
- Extend conflict resolution in `resolveSyncConflict` to consider `deletedAt` so newer tombstones beat stale remote updates while newer remote updates can still win. 
- Extend `syncFetch` to request `deleted_at`, emit a `tombstones` payload, and exclude deleted rows from the active result arrays. 
- Add `syncPushTombstone` to push deletion markers (`deleted_at`, `revision`, `updated_at`) to remote rows and wire the app to persist, merge, and push tombstones (`tombstones` state, `commitTombstones`, `addTombstone`, tombstone push loop). 
- Update history delete and bulk-clear flows to create local tombstones (`addTombstone`) when items are deleted so deletes remain durable even if remote DELETE fails. 

### Testing
- Ran the targeted test suite with `npm test -- --run tests/syncConflict.test.js tests/syncFetchRuntime.test.js tests/historyDeleteMutations.test.js`, covering conflict rules, fetch/push tombstone behavior, and delete mutation logic. 
- All tests passed: `3 test files` / `20 tests` ran and succeeded (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9648a42c8332b5ce80ddc9e1c371)