### PR TITLE
Canonicalize distressSeverity to normalized distressLevel

### DIFF
--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -297,11 +297,7 @@ const inferDistressLevelFromRow = (row = {}) => {
   return null;
 };
 
-export const normalizeSession = (row = {}) => {
-  const context = row.context ?? {};
-  const symptoms = row.symptoms ?? {};
-  const preSession = row.preSession ?? row.pre_session ?? {};
-  const environment = row.environment ?? {};
+const resolveCanonicalDistress = (row = {}) => {
   const normalizedDistressType = row.distressType ?? row.distress_type ?? null;
   const normalizedDistressSeverity = row.distressSeverity ?? row.distress_severity ?? null;
   const restoredLegacyDistress = decodeLegacyDistressFields({
@@ -309,6 +305,20 @@ export const normalizeSession = (row = {}) => {
     distressType: normalizedDistressType,
     distressSeverity: normalizedDistressSeverity,
   });
+  const canonicalDistressLevel = normalizeDistressLevel(restoredLegacyDistress.distressLevel);
+  return {
+    distressLevel: canonicalDistressLevel,
+    distressSeverity: canonicalDistressLevel,
+    distressType: restoredLegacyDistress.distressType,
+  };
+};
+
+export const normalizeSession = (row = {}) => {
+  const context = row.context ?? {};
+  const symptoms = row.symptoms ?? {};
+  const preSession = row.preSession ?? row.pre_session ?? {};
+  const environment = row.environment ?? {};
+  const canonicalDistress = resolveCanonicalDistress(row);
   const actualDuration = resolveDurationSeconds(row, {
     secondsKeys: ["actualDurationSeconds", "actual_duration_seconds", "durationSeconds", "duration_seconds", "completedDurationSeconds", "completed_duration_seconds"],
     canonicalKeys: ["actualDuration", "actual_duration"],
@@ -325,7 +335,7 @@ export const normalizeSession = (row = {}) => {
     ...row,
     actualDuration,
     plannedDuration,
-    distressLevel: restoredLegacyDistress.distressLevel,
+    distressLevel: canonicalDistress.distressLevel,
     context: {
       timeOfDay: context.timeOfDay ?? context.time_of_day ?? null,
       departureType: context.departureType ?? context.departure_type ?? "training",
@@ -346,12 +356,12 @@ export const normalizeSession = (row = {}) => {
     latencyToFirstDistress: Number.isFinite(row.latencyToFirstDistress) ? row.latencyToFirstDistress : (Number.isFinite(row.latency_to_first_distress) ? row.latency_to_first_distress : null),
     belowThreshold: inferBelowThreshold({
       ...row,
-      distressLevel: restoredLegacyDistress.distressLevel,
+      distressLevel: canonicalDistress.distressLevel,
       actualDuration,
       plannedDuration,
     }),
-    distressType: restoredLegacyDistress.distressType,
-    distressSeverity: normalizedDistressSeverity,
+    distressType: canonicalDistress.distressType,
+    distressSeverity: canonicalDistress.distressSeverity,
     videoReview: {
       recorded: hasValue((row.videoReview || {}).recorded) ? !!row.videoReview.recorded : asBool((row.video_review || {}).recorded),
       firstSubtleDistressTs: (row.videoReview || {}).firstSubtleDistressTs ?? (row.video_review || {}).first_subtle_distress_ts ?? null,

--- a/tests/storageNormalization.test.js
+++ b/tests/storageNormalization.test.js
@@ -81,6 +81,7 @@ describe("storage normalization", () => {
     });
 
     expect(session.distressLevel).toBe("active");
+    expect(session.distressSeverity).toBe("active");
   });
 
   it("keeps known success rows calm", () => {
@@ -101,6 +102,45 @@ describe("storage normalization", () => {
     });
 
     expect(session.distressLevel).toBe("severe");
+    expect(session.distressSeverity).toBe("severe");
+  });
+
+  it("keeps malformed rows canonical and consistent", () => {
+    const session = normalizeSession({
+      id: "s-malformed-distress",
+      distressLevel: "unknown-value",
+      distressSeverity: "invalid-value",
+      result: "not-a-real-result",
+    });
+
+    expect(session.distressLevel).toBe("none");
+    expect(session.distressSeverity).toBe("none");
+  });
+
+  it("canonicalizes explicit distress rows from distressLevel", () => {
+    const session = normalizeSession({
+      id: "s-explicit-active",
+      distressLevel: "active",
+      distressSeverity: "none",
+      result: "success",
+    });
+
+    expect(session.distressLevel).toBe("active");
+    expect(session.distressSeverity).toBe("active");
+  });
+
+  it("prefers reconstructed legacy severe level over conflicting raw severity", () => {
+    const session = normalizeSession({
+      id: "s-legacy-reconstructed-severe",
+      distressLevel: "active",
+      distressSeverity: "none",
+      distressType: "__severity:severe|panic",
+      result: "distress",
+    });
+
+    expect(session.distressLevel).toBe("severe");
+    expect(session.distressSeverity).toBe("severe");
+    expect(session.distressType).toBe("panic");
   });
 
   it("does not allow malformed explicit below-threshold values to override inference", () => {


### PR DESCRIPTION
### Motivation
- Legacy decoding could reconstruct a canonical `distressLevel` while `distressSeverity` remained assigned from raw input, allowing normalized session objects where `distressLevel !== distressSeverity`.
- This dual-source behavior risks inconsistent downstream logic that reads one field and not the other.
- The change enforces a single canonical source for normalized distress semantics so consumers cannot observe contradictory values.

### Description
- Introduced `resolveCanonicalDistress(row)` which runs legacy decoding (`decodeLegacyDistressFields`), normalizes the resulting level with `normalizeDistressLevel`, and returns a canonical object containing `distressLevel`, `distressSeverity` (mirrored), and `distressType`.
- Updated `normalizeSession()` to use the canonical distress object for `distressLevel`, `distressSeverity`, and `distressType`, and to pass the canonical level into `inferBelowThreshold` so all downstream derived fields are consistent.
- Preserved existing legacy decoding behavior and payload decoding (including the `__severity:` encoded `distressType`) while eliminating the separate raw-path assignment for `distressSeverity`.
- Added/updated normalization tests to assert that legacy alias rows, malformed rows, explicit distress rows, and legacy-reconstruction-vs-raw-severity divergence cases all produce consistent mirrored `distressLevel`/`distressSeverity`.

### Testing
- Ran `npm test -- tests/storageNormalization.test.js` and it passed: 16 tests passed (file ran successfully).
- Ran `npm test -- tests/sessionEditing.test.js` and it passed: 6 tests passed (file ran successfully).
- The updated tests validate legacy aliases, malformed inputs, explicit/distinct severity inputs, and reconstructed legacy severe encoding, and they all succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc5d60c048332a7be122008bb6d57)