### PR TITLE
Fix PT-LOGIC-001: ensure distress always overrides belowThreshold evidence

### DIFF
--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -130,13 +130,6 @@ export function inferBelowThreshold(session = {}) {
     return null;
   };
 
-  const explicit = toExplicitBool(
-    session?.belowThreshold
-    ?? session?.below_threshold
-    ?? session?.stayedBelowThreshold,
-  );
-  if (explicit != null) return explicit;
-
   const distress = normalizeDistressLevel(
     session?.distressLevel
     ?? session?.distress_level
@@ -144,6 +137,13 @@ export function inferBelowThreshold(session = {}) {
     ?? session?.distress_severity,
   );
   if (distress !== DISTRESS_LEVELS.NONE) return false;
+
+  const explicit = toExplicitBool(
+    session?.belowThreshold
+    ?? session?.below_threshold
+    ?? session?.stayedBelowThreshold,
+  );
+  if (explicit != null) return explicit;
 
   const actual = Number(session?.actualDuration);
   const planned = Number(session?.plannedDuration);
@@ -154,6 +154,13 @@ export function inferBelowThreshold(session = {}) {
 function getLatestSessions(sessions, count) {
   if (!Array.isArray(sessions)) return [];
   return sessions.slice(-count);
+}
+
+function isCalmBelowThreshold(session = {}) {
+  return (
+    normalizeDistressLevel(session?.distressLevel) === DISTRESS_LEVELS.NONE
+    && session?.belowThreshold === true
+  );
 }
 
 const sortByDateAsc = (sessions = []) => sortByDateAscShared(sessions, { invalidPolicy: "drop" });
@@ -294,7 +301,9 @@ function toRichSession(session = {}) {
     actualDuration: actual,
     plannedDuration: hasReliablePlan ? planned : null,
   });
-  const belowThreshold = hasReliablePlan ? inferredBelowThreshold : false;
+  const belowThreshold = (hasReliablePlan && level === DISTRESS_LEVELS.NONE)
+    ? inferredBelowThreshold
+    : false;
   const progressionActualDuration = hasReliablePlan
     ? actual
     : Math.min(actual, PROTOCOL.startDurationSeconds);
@@ -342,7 +351,7 @@ function computeSafeAloneTime(sessions = []) {
   const nowTime = Date.now();
   const recentWindow = getLatestSessions(sorted, PROTOCOL.confidenceSessionWindow);
   const calmBelowThreshold = recentWindow
-    .filter((s) => s.belowThreshold)
+    .filter((s) => isCalmBelowThreshold(s))
     .map((s) => {
       const ageDays = Math.max(0, (nowTime - (toTimestamp(s.date) ?? nowTime)) / DAY_MS);
       let recencyWeight = 0.1;
@@ -394,7 +403,7 @@ function computeStability(sessions = []) {
   const recent = getLatestSessions(sessions.map(toRichSession), PROTOCOL.calmWindow);
   if (!recent.length) return 0;
 
-  const calmConsistency = recent.filter((s) => s.belowThreshold).length / recent.length;
+  const calmConsistency = recent.filter((s) => isCalmBelowThreshold(s)).length / recent.length;
   const subtlePenalty = recent.filter((s) => s.distressLevel === DISTRESS_LEVELS.SUBTLE).length / recent.length;
   const severePenalty = recent.filter((s) => [DISTRESS_LEVELS.ACTIVE, DISTRESS_LEVELS.SEVERE].includes(s.distressLevel)).length / recent.length;
   const completion = recent.reduce((sum, s) => sum + ratio(s.actualDuration, s.plannedDuration), 0) / recent.length;
@@ -491,7 +500,7 @@ export function calculateTrainingStats(sessions = [], options = {}) {
   const safeAloneTime = computeSafeAloneTime(trainingSessions);
 
   const calmRate = trainingSessions.length
-    ? trainingSessions.filter((s) => s.belowThreshold).length / trainingSessions.length
+    ? trainingSessions.filter((s) => isCalmBelowThreshold(s)).length / trainingSessions.length
     : 0;
   const subtleRate = trainingSessions.length
     ? trainingSessions.filter((s) => s.distressLevel === DISTRESS_LEVELS.SUBTLE).length / trainingSessions.length
@@ -1345,7 +1354,7 @@ export function explainNextTarget(sessions = [], walks = [], patterns = [], dog 
     }
   }
 
-  const calmStreak = countStreak(trainingSessions, (session) => session.belowThreshold);
+  const calmStreak = countStreak(trainingSessions, (session) => isCalmBelowThreshold(session));
   const factors = [
     `Safe-alone estimate: ${Math.round(recommendation.stats.safeAloneTime)} sec, weighted toward recent calm sessions.`,
     `Last training result: ${lastTraining ? normalizeDistressLevel(lastTraining.distressLevel) : "none"}.`,

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -64,6 +64,21 @@ describe("below-threshold inference", () => {
     })).toBe(true);
   });
 
+  it("never treats distressed sessions as below-threshold even with explicit true", () => {
+    expect(inferBelowThreshold({
+      distressLevel: "active",
+      plannedDuration: 600,
+      actualDuration: 590,
+      belowThreshold: true,
+    })).toBe(false);
+    expect(inferBelowThreshold({
+      distressLevel: "severe",
+      plannedDuration: 600,
+      actualDuration: 600,
+      belowThreshold: "true",
+    })).toBe(false);
+  });
+
   it("accepts supported canonical explicit string values", () => {
     expect(inferBelowThreshold({
       distressLevel: "none",
@@ -140,6 +155,19 @@ describe("training stats", () => {
     ];
     const stats = calculateTrainingStats(sessions);
     expect(stats.safeAloneTime).toBeGreaterThanOrEqual(40);
+  });
+
+  it("does not let distressed sessions with contradictory below-threshold flags inflate safe-alone time", () => {
+    const calmOnly = calculateTrainingStats([
+      { date: daysAgo(1), plannedDuration: 300, actualDuration: 300, distressLevel: "none", belowThreshold: true },
+    ]);
+    const withContradictoryDistress = calculateTrainingStats([
+      { date: daysAgo(1), plannedDuration: 300, actualDuration: 300, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(0), plannedDuration: 1200, actualDuration: 1200, distressLevel: "active", belowThreshold: true },
+    ]);
+
+    expect(withContradictoryDistress.safeAloneTime).toBeLessThanOrEqual(calmOnly.safeAloneTime);
+    expect(withContradictoryDistress.calmSessionRate).toBeLessThan(calmOnly.calmSessionRate);
   });
 
   it("raises relapse risk after recent severe and uncontrolled real-life absence", () => {

--- a/tests/storageNormalization.test.js
+++ b/tests/storageNormalization.test.js
@@ -134,4 +134,38 @@ describe("storage normalization", () => {
     expect(trueSession.belowThreshold).toBe(true);
     expect(falseSession.belowThreshold).toBe(false);
   });
+
+  it("overrides explicit below-threshold truthy flags when distress is present", () => {
+    const activeSession = normalizeSession({
+      id: "s-active-contradict",
+      plannedDuration: 120,
+      actualDuration: 120,
+      distressLevel: "active",
+      below_threshold: true,
+    });
+    const severeSession = normalizeSession({
+      id: "s-severe-contradict",
+      plannedDuration: 120,
+      actualDuration: 120,
+      distress_level: "severe",
+      belowThreshold: "true",
+    });
+
+    expect(activeSession.belowThreshold).toBe(false);
+    expect(severeSession.belowThreshold).toBe(false);
+  });
+
+  it("forces contradictory legacy rows to non-below-threshold when distress metadata indicates stress", () => {
+    const legacyContradictory = normalizeSession({
+      id: "s-legacy-contradict",
+      result: "success",
+      distress_level: "strong",
+      plannedDuration: 180,
+      actualDuration: 180,
+      below_threshold: 1,
+    });
+
+    expect(legacyContradictory.distressLevel).toBe("active");
+    expect(legacyContradictory.belowThreshold).toBe(false);
+  });
 });


### PR DESCRIPTION
### Motivation
- Distressed sessions with explicit `belowThreshold: true` were being accepted as calm evidence because `inferBelowThreshold` considered explicit flags before validating `distressLevel`. 
- This allowed corrupted/legacy rows to inflate safe-alone estimates and progression metrics, violating the invariant that below-threshold represents calm successful evidence only.

### Description
- Reordered `inferBelowThreshold` so `distressLevel` is normalized and checked first, returning `false` immediately for any non-`none` distress before honoring explicit `belowThreshold` values.
- Added `isCalmBelowThreshold(session)` helper to canonically represent calm evidence as `distressLevel === "none" && belowThreshold === true` and used it where calm evidence is consumed.
- Hardened mapping in `toRichSession` so `belowThreshold` is only possible when the session is calm (`distressLevel === "none"`) and `hasReliablePlan` is true.
- Replaced direct `s.belowThreshold` checks with `isCalmBelowThreshold` across consumers (`computeSafeAloneTime`, `computeStability`, `calculateTrainingStats`, and recommendation streak/factor logic) to prevent downstream trust of raw flags.
- Updated/added tests and normalization handling to assert that contradictory explicit/legacy flags are overridden when distress metadata indicates stress.

### Testing
- Ran `npm test -- tests/protocol.test.js tests/storageNormalization.test.js` (Vitest); both files ran and all tests passed.
- Test results: 2 test files, 89 tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb7d49a00833290096431212a6339)