### PR TITLE
Align plateau recommendation type with numeric target (increase vs hold)

### DIFF
--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -1102,7 +1102,7 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
       : microIncrease;
     return {
       recommendedDuration: clamp(adjustedForGap, PROTOCOL.minDurationSeconds, goalSeconds),
-      recommendationType: 'keep_same_duration',
+      recommendationType: adjustedForGap > lastReferenceDuration ? 'increase_duration' : 'keep_same_duration',
       recoveryMode: {
         active: false,
         remainingSessions: 0,
@@ -1134,7 +1134,7 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
 
   return {
     recommendedDuration: clamp(smoothed, PROTOCOL.minDurationSeconds, goalSeconds),
-    recommendationType: 'keep_same_duration',
+    recommendationType: smoothed > lastReferenceDuration ? 'increase_duration' : 'keep_same_duration',
     recoveryMode: {
       active: false,
       remainingSessions: 0,
@@ -1217,7 +1217,9 @@ function describeRecommendationType(type) {
     case "recovery_mode_resume":
       return "Calm recovery sessions were completed, so progression resumes at a cautious step below the prior anchor.";
     case "keep_same_duration":
-      return "The next target keeps a steady progression from your recent calm baseline.";
+      return "The next target holds at your current safe training duration.";
+    case "increase_duration":
+      return "The next target nudges upward after calm threshold-confirmed sessions.";
     default:
       return "The next target is adjusted from the current safe-alone estimate.";
   }
@@ -1247,6 +1249,11 @@ function buildRecommendationExplanation({
       return "Recovery sessions went well, so we are carefully stepping back up.";
     case "departure_cues_first":
       return "Holding duration while cue practice catches up.";
+    case "increase_duration":
+      if (prev > 0 && next > prev && changePct > 0) {
+        return `Increased by ${changePct}% after ${calmLabel}.`;
+      }
+      return "Stepping up cautiously after calm threshold-confirmed sessions.";
     case "keep_same_duration":
     case "repeat_current_duration":
       if (prev > 0 && next > prev && changePct > 0) {

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -210,7 +210,7 @@ describe("recommendation engine", () => {
 
     const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
     expect(rec.recommendedDuration).toBe(57);
-    expect(rec.recommendationType).toBe("keep_same_duration");
+    expect(rec.recommendationType).toBe("increase_duration");
   });
 
   it("does not let older short sessions drag recommendation near minimum", () => {
@@ -270,7 +270,7 @@ describe("recommendation engine", () => {
     ];
     const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
     expect(rec.recommendedDuration).toBeGreaterThan(900);
-    expect(rec.recommendationType).toBe("keep_same_duration");
+    expect(rec.recommendationType).toBe("increase_duration");
   });
 
   it("holds on repeated near-threshold calm sessions", () => {
@@ -303,7 +303,7 @@ describe("recommendation engine", () => {
     ];
     const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
     expect(rec.recommendedDuration).toBeGreaterThan(900);
-    expect(rec.recommendationType).toBe("keep_same_duration");
+    expect(rec.recommendationType).toBe("increase_duration");
   });
 
   it("still falls back to recovery mode for distress sessions", () => {
@@ -377,7 +377,7 @@ describe("recommendation engine", () => {
     expect(rec.recoveryMode.active).toBe(true);
   });
 
-  it("allows a small increase after five-session plateau", () => {
+  it("uses non-hold recommendation type for a small increase after five-session plateau", () => {
     const sessions = [
       { date: daysAgo(4), plannedDuration: 600, actualDuration: 600, distressLevel: "none", belowThreshold: true },
       { date: daysAgo(3), plannedDuration: 600, actualDuration: 600, distressLevel: "none", belowThreshold: true },
@@ -387,6 +387,19 @@ describe("recommendation engine", () => {
     ];
     const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
     expect(rec.recommendedDuration).toBe(630);
+    expect(rec.recommendationType).toBe("increase_duration");
+    expect(rec.recommendationType).not.toBe("keep_same_duration");
+  });
+
+  it("keeps exact duration and hold type in near-threshold plateau hold branch", () => {
+    const sessions = [
+      { date: daysAgo(2), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(1), plannedDuration: 900, actualDuration: 855, distressLevel: "none", belowThreshold: false },
+      { date: hoursAgo(1), plannedDuration: 900, actualDuration: 855, distressLevel: "none", belowThreshold: false },
+    ];
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recommendedDuration).toBe(900);
+    expect(rec.recommendationType).toBe("keep_same_duration");
   });
 
   it("applies deterministic high/medium/low risk step multipliers in computeNextTarget", () => {
@@ -652,7 +665,7 @@ describe("recommendation engine", () => {
       { id: "c2", date: daysAgo(0), plannedDuration: 760, actualDuration: 760, distressLevel: "none", belowThreshold: true },
     ];
     const rec = buildRecommendation(sessions, { goalSeconds: 3600, recoveryState: staleRecoveryState });
-    expect(rec.recommendationType).toBe("keep_same_duration");
+    expect(rec.recommendationType).toBe("increase_duration");
     expect(rec.recoveryMode.active).toBe(false);
     expect(rec.recoveryState?.active).toBe(false);
     expect(rec.recoveryState?.triggerSessionId).toBe(null);
@@ -684,10 +697,17 @@ describe("public compatibility APIs", () => {
     expect(noHistory.recommendationType).toBe("baseline_start");
 
     const keepSameDuration = explainNextTarget([
-      { date: daysAgo(1), plannedDuration: 70, actualDuration: 70, distressLevel: "none", belowThreshold: true },
-      { date: daysAgo(0), plannedDuration: 72, actualDuration: 72, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(1), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(0), plannedDuration: 900, actualDuration: 300, distressLevel: "none", belowThreshold: false },
     ], [], [], { goalSeconds: 3600 });
     expect(keepSameDuration.recommendationType).toBe("keep_same_duration");
+
+    const increaseDuration = explainNextTarget([
+      { date: daysAgo(2), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(1), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(0), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
+    ], [], [], { goalSeconds: 3600 });
+    expect(increaseDuration.recommendationType).toBe("increase_duration");
 
     const repeatCurrent = explainNextTarget([
       { date: daysAgo(2), plannedDuration: 300, actualDuration: 120, distressLevel: "none", belowThreshold: false },
@@ -718,11 +738,12 @@ describe("public compatibility APIs", () => {
     ], { goalSeconds: 3600 });
     expect(cueFirst.recommendationType).toBe("departure_cues_first");
 
-    const results = [noHistory, keepSameDuration, repeatCurrent, recoveryActive, recoveryResume, cueFirst];
+    const results = [noHistory, keepSameDuration, increaseDuration, repeatCurrent, recoveryActive, recoveryResume, cueFirst];
     const emittedTypes = new Set(results.map((result) => result.recommendationType));
     expect(emittedTypes).toEqual(new Set([
       "baseline_start",
       "keep_same_duration",
+      "increase_duration",
       "repeat_current_duration",
       "recovery_mode_active",
       "recovery_mode_resume",


### PR DESCRIPTION
### Motivation
- The 5-session plateau path computed a small numeric micro-increase (~+5%) but still emitted `recommendationType: "keep_same_duration"`, creating a semantic mismatch between the type and the numeric target. 
- The goal is to make recommendation semantics internally consistent so downstream consumers can trust `recommendationType` to reflect numeric direction while preserving near-threshold and recovery protections.

### Description
- In `src/lib/protocol.js` the plateau micro-increase branch now emits `recommendationType: 'increase_duration'` when the computed numeric target is strictly greater than the last reference duration, otherwise it emits `keep_same_duration`.
- The final calm progression return path was aligned the same way so any true numeric increase uses `increase_duration` while holds remain `keep_same_duration`.
- Added `increase_duration` handling to `describeRecommendationType` and `buildRecommendationExplanation` so summary/explanation text matches the new semantic.
- Updated `tests/protocol.test.js` to expect `increase_duration` for true increases, added an explicit plateau test asserting the +5% micro-increase is not labeled as a hold, and added a near-threshold hold test ensuring exact held durations still emit `keep_same_duration`.

### Testing
- Ran `npm test -- tests/protocol.test.js` and the file's full suite passed (`74 tests` passed). 
- Ran `npm test -- tests/activityLogMaterialization.test.js` and that file's tests passed (`4 tests` passed). 
- Verified the changes only affect progression/increase vs hold semantics and that recovery and near-threshold protections remain intact by the updated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfad8c3db48332bc6182cd3e16fe22)