### PR TITLE
Fix sync fetch shape tests to include deleted_at

### DIFF
--- a/tests/syncFetchShape.test.js
+++ b/tests/syncFetchShape.test.js
@@ -10,7 +10,7 @@ import {
 describe("syncFetch sessions projection shape", () => {
   it("projection exactly matches mapped session fields", () => {
     const selectedFields = SESSION_SYNC_FETCH_SELECT.split(",").map((field) => field.trim());
-    const expectedFields = ["id", "dog_id", "date", ...Object.values(SESSION_SYNC_FETCH_FIELD_MAP)];
+    const expectedFields = ["id", "dog_id", "date", ...Object.values(SESSION_SYNC_FETCH_FIELD_MAP), "deleted_at"];
 
     expect(new Set(selectedFields).size).toBe(selectedFields.length);
     expect([...selectedFields].sort()).toEqual([...expectedFields].sort());
@@ -18,7 +18,7 @@ describe("syncFetch sessions projection shape", () => {
 
   it("walk projection includes sync merge metadata", () => {
     const selectedFields = WALKS_SYNC_FETCH_SELECT.split(",").map((field) => field.trim());
-    const expectedFields = ["id", "dog_id", "date", "duration", "walk_type", "revision", "updated_at"];
+    const expectedFields = ["id", "dog_id", "date", "duration", "walk_type", "revision", "updated_at", "deleted_at"];
 
     expect(new Set(selectedFields).size).toBe(selectedFields.length);
     expect([...selectedFields].sort()).toEqual([...expectedFields].sort());
@@ -29,9 +29,9 @@ describe("syncFetch sessions projection shape", () => {
     const feedingFields = FEEDINGS_SYNC_FETCH_SELECT.split(",").map((field) => field.trim());
 
     expect(new Set(patternFields).size).toBe(patternFields.length);
-    expect(patternFields).toEqual(["id", "dog_id", "date", "type", "revision", "updated_at"]);
+    expect(patternFields).toEqual(["id", "dog_id", "date", "type", "revision", "updated_at", "deleted_at"]);
 
     expect(new Set(feedingFields).size).toBe(feedingFields.length);
-    expect(feedingFields).toEqual(["id", "dog_id", "date", "food_type", "amount", "revision", "updated_at"]);
+    expect(feedingFields).toEqual(["id", "dog_id", "date", "food_type", "amount", "revision", "updated_at", "deleted_at"]);
   });
 });


### PR DESCRIPTION
### Motivation
- The runtime sync fetch selectors for `sessions`, `walks`, `patterns`, and `feedings` include `deleted_at` for tombstone-aware sync merging, but the shape tests were asserting the older selectors and therefore had stale contract expectations.

### Description
- Updated `tests/syncFetchShape.test.js` to include `deleted_at` in the expected session projection fields and to assert `deleted_at` is present for `walks`, `patterns`, and `feedings` projections; no runtime code was changed.
- The change aligns test expectations with the actual selector constants in `src/features/app/storage.js` (`SESSION_SYNC_FETCH_SELECT`, `WALKS_SYNC_FETCH_SELECT`, `PATTERNS_SYNC_FETCH_SELECT`, `FEEDINGS_SYNC_FETCH_SELECT`).

### Testing
- Ran `npm test -- tests/syncFetchShape.test.js tests/syncFetchRuntime.test.js` and all tests passed (2 test files, 10 tests total passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb107a0cc8332984c3f13bcb1a41f)