### PR TITLE
Keep bulk clear routed through tombstone-based sync (avoid hard remote delete)

### DIFF
--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -213,7 +213,6 @@ export function useHistoryEditing({
           prev.forEach((entry) => addTombstone("session", entry));
           return [];
         });
-        syncDeleteSessionsForDog(activeDogId).then(() => {});
         showToast("Sessions cleared");
       }
     },

--- a/tests/historyDeleteMutations.test.js
+++ b/tests/historyDeleteMutations.test.js
@@ -25,6 +25,7 @@ const buildDeleteActions = ({
   commitPatterns,
   commitFeedings,
   syncDelete = vi.fn(() => Promise.resolve(true)),
+  syncDeleteSessionsForDog = vi.fn(() => Promise.resolve(true)),
   addTombstone = vi.fn(),
   showToast = vi.fn(),
 } = {}) => {
@@ -37,7 +38,7 @@ const buildDeleteActions = ({
     showToast,
     pushWithSyncStatus: vi.fn(() => Promise.resolve({ ok: true })),
     syncDelete,
-    syncDeleteSessionsForDog: vi.fn(() => Promise.resolve(true)),
+    syncDeleteSessionsForDog,
     addTombstone,
     commitSessions: commitSessions ?? vi.fn(),
     setWalks: commitWalks ?? vi.fn(),
@@ -51,6 +52,7 @@ const buildDeleteActions = ({
     actions,
     showToast,
     syncDelete,
+    syncDeleteSessionsForDog,
     addTombstone,
     commitSessions: commitSessions ?? vi.fn(),
     commitWalks: commitWalks ?? vi.fn(),
@@ -63,6 +65,7 @@ describe("history delete mutations", () => {
   it("creates tombstones for every session during bulk clear", () => {
     const commitSessions = vi.fn();
     const addTombstone = vi.fn();
+    const syncDeleteSessionsForDog = vi.fn(() => Promise.resolve(true));
     const originalWindow = globalThis.window;
     globalThis.window = { confirm: vi.fn(() => true) };
     const { actions } = buildDeleteActions({
@@ -72,6 +75,7 @@ describe("history delete mutations", () => {
       ],
       commitSessions,
       addTombstone,
+      syncDeleteSessionsForDog,
     });
 
     actions.clearSessions();
@@ -80,6 +84,7 @@ describe("history delete mutations", () => {
     expect(clearUpdater([{ ...baseSession, id: "sess-1" }, { ...baseSession, id: "sess-2" }])).toEqual([]);
     expect(addTombstone).toHaveBeenCalledTimes(2);
     expect(addTombstone.mock.calls.map((call) => call[0])).toEqual(["session", "session"]);
+    expect(syncDeleteSessionsForDog).not.toHaveBeenCalled();
     globalThis.window = originalWindow;
   });
 


### PR DESCRIPTION
### Motivation
- Bulk-clearing sessions was bypassing the tombstone-based sync pipeline by calling a hard remote delete, which could break durable-delete semantics and desynchronize deletes across devices.

### Description
- Remove the direct `syncDeleteSessionsForDog(activeDogId)` call from `clearSessions` in `useHistoryEditing` so bulk clears only create local tombstones and let the existing tombstone push/retry pipeline handle remote deletion.
- Update `tests/historyDeleteMutations.test.js` to inject `syncDeleteSessionsForDog` and assert that bulk clear does not call the legacy hard-delete API while still creating tombstones for each session.
- Changes touched `src/features/history/HistoryFeature.jsx` (remove direct delete) and `tests/historyDeleteMutations.test.js` (test adjustments).

### Testing
- `npm test -- --runInBand` was attempted but failed due to an invalid Vitest CLI flag (expected failure in this environment).
- `npm test -- tests/historyDeleteMutations.test.js` passed (4 tests) and verified the new behavior that bulk clear creates tombstones and does not call hard-delete.
- `npm test` (full suite) passed with all test files green (12 files, 138 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb304d8708332b92ec948d91f69d1)