### PR TITLE
Fix SYNC-001: make sync commit mutation-safe during in-flight updates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import { PROTOCOL, explainNextTarget, normalizeDistressLevel, suggestNext, sugge
 import { sortByDateAsc } from "./lib/activityDateTime";
 import { sortValidDateAsc } from "./lib/dateSort";
 import { selectAppData } from "./features/app/selectors";
-import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeById, mergeSessionWithDerivedFields, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, save, sessKey, syncDelete, syncDeleteSessionsForDog, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
+import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeById, mergeMutationSafeSyncCollection, mergeSessionWithDerivedFields, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, save, sessKey, syncDelete, syncDeleteSessionsForDog, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
 import { fmt, fmtClock, getOutcomeTone, normalizeWalkType, walkTypeLabel } from "./features/app/helpers";
 import { CameraIcon, ChartIcon, HistoryIcon, HomeIcon, PawIcon, SettingsIcon } from "./features/app/ui.jsx";
 import { DogSelect, Onboarding } from "./features/setup/SetupScreens";
@@ -97,7 +97,6 @@ export default function PawTimer() {
     commitWalks: null,
     commitPatterns: null,
     commitFeedings: null,
-    mergeSyncedCollection: null,
     recomputeTarget: null,
     setEntrySyncState: null,
   });
@@ -174,11 +173,6 @@ export default function PawTimer() {
     };
   }, []);
 
-  const mergeSyncedCollection = useCallback((localItems, remoteItems) => mergeById(
-    ensureArray(localItems).map(withHydratedSyncState),
-    ensureArray(remoteItems).map(markRemoteEntryConfirmed),
-  ), [markRemoteEntryConfirmed, withHydratedSyncState]);
-
   useEffect(() => {
     syncSnapshotRef.current = { dogs, sessions, walks, patterns, feedings, tombstones };
   }, [dogs, sessions, walks, patterns, feedings, tombstones]);
@@ -252,41 +246,53 @@ export default function PawTimer() {
   }, [activeDogId, recomputeTarget, withHydratedSyncState]);
 
   const commitWalks = useCallback((updater) => {
+    let committed = [];
     setWalks((prev) => {
       const resolved = typeof updater === "function" ? updater(prev) : updater;
       const normalized = sortByDateAsc(ensureArray(resolved).map((item) => ({ ...withHydratedSyncState(item), type: normalizeWalkType(item?.type) })));
       if (activeDogId) save(walkKey(activeDogId), normalized);
       recomputeTarget(sessions, normalized, patterns, activeDog || {});
+      committed = normalized;
       return normalized;
     });
+    return committed;
   }, [activeDog, activeDogId, patterns, recomputeTarget, sessions, withHydratedSyncState]);
 
   const commitPatterns = useCallback((updater) => {
+    let committed = [];
     setPatterns((prev) => {
       const resolved = typeof updater === "function" ? updater(prev) : updater;
       const normalized = sortByDateAsc(ensureArray(resolved).map(withHydratedSyncState));
       if (activeDogId) save(patKey(activeDogId), normalized);
       recomputeTarget(sessions, walks, normalized, activeDog || {});
+      committed = normalized;
       return normalized;
     });
+    return committed;
   }, [activeDog, activeDogId, recomputeTarget, sessions, walks, withHydratedSyncState]);
 
   const commitFeedings = useCallback((updater) => {
+    let committed = [];
     setFeedings((prev) => {
       const resolved = typeof updater === "function" ? updater(prev) : updater;
       const normalized = normalizeFeedings(ensureArray(resolved)).map(withHydratedSyncState);
       if (activeDogId) save(feedingKey(activeDogId), normalized);
+      committed = normalized;
       return normalized;
     });
+    return committed;
   }, [activeDogId, withHydratedSyncState]);
 
   const commitTombstones = useCallback((updater) => {
+    let committed = [];
     setTombstones((prev) => {
       const resolved = typeof updater === "function" ? updater(prev) : updater;
       const normalized = normalizeTombstones(ensureArray(resolved)).map(withHydratedSyncState);
       if (activeDogId) save(tombKey(activeDogId), normalized);
+      committed = normalized;
       return normalized;
     });
+    return committed;
   }, [activeDogId, withHydratedSyncState]);
 
   const addTombstone = useCallback((kind, entry) => {
@@ -344,11 +350,10 @@ export default function PawTimer() {
       commitWalks,
       commitPatterns,
       commitFeedings,
-      mergeSyncedCollection,
       recomputeTarget,
       setEntrySyncState,
     };
-  }, [commitFeedings, commitPatterns, commitSessions, commitWalks, mergeSyncedCollection, recomputeTarget, setEntrySyncState]);
+  }, [commitFeedings, commitPatterns, commitSessions, commitWalks, recomputeTarget, setEntrySyncState]);
 
   useEffect(() => {
     if (!activeDogId) { setScreen("select"); return; }
@@ -442,36 +447,42 @@ export default function PawTimer() {
         const remotePatterns = ensureArray(remote.patterns);
         const remoteFeedings = normalizeFeedings(remote.feedings);
 
-        const mergedTombstones = mergeById(
-          normalizeTombstones(snapshot.tombstones).map(withHydratedSyncState),
+        const mergedTombstones = commitTombstones((prev) => mergeById(
+          normalizeTombstones(prev).map(withHydratedSyncState),
           normalizeTombstones(remote.tombstones).map(markRemoteEntryConfirmed),
-        );
-        const mergedSessions = applyTombstonesToCollection(
-          syncHelpersRef.current.mergeSyncedCollection(snapshot.sessions, remoteSessions),
-          mergedTombstones,
-          "session",
-        );
-        const mergedWalks = applyTombstonesToCollection(
-          syncHelpersRef.current.mergeSyncedCollection(snapshot.walks, remoteWalks),
-          mergedTombstones,
-          "walk",
-        );
-        const mergedPatterns = applyTombstonesToCollection(
-          syncHelpersRef.current.mergeSyncedCollection(snapshot.patterns, remotePatterns),
-          mergedTombstones,
-          "pattern",
-        );
-        const mergedFeedings = applyTombstonesToCollection(
-          syncHelpersRef.current.mergeSyncedCollection(snapshot.feedings, remoteFeedings),
-          mergedTombstones,
-          "feeding",
-        );
-
-        commitTombstones(mergedTombstones);
-        syncHelpersRef.current.commitSessions(mergedSessions);
-        syncHelpersRef.current.commitWalks(mergedWalks);
-        syncHelpersRef.current.commitPatterns(mergedPatterns);
-        syncHelpersRef.current.commitFeedings(mergedFeedings);
+        ));
+        const mergedSessions = syncHelpersRef.current.commitSessions((prev) => mergeMutationSafeSyncCollection({
+          currentItems: prev,
+          remoteItems: remoteSessions,
+          tombstones: mergedTombstones,
+          kind: "session",
+          mapLocalItem: withHydratedSyncState,
+          mapRemoteItem: markRemoteEntryConfirmed,
+        }));
+        const mergedWalks = syncHelpersRef.current.commitWalks((prev) => mergeMutationSafeSyncCollection({
+          currentItems: prev,
+          remoteItems: remoteWalks,
+          tombstones: mergedTombstones,
+          kind: "walk",
+          mapLocalItem: withHydratedSyncState,
+          mapRemoteItem: markRemoteEntryConfirmed,
+        }));
+        const mergedPatterns = syncHelpersRef.current.commitPatterns((prev) => mergeMutationSafeSyncCollection({
+          currentItems: prev,
+          remoteItems: remotePatterns,
+          tombstones: mergedTombstones,
+          kind: "pattern",
+          mapLocalItem: withHydratedSyncState,
+          mapRemoteItem: markRemoteEntryConfirmed,
+        }));
+        const mergedFeedings = syncHelpersRef.current.commitFeedings((prev) => mergeMutationSafeSyncCollection({
+          currentItems: prev,
+          remoteItems: remoteFeedings,
+          tombstones: mergedTombstones,
+          kind: "feeding",
+          mapLocalItem: withHydratedSyncState,
+          mapRemoteItem: markRemoteEntryConfirmed,
+        }));
 
         const currentDog = snapshot.dogs.find((d) => canonicalDogId(d.id) === canonicalDogId(activeDogId));
         const dogSettings = currentDog ? { ...currentDog, id: canonicalDogId(currentDog.id) } : remoteDog;

--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -229,6 +229,22 @@ export const mergeById = (a = [], b = [], pickWinner = resolveSyncConflict) => {
   return sortByDateAsc(Array.from(merged.values()));
 };
 
+export const mergeMutationSafeSyncCollection = ({
+  currentItems = [],
+  remoteItems = [],
+  tombstones = [],
+  kind = "",
+  mapLocalItem = (item) => item,
+  mapRemoteItem = (item) => item,
+} = {}) => applyTombstonesToCollection(
+  mergeById(
+    ensureArray(currentItems).map(mapLocalItem),
+    ensureArray(remoteItems).map(mapRemoteItem),
+  ),
+  tombstones,
+  kind,
+);
+
 const asBool = (value) => value === true || value === 1;
 const hasValue = (value) => value !== null && value !== undefined;
 

--- a/tests/syncConflict.test.js
+++ b/tests/syncConflict.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mergeById, resolveSyncConflict } from "../src/features/app/storage";
+import { mergeMutationSafeSyncCollection, resolveSyncConflict } from "../src/features/app/storage";
 
 const iso = (hour) => `2026-04-01T${String(hour).padStart(2, "0")}:00:00.000Z`;
 
@@ -33,12 +33,16 @@ describe("resolveSyncConflict", () => {
   });
 });
 
-describe("mergeById concurrent edits", () => {
+describe("mergeMutationSafeSyncCollection concurrent edits", () => {
   it("keeps the higher revision entry across arrays", () => {
     const localSessions = [{ id: "session-1", date: iso(8), revision: 5, updatedAt: iso(8), result: "success" }];
     const remoteSessions = [{ id: "session-1", date: iso(8), revision: 4, updatedAt: iso(10), result: "distress" }];
 
-    const merged = mergeById(localSessions, remoteSessions);
+    const merged = mergeMutationSafeSyncCollection({
+      currentItems: localSessions,
+      remoteItems: remoteSessions,
+      kind: "session",
+    });
 
     expect(merged).toHaveLength(1);
     expect(merged[0].revision).toBe(5);
@@ -49,7 +53,11 @@ describe("mergeById concurrent edits", () => {
     const localPatterns = [{ id: "pattern-1", date: iso(8), revision: 8, updatedAt: iso(9), type: "keys" }];
     const remotePatterns = [{ id: "pattern-1", date: iso(8), revision: 8, updatedAt: iso(12), type: "jacket" }];
 
-    const merged = mergeById(localPatterns, remotePatterns);
+    const merged = mergeMutationSafeSyncCollection({
+      currentItems: localPatterns,
+      remoteItems: remotePatterns,
+      kind: "pattern",
+    });
 
     expect(merged).toHaveLength(1);
     expect(merged[0].type).toBe("jacket");
@@ -60,7 +68,11 @@ describe("mergeById concurrent edits", () => {
     const localPatterns = [{ id: "pattern-2", date: iso(8), revision: 10, updatedAt: iso(9), type: "keys" }];
     const remotePatterns = [{ id: "pattern-2", date: iso(8), revision: 9, updatedAt: iso(12), type: "jacket" }];
 
-    const merged = mergeById(localPatterns, remotePatterns);
+    const merged = mergeMutationSafeSyncCollection({
+      currentItems: localPatterns,
+      remoteItems: remotePatterns,
+      kind: "pattern",
+    });
 
     expect(merged).toHaveLength(1);
     expect(merged[0].revision).toBe(10);
@@ -71,7 +83,11 @@ describe("mergeById concurrent edits", () => {
     const localFeedings = [{ id: "feeding-1", date: iso(8), revision: 6, updatedAt: iso(9), foodType: "meal", amount: "small" }];
     const remoteFeedings = [{ id: "feeding-1", date: iso(8), revision: 5, updatedAt: iso(12), foodType: "snack", amount: "large" }];
 
-    const merged = mergeById(localFeedings, remoteFeedings);
+    const merged = mergeMutationSafeSyncCollection({
+      currentItems: localFeedings,
+      remoteItems: remoteFeedings,
+      kind: "feeding",
+    });
 
     expect(merged).toHaveLength(1);
     expect(merged[0].revision).toBe(6);
@@ -82,10 +98,77 @@ describe("mergeById concurrent edits", () => {
     const localWalks = [{ id: "walk-1", date: iso(8), revision: 3, updatedAt: iso(8), type: "training_walk", duration: 900 }];
     const remoteWalks = [{ id: "walk-1", date: iso(8), revision: 2, updatedAt: iso(10), type: "regular_walk", duration: 900 }];
 
-    const merged = mergeById(localWalks, remoteWalks);
+    const merged = mergeMutationSafeSyncCollection({
+      currentItems: localWalks,
+      remoteItems: remoteWalks,
+      kind: "walk",
+    });
 
     expect(merged).toHaveLength(1);
     expect(merged[0].revision).toBe(3);
     expect(merged[0].type).toBe("training_walk");
+  });
+
+  it("preserves local edit made after sync start when remote has older revision", () => {
+    const staleSnapshot = [{ id: "session-1", date: iso(8), revision: 1, updatedAt: iso(8), result: "success" }];
+    const currentLocal = [{ id: "session-1", date: iso(8), revision: 2, updatedAt: iso(10), result: "distress" }];
+    const remoteSessions = staleSnapshot;
+
+    const merged = mergeMutationSafeSyncCollection({
+      currentItems: currentLocal,
+      remoteItems: remoteSessions,
+      kind: "session",
+    });
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].revision).toBe(2);
+    expect(merged[0].result).toBe("distress");
+  });
+
+  it("preserves local create made during in-flight sync when absent remotely", () => {
+    const currentLocal = [
+      { id: "session-1", date: iso(8), revision: 1, updatedAt: iso(8), result: "success" },
+      { id: "session-new", date: iso(9), revision: 1, updatedAt: iso(9), result: "distress", pendingSync: true },
+    ];
+    const remoteSessions = [{ id: "session-1", date: iso(8), revision: 1, updatedAt: iso(8), result: "success" }];
+
+    const merged = mergeMutationSafeSyncCollection({
+      currentItems: currentLocal,
+      remoteItems: remoteSessions,
+      kind: "session",
+    });
+
+    expect(merged.map((row) => row.id)).toEqual(["session-1", "session-new"]);
+    expect(merged.find((row) => row.id === "session-new")?.pendingSync).toBe(true);
+  });
+
+  it("preserves local delete made during in-flight sync via tombstone", () => {
+    const currentLocal = [{ id: "walk-1", date: iso(8), revision: 1, updatedAt: iso(8), duration: 600 }];
+    const remoteWalks = [{ id: "walk-1", date: iso(8), revision: 1, updatedAt: iso(8), duration: 600 }];
+    const tombstones = [{ id: "walk-1", kind: "walk", deletedAt: iso(10), revision: 2, updatedAt: iso(10), pendingSync: true }];
+
+    const merged = mergeMutationSafeSyncCollection({
+      currentItems: currentLocal,
+      remoteItems: remoteWalks,
+      tombstones,
+      kind: "walk",
+    });
+
+    expect(merged).toEqual([]);
+  });
+
+  it("keeps in-flight tombstone creation even when remote has no tombstone yet", () => {
+    const localTombstones = [{ id: "feeding-1", kind: "feeding", deletedAt: iso(11), revision: 4, updatedAt: iso(11), pendingSync: true }];
+    const remoteTombstones = [];
+
+    const mergedTombstones = mergeMutationSafeSyncCollection({
+      currentItems: localTombstones,
+      remoteItems: remoteTombstones,
+      kind: "feeding",
+      mapLocalItem: (item) => item,
+      mapRemoteItem: (item) => item,
+    });
+
+    expect(mergedTombstones).toEqual(localTombstones);
   });
 });


### PR DESCRIPTION
### Motivation
- The sync flow previously merged remote payloads against a snapshot captured at sync start and then replaced collections wholesale, which allowed newer local mutations made while sync was in-flight to be overwritten.
- The goal is to make sync commits merge-on-commit (rebase-style) so post-snapshot local creates/edits/deletes/tombstones are preserved without changing application business logic.

### Description
- Added `mergeMutationSafeSyncCollection` in `src/features/app/storage.js` to centralize a merge-on-commit that merges `currentItems` with `remoteItems` using `mergeById` and then applies tombstones via `applyTombstonesToCollection`.
- Refactored the sync commit in `src/App.jsx` to use functional state updaters for tombstones/sessions/walks/patterns/feedings so merges are executed against the actual `prev` state at commit-time rather than a stale snapshot.
- Modified `commitWalks`, `commitPatterns`, `commitFeedings`, and `commitTombstones` to return the normalized committed arrays (matching `commitSessions`) so downstream steps (pending push and target recompute) use the exact committed data.
- Removed the old snapshot-based `mergeSyncedCollection` usage and ensured tombstones are committed first, then each collection is merged in a mutation-safe way without changing session/walk/pattern/feeding semantics.

### Testing
- Ran `npm test -- tests/syncConflict.test.js` and the file passed (13 tests) verifying higher-revision resolution and new tests for in-flight local edit/create/delete/tombstone scenarios.
- Ran full test suite with `npm test` and all tests passed (12 files, 160 tests) confirming no regressions in sync fetch/push logic and existing storage semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcd77af308332959f480dba6c806b)