### PR TITLE
Fix PT-LOGIC-004: canonicalize session history by dropping invalid/malformed dates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRegisterSW } from "virtual:pwa-register/react";
 import { PROTOCOL, explainNextTarget, normalizeDistressLevel, suggestNext, suggestNextWithContext } from "./lib/protocol";
 import { sortByDateAsc } from "./lib/activityDateTime";
+import { sortValidDateAsc } from "./lib/dateSort";
 import { selectAppData } from "./features/app/selectors";
 import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeById, mergeSessionWithDerivedFields, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, save, sessKey, syncDelete, syncDeleteSessionsForDog, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
 import { fmt, fmtClock, getOutcomeTone, normalizeWalkType, walkTypeLabel } from "./features/app/helpers";
@@ -198,10 +199,12 @@ export default function PawTimer() {
     () => dogs.find((d) => canonicalDogId(d.id) === canonicalDogId(activeDogId)) ?? null,
     [activeDogId, dogs],
   );
+  const canonicalSessions = useMemo(() => sortValidDateAsc(sessions), [sessions]);
   const deriveRecommendation = useCallback((nextSessions, nextWalks = walks, nextPatterns = patterns, nextDog = activeDog || {}) => {
-    const details = explainNextTarget(nextSessions, nextWalks, nextPatterns, nextDog || {});
+    const logicalSessions = sortValidDateAsc(nextSessions);
+    const details = explainNextTarget(logicalSessions, nextWalks, nextPatterns, nextDog || {});
     const recommendedDuration = details?.recommendedDuration
-      ?? (suggestNextWithContext(nextSessions, nextWalks, nextPatterns, nextDog) ?? suggestNext(nextSessions, nextDog));
+      ?? (suggestNextWithContext(logicalSessions, nextWalks, nextPatterns, nextDog) ?? suggestNext(logicalSessions, nextDog));
     return {
       duration: recommendedDuration,
       decisionState: details?.decisionState ?? null,
@@ -210,14 +213,13 @@ export default function PawTimer() {
     };
   }, [activeDog, patterns, walks]);
 
-  const sortedSessions = useMemo(() => sortByDateAsc(sessions), [sessions]);
   const recommendation = useMemo(() => {
-    return deriveRecommendation(sortedSessions, walks, patterns, activeDog || {});
-  }, [activeDog, deriveRecommendation, patterns, sortedSessions, walks]);
+    return deriveRecommendation(canonicalSessions, walks, patterns, activeDog || {});
+  }, [activeDog, canonicalSessions, deriveRecommendation, patterns, walks]);
   const appData = selectAppData({
     dogs,
     activeDogId,
-    sessions: sortedSessions,
+    sessions: canonicalSessions,
     walks,
     patterns,
     feedings,
@@ -890,8 +892,8 @@ export default function PawTimer() {
           </div>
         </div>
 
-        {tab === "home" && <HomeScreen name={appData.name} sessions={sessions} recommendation={appData.recommendation} goalPct={appData.goalPct} goalSec={appData.goalSec} phase={phase} elapsed={elapsed} finalElapsed={finalElapsed} sessionCompleted={sessionCompleted} sessionOutcome={sessionOutcome} setSessionOutcome={setSessionOutcome} recordResult={recordResult} latencyDraft={latencyDraft} setLatencyDraft={setLatencyDraft} distressTypeDraft={distressTypeDraft} setDistressTypeDraft={setDistressTypeDraft} setPhase={setPhase} setElapsed={setElapsed} setFinalElapsed={setFinalElapsed} startSession={startSession} endSession={endSession} cancelSession={cancelSession} activeProto={appData.activeProto} daily={appData.daily} pattern={appData.pattern} walkPhase={walkPhase} startWalk={startWalk} cancelWalk={cancelWalk} walkElapsed={walkElapsed} endWalk={endWalk} walkPendingDuration={walkPendingDuration} saveWalkWithType={saveWalkWithType} patOpen={patOpen} setPatOpen={setPatOpen} patReminderText={appData.patReminderText} logPattern={logPattern} patLabels={patLabels} patterns={patterns} feedings={feedings} feedingOpen={feedingOpen} openFeedingForm={openFeedingForm} feedingDraft={feedingDraft} setFeedingDraft={setFeedingDraft} cancelFeedingForm={cancelFeedingForm} saveFeeding={saveFeeding} />}
-        {tab === "history" && <HistoryScreen timeline={appData.timeline} sessions={sessions} name={appData.name} setTab={setTab} patLabels={patLabels} historyModal={historyModal} setHistoryModal={setHistoryModal} actions={historyActions} />}
+        {tab === "home" && <HomeScreen name={appData.name} sessions={canonicalSessions} recommendation={appData.recommendation} goalPct={appData.goalPct} goalSec={appData.goalSec} phase={phase} elapsed={elapsed} finalElapsed={finalElapsed} sessionCompleted={sessionCompleted} sessionOutcome={sessionOutcome} setSessionOutcome={setSessionOutcome} recordResult={recordResult} latencyDraft={latencyDraft} setLatencyDraft={setLatencyDraft} distressTypeDraft={distressTypeDraft} setDistressTypeDraft={setDistressTypeDraft} setPhase={setPhase} setElapsed={setElapsed} setFinalElapsed={setFinalElapsed} startSession={startSession} endSession={endSession} cancelSession={cancelSession} activeProto={appData.activeProto} daily={appData.daily} pattern={appData.pattern} walkPhase={walkPhase} startWalk={startWalk} cancelWalk={cancelWalk} walkElapsed={walkElapsed} endWalk={endWalk} walkPendingDuration={walkPendingDuration} saveWalkWithType={saveWalkWithType} patOpen={patOpen} setPatOpen={setPatOpen} patReminderText={appData.patReminderText} logPattern={logPattern} patLabels={patLabels} patterns={patterns} feedings={feedings} feedingOpen={feedingOpen} openFeedingForm={openFeedingForm} feedingDraft={feedingDraft} setFeedingDraft={setFeedingDraft} cancelFeedingForm={cancelFeedingForm} saveFeeding={saveFeeding} />}
+        {tab === "history" && <HistoryScreen timeline={appData.timeline} sessions={canonicalSessions} name={appData.name} setTab={setTab} patLabels={patLabels} historyModal={historyModal} setHistoryModal={setHistoryModal} actions={historyActions} />}
         {tab === "progress" && <StatsScreen name={appData.name} totalCount={appData.totalCount} setTab={setTab} bestCalm={appData.bestCalm} recommendation={appData.recommendation} relapseTone={appData.relapseTone} chartData={appData.chartData} goalSec={appData.goalSec} CustomDot={CustomDot} distressLabel={appData.distressLabel} chartTrendLabel={appData.chartTrendLabel} aloneLastWeek={appData.aloneLastWeek} avgWalkDuration={appData.avgWalkDuration} avgSessionsPerDay={appData.avgSessionsPerDay} avgWalksPerDay={appData.avgWalksPerDay} headlineStatus={appData.headlineStatus} headlineStatusTone={appData.headlineStatusTone} />}
         {tab === "settings" && <SettingsScreen name={appData.name} activeDogId={activeDogId} copyDogId={copyDogId} notifEnabled={notifEnabled} handleToggleNotif={handleToggleNotif} notifTime={notifTime} setNotifTime={setNotifTime} scheduleNotif={scheduleNotif} dogs={dogs} activeProto={appData.activeProto} pattern={appData.pattern} recommendation={appData.recommendation} setTrainingSettingsOpen={setTrainingSettingsOpen} patLabels={patLabels} editingPat={editingPat} setEditingPat={setEditingPat} setPatLabels={setPatLabels} settingsDisclosure={settingsDisclosure} setSettingsDisclosure={setSettingsDisclosure} syncDiagRunning={syncDiagRunning} runSyncDiagnostics={runSyncDiagnostics} SYNC_ENABLED={SYNC_ENABLED} SB_URL={SB_URL} SB_KEY={SB_KEY} SB_BASE_URL={SB_BASE_URL} syncDiagResult={syncDiagResult} syncSummary={syncSummary} syncDegradation={syncDegradation} trainingSettingsOpen={trainingSettingsOpen} setProtoWarnAck={setProtoWarnAck} protoWarnAck={protoWarnAck} protoOverride={protoOverride} setProtoOverride={setProtoOverride} setScreen={setScreen} setOnboardingState={setOnboardingState} dogsState={dogs} setDogs={setDogs} save={save} ACTIVE_DOG_KEY={ACTIVE_DOG_KEY} setActiveDogId={setActiveDogId} clearDogActivityState={clearDogActivityState} />}
       </div>

--- a/src/features/app/selectors.js
+++ b/src/features/app/selectors.js
@@ -1,11 +1,9 @@
 import { PROTOCOL, getCalmStreak, getDistressCounts, getRecentHighDistressSummary } from "../../lib/protocol";
+import { hasValidDate, sortValidDateAsc, toTimestampOrNull } from "../../lib/dateSort";
 import { dailyInfo, distressLabel, fmt, getInformationalTone, getLeaveProfile, getRiskTone, isToday, patternInfo, toDayKey } from "./helpers";
 
 const hasValue = (value) => value !== null && value !== undefined;
-const toSortableTimestamp = (value) => {
-  const parsed = new Date(value ?? "").getTime();
-  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
-};
+const toSortableTimestamp = (value) => toTimestampOrNull(value) ?? Number.NEGATIVE_INFINITY;
 const resolveActivityDate = (entry = {}) => (
   entry?.date
   ?? entry?.updatedAt
@@ -28,13 +26,14 @@ const statusTone = (value, { good, warn, invert = false }) => {
 };
 
 export function selectAppData({ dogs, activeDogId, sessions, walks, patterns, feedings, target, protoOverride, recommendation }) {
+  const canonicalSessions = sortValidDateAsc(sessions);
   const dog = dogs.find((d) => String(d.id || "").trim().toUpperCase() === String(activeDogId || "").trim().toUpperCase());
   const name = dog?.dogName ?? "your dog";
   const goalSec = dog?.goalSeconds ?? 2400;
   const goalPct = Math.min((target / goalSec) * 100, 100);
   const activeProto = { ...PROTOCOL, ...protoOverride };
 
-  const daily = dailyInfo(sessions);
+  const daily = dailyInfo(canonicalSessions);
   const capPct = Math.min((daily.usedSec / daily.capSec) * 100, 100);
   const leaveProfile = getLeaveProfile(dog?.leavesPerDay);
   const pattern = patternInfo(patterns, walks, dog?.leavesPerDay, activeProto);
@@ -57,23 +56,23 @@ export function selectAppData({ dogs, activeDogId, sessions, walks, patterns, fe
     return `${pattern.todayPat} of ${pattern.recMin}–${pattern.recMax} pattern breaks done for a ${leaveProfile.desc}. Do a few more at random times — not before walks, just scattered through the day.`;
   })();
 
-  const totalCount = sessions.length;
-  const bestCalm = sessions.filter((s) => s.distressLevel === "none").reduce((m, s) => Math.max(m, s.actualDuration), 0);
+  const totalCount = canonicalSessions.length;
+  const bestCalm = canonicalSessions.filter((s) => s.distressLevel === "none").reduce((m, s) => Math.max(m, s.actualDuration), 0);
   const avgWalkDuration = walks.length ? walks.reduce((sum, w) => sum + (Number.isFinite(w.duration) ? w.duration : 0), 0) / walks.length : null;
-  const uniqueSessionDays = new Set(sessions.map((s) => toDayKey(s.date)).filter(Boolean));
+  const uniqueSessionDays = new Set(canonicalSessions.map((s) => toDayKey(s.date)).filter(Boolean));
   const uniqueWalkDays = new Set(walks.map((w) => toDayKey(w.date)).filter(Boolean));
   const avgSessionsPerDay = uniqueSessionDays.size ? totalCount / uniqueSessionDays.size : null;
   const avgWalksPerDay = uniqueWalkDays.size ? walks.length / uniqueWalkDays.size : null;
   const recentWeekCutoff = Date.now() - (7 * 24 * 60 * 60 * 1000);
-  const aloneLastWeek = sessions.reduce((sum, s) => {
+  const aloneLastWeek = canonicalSessions.reduce((sum, s) => {
     const ts = new Date(s.date).getTime();
     if (!Number.isFinite(ts) || ts < recentWeekCutoff) return sum;
     return sum + (Number.isFinite(s.actualDuration) ? s.actualDuration : 0);
   }, 0);
-  const streak = getCalmStreak(sessions);
-  const lastSess = sessions[sessions.length - 1];
+  const streak = getCalmStreak(canonicalSessions);
+  const lastSess = canonicalSessions[canonicalSessions.length - 1];
 
-  const recommendationCoverageCount = sessions.filter((s) =>
+  const recommendationCoverageCount = canonicalSessions.filter((s) =>
     (hasValue(s.context?.timeOfDay) || hasValue(s.context?.departureType) || (Array.isArray(s.context?.cuesUsed) && s.context.cuesUsed.length > 0))
     && ["barking", "pacing", "destructive", "salivation"].some((k) => hasValue(s.symptoms?.[k]))
     && hasValue(s.recoverySeconds)
@@ -86,7 +85,7 @@ export function selectAppData({ dogs, activeDogId, sessions, walks, patterns, fe
     const cutoff = new Date();
     cutoff.setHours(0, 0, 0, 0);
     cutoff.setDate(cutoff.getDate() - (days - 1));
-    const windowSessions = sessions.filter((s) => {
+    const windowSessions = canonicalSessions.filter((s) => {
       const d = new Date(s.date);
       return !isNaN(d) && d >= cutoff;
     });
@@ -100,13 +99,13 @@ export function selectAppData({ dogs, activeDogId, sessions, walks, patterns, fe
   const doseMultiplier = leaveProfile.confidenceScale;
   const adjustedTarget = Math.max(activeProto.startDurationSeconds, Math.round(target * doseMultiplier));
   const recommendationConfidence = (() => {
-    if (!sessions.length) return "building";
-    const recent = sessions.slice(-8);
+    if (!canonicalSessions.length) return "building";
+    const recent = canonicalSessions.slice(-8);
     const calmRecent = recent.filter((s) => s.distressLevel === "none").length;
     const subtleRecent = recent.filter((s) => s.distressLevel === "subtle").length;
     const activeRecent = recent.filter((s) => s.distressLevel === "active").length;
     const severeRecent = recent.filter((s) => s.distressLevel === "severe").length;
-    const sessionVolumeScore = Math.min(1, sessions.length / 12);
+    const sessionVolumeScore = Math.min(1, canonicalSessions.length / 12);
     const qualityScore = Math.max(0, Math.min(1, (calmRecent + (subtleRecent * 0.45) - (activeRecent * 0.7) - (severeRecent * 0.9)) / Math.max(1, recent.length)));
     const streakScore = Math.min(1, streak / 5);
     const weighted = (sessionVolumeScore * 0.3) + (qualityScore * 0.5) + (streakScore * 0.2);
@@ -115,7 +114,7 @@ export function selectAppData({ dogs, activeDogId, sessions, walks, patterns, fe
     return "building";
   })();
 
-  const calmDurations = sessions.filter((s) => s.distressLevel === "none" && Number.isFinite(s.actualDuration)).map((s) => s.actualDuration).slice(-11);
+  const calmDurations = canonicalSessions.filter((s) => s.distressLevel === "none" && Number.isFinite(s.actualDuration)).map((s) => s.actualDuration).slice(-11);
   const calmMedian = (() => {
     if (!calmDurations.length) return null;
     const sorted = [...calmDurations].sort((a, b) => a - b);
@@ -123,14 +122,14 @@ export function selectAppData({ dogs, activeDogId, sessions, walks, patterns, fe
     return sorted.length % 2 === 0 ? Math.round((sorted[mid - 1] + sorted[mid]) / 2) : sorted[mid];
   })();
   const durationVariability = (() => {
-    const durations = sessions.map((s) => s.actualDuration).filter((n) => Number.isFinite(n));
+    const durations = canonicalSessions.map((s) => s.actualDuration).filter((n) => Number.isFinite(n));
     if (durations.length < 2) return null;
     const mean = durations.reduce((sum, n) => sum + n, 0) / durations.length;
     const variance = durations.reduce((sum, n) => sum + ((n - mean) ** 2), 0) / durations.length;
     return Math.round(Math.sqrt(variance));
   })();
 
-  const recentHighDistress = getRecentHighDistressSummary(sessions);
+  const recentHighDistress = getRecentHighDistressSummary(canonicalSessions);
   const decisionState = unifiedRecommendation.decisionState || null;
 
   const trainingReadiness = (() => {
@@ -172,7 +171,7 @@ export function selectAppData({ dogs, activeDogId, sessions, walks, patterns, fe
     return getRiskTone(decisionState?.riskLevel || "medium");
   })();
 
-  const chartData = sessions.slice(-25).map((s, i) => ({
+  const chartData = canonicalSessions.slice(-25).map((s, i) => ({
     session: i + 1,
     durationSeconds: s.actualDuration,
     durationMinutes: Math.round(s.actualDuration / 60 * 10) / 10,
@@ -202,7 +201,9 @@ export function selectAppData({ dogs, activeDogId, sessions, walks, patterns, fe
   })();
 
   const timeline = [
-    ...sessions.map((s, idx) => ({ kind: "session", date: resolveActivityDate(s), data: s, sourceOrder: idx })),
+    ...canonicalSessions
+      .filter((s) => hasValidDate(resolveActivityDate(s)))
+      .map((s, idx) => ({ kind: "session", date: resolveActivityDate(s), data: s, sourceOrder: idx })),
     ...walks.map((w, idx) => ({ kind: "walk", date: resolveActivityDate(w), data: w, sourceOrder: idx })),
     ...patterns.map((p, idx) => ({ kind: "pat", date: resolveActivityDate(p), data: p, sourceOrder: idx })),
     ...feedings.map((f, idx) => ({ kind: "feeding", date: resolveActivityDate(f), data: f, sourceOrder: idx })),
@@ -214,7 +215,7 @@ export function selectAppData({ dogs, activeDogId, sessions, walks, patterns, fe
       return a.sourceOrder - b.sourceOrder;
     });
 
-  const distressCounts = getDistressCounts(sessions);
+  const distressCounts = getDistressCounts(canonicalSessions);
 
   return {
     dog,

--- a/src/lib/dateSort.js
+++ b/src/lib/dateSort.js
@@ -38,4 +38,14 @@ export const sortByDateAsc = (items = [], options = {}) => {
     .map(({ item }) => item);
 };
 
+export const hasValidDate = (value) => toTimestampOrNull(value) != null;
+
+export const filterValidDateItems = (items = [], getDate = (item) => item?.date) => (
+  ensureArray(items).filter((item) => hasValidDate(getDate(item)))
+);
+
+export const sortValidDateAsc = (items = []) => (
+  sortByDateAsc(filterValidDateItems(items), { invalidPolicy: INVALID_DATE_POLICIES.DROP })
+);
+
 export { INVALID_DATE_POLICIES, toTimestampOrNull };

--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -1,4 +1,4 @@
-import { sortByDateAsc as sortByDateAscShared } from "./dateSort";
+import { sortValidDateAsc } from "./dateSort";
 
 export const PROTOCOL = {
   sessionsPerDayDefault: 1,
@@ -163,7 +163,7 @@ function isCalmBelowThreshold(session = {}) {
   );
 }
 
-const sortByDateAsc = (sessions = []) => sortByDateAscShared(sessions, { invalidPolicy: "drop" });
+const sortByDateAsc = (sessions = []) => sortValidDateAsc(sessions);
 
 function isProgressionEligibleSession(session = {}) {
   const distress = normalizeDistressLevel(session?.distressLevel);

--- a/tests/activityLogMaterialization.test.js
+++ b/tests/activityLogMaterialization.test.js
@@ -65,6 +65,34 @@ describe("activity log materialization regression guard", () => {
     expect(app.timeline).toHaveLength(4);
   });
 
+  it("keeps timeline ordering deterministic while excluding invalid-dated session rows from logic", () => {
+    const sessions = [
+      { id: "sess-invalid", date: "invalid-date", plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
+      { id: "sess-valid", date: daysAgo(3), plannedDuration: 600, actualDuration: 600, distressLevel: "none", belowThreshold: true },
+    ];
+    const walks = [{ id: "walk-1", date: daysAgo(2), duration: 300, type: "exercise" }];
+    const patterns = [{ id: "pat-1", date: daysAgo(1), type: "keys" }];
+    const feedings = [{ id: "feed-1", date: daysAgo(0), foodType: "meal", amount: "small" }];
+    const recommendation = { duration: 900, decisionState: null, details: {}, explanation: "" };
+
+    const app = selectAppData({
+      ...baseArgs,
+      sessions,
+      walks,
+      patterns,
+      feedings,
+      recommendation,
+    });
+
+    expect(app.totalCount).toBe(1);
+    expect(app.timeline.map((entry) => `${entry.kind}:${entry.data.id}`)).toEqual([
+      "feeding:feed-1",
+      "pat:pat-1",
+      "walk:walk-1",
+      "session:sess-valid",
+    ]);
+  });
+
   it("retains PT-LOGIC-003 plateau hold behavior for repeated near-threshold sessions", () => {
     const sessions = [
       { id: "s-1", date: daysAgo(2), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },

--- a/tests/statusSemantics.test.js
+++ b/tests/statusSemantics.test.js
@@ -3,6 +3,7 @@ import { selectAppData } from "../src/features/app/selectors";
 import { getInformationalTone, getOutcomeTone, getRiskTone } from "../src/features/app/helpers";
 import { explainNextTarget } from "../src/lib/protocol";
 import { sortByDateAsc } from "../src/lib/activityDateTime";
+import { sortValidDateAsc } from "../src/lib/dateSort";
 
 const daysAgo = (n) => new Date(Date.now() - n * 86400000).toISOString();
 const buildRecommendation = ({ sessions, walks, patterns, dog, target }) => {
@@ -141,5 +142,40 @@ describe("semantic status mapping", () => {
     expect(appData.chartTrendLabel).toBe("Trend: Improving");
     expect(appData.streak).toBe(6);
     expect(appData.relapseTone.label).toBe(recommendation.decisionState.riskLevel === "low" ? "Low" : recommendation.decisionState.riskLevel === "high" ? "High" : "Medium");
+  });
+
+  it("drops invalid-dated sessions consistently across recommendation and derived metrics", () => {
+    const sessions = sortByDateAsc([
+      { id: "invalid-text", date: "not-a-date", plannedDuration: 999, actualDuration: 999, distressLevel: "none", belowThreshold: true },
+      { id: "valid-1", date: "2026-04-10T09:00:00.000Z", plannedDuration: 120, actualDuration: 120, distressLevel: "none", belowThreshold: true },
+      { id: "invalid-missing", plannedDuration: 200, actualDuration: 200, distressLevel: "none", belowThreshold: true },
+      { id: "valid-2", date: "2026-04-11T09:00:00.000Z", plannedDuration: 150, actualDuration: 150, distressLevel: "active", belowThreshold: false },
+    ]);
+    const dog = { id: "DOG-1", dogName: "Milo", goalSeconds: 1800, leavesPerDay: 3 };
+    const canonicalSessions = sortValidDateAsc(sessions);
+    const recommendation = buildRecommendation({
+      sessions: canonicalSessions,
+      walks: [],
+      patterns: [],
+      dog,
+      target: 60,
+    });
+    const appData = selectAppData({
+      dogs: [dog],
+      activeDogId: "DOG-1",
+      sessions,
+      walks: [],
+      patterns: [],
+      feedings: [],
+      target: 60,
+      protoOverride: {},
+      recommendation,
+    });
+
+    expect(canonicalSessions.map((session) => session.id)).toEqual(["valid-1", "valid-2"]);
+    expect(appData.totalCount).toBe(canonicalSessions.length);
+    expect(appData.chartData.map((entry) => entry.durationSeconds)).toEqual([120, 150]);
+    expect(appData.timeline.filter((entry) => entry.kind === "session").map((entry) => entry.data.id)).toEqual(["valid-2", "valid-1"]);
+    expect(appData.recentHighDistress.recentSessions).toHaveLength(canonicalSessions.length);
   });
 });


### PR DESCRIPTION
### Motivation
- There was a split-brain: recommendation/protocol logic dropped invalid-date sessions while selector/app logic kept them (pushed to end), causing recommendation and metrics to operate on different datasets.  
- The goal is a single deterministic policy for date handling so recommendation and derived metrics see the same history.  
- Chosen canonical policy: drop invalid/malformed-date sessions from all logic paths to keep ordering deterministic and avoid silent divergence.  

### Description
- Added shared date utilities in `src/lib/dateSort.js`: `hasValidDate`, `filterValidDateItems`, and `sortValidDateAsc` to provide a single source of truth for valid-date filtering and ordering.  
- Switched protocol/recommendation sorting to use `sortValidDateAsc` so recommendation calculations always use valid-dated sessions (`src/lib/protocol.js`).  
- Introduced a canonical session view in `App.jsx` (`canonicalSessions = sortValidDateAsc(sessions)`) and used it for recommendation derivation, screen props, and when feeding selectors so both recommendation and metrics share the same dataset.  
- Updated `selectAppData` to compute all derived metrics, streaks, chart data, distress summaries, and timeline entries from `canonicalSessions` and to build timeline session entries only from valid-dated rows (`src/features/app/selectors.js`).  
- Added/updated regression tests to cover mixed valid/invalid histories and timeline ordering (`tests/statusSemantics.test.js`, `tests/activityLogMaterialization.test.js`).  

### Testing
- Ran targeted tests: `tests/statusSemantics.test.js`, `tests/activityLogMaterialization.test.js`, `tests/protocol.test.js`, and `tests/activityDateTime.test.js`, and all targeted tests passed.  
- Ran full test suite via `npm test` and observed all test files passing: `12` test files and `150` tests passed.  
- New/updated tests assert that invalid-dated session rows are excluded consistently from recommendation and derived metrics and that timeline ordering remains deterministic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfbc7d53108332a3bda66df514ca20)