### PR TITLE
Make tombstone sync compatible with strict not-null schemas (SYNC-002)

### DIFF
--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -958,6 +958,52 @@ export const syncDelete = async (kind, id) => {
   return res.ok;
 };
 
+const buildSchemaCompatibleTombstonePayload = (kind, dogId, tombstone) => {
+  const deletedAt = tombstone.deletedAt;
+  const updatedAt = tombstone.updatedAt ?? deletedAt;
+  const revision = Number.isFinite(tombstone.revision) ? tombstone.revision : 0;
+  const base = {
+    id: String(tombstone.id),
+    dog_id: dogId,
+    deleted_at: deletedAt,
+    revision,
+    updated_at: updatedAt,
+  };
+  if (kind === "session") {
+    return {
+      ...base,
+      date: deletedAt,
+      planned_duration: 0,
+      actual_duration: 0,
+      distress_level: "none",
+      result: "success",
+    };
+  }
+  if (kind === "walk") {
+    return {
+      ...base,
+      date: deletedAt,
+      duration: 0,
+      walk_type: "regular_walk",
+    };
+  }
+  if (kind === "pattern") {
+    return {
+      ...base,
+      date: deletedAt,
+      type: "keys",
+    };
+  }
+  return {
+    ...base,
+    date: deletedAt,
+    food_type: "tombstone",
+    amount: "0",
+  };
+};
+
+const isStrictSchemaNotNullError = (errorText = "") => /null value in column .* violates not-null constraint/i.test(errorText);
+
 export const syncPushTombstone = async (dogId, tombstone, dogSettings = null) => {
   const id = canonicalDogId(dogId);
   const dogReady = await syncUpsertDog(dogSettings && typeof dogSettings === "object" ? { ...dogSettings, id } : { id });
@@ -965,18 +1011,26 @@ export const syncPushTombstone = async (dogId, tombstone, dogSettings = null) =>
   const kind = normalizeTombstoneKind(tombstone?.kind);
   if (!kind || !tombstone?.id || !tombstone?.deletedAt) return { ok: false, error: "Invalid tombstone payload" };
   const table = kind === "session" ? "sessions" : kind === "walk" ? "walks" : kind === "pattern" ? "patterns" : "feedings";
-  const payload = {
+  const metadataOnlyPayload = {
     id: String(tombstone.id),
     dog_id: id,
     deleted_at: tombstone.deletedAt,
-    revision: tombstone.revision ?? null,
+    revision: Number.isFinite(tombstone.revision) ? tombstone.revision : 0,
     updated_at: tombstone.updatedAt ?? tombstone.deletedAt,
   };
-  const res = await sbReq(table, {
+
+  const pushPayload = (payload) => sbReq(table, {
     method: "POST",
     body: JSON.stringify(payload),
     prefer: "resolution=merge-duplicates,return=minimal",
   });
+
+  let res = await pushPayload(metadataOnlyPayload);
+  if (!res.ok && isStrictSchemaNotNullError(String(res.error || ""))) {
+    const strictPayload = buildSchemaCompatibleTombstonePayload(kind, id, tombstone);
+    res = await pushPayload(strictPayload);
+  }
+
   return res.ok ? { ok: true, error: null } : { ok: false, error: `${kind} tombstone push failed: ${res.error}` };
 };
 

--- a/tests/syncFetchRuntime.test.js
+++ b/tests/syncFetchRuntime.test.js
@@ -275,4 +275,96 @@ describe("syncFetch runtime fallbacks", () => {
       revision: 9,
     });
   });
+
+  it("retries tombstone push with strict-schema compatible payload after not-null failure", async () => {
+    const postedBodies = [];
+    global.fetch = vi.fn(async (url, options = {}) => {
+      const { path } = getPathAndParams(url);
+      if (path === "dogs") return jsonResponse(201, {});
+      if (path === "walks" && (options.method || "GET") === "POST") {
+        const payload = JSON.parse(options.body || "{}");
+        postedBodies.push(payload);
+        if (postedBodies.length === 1) {
+          return jsonResponse(400, { message: "null value in column \"date\" of relation \"walks\" violates not-null constraint" });
+        }
+        return jsonResponse(201, {});
+      }
+      if (path === "sessions") return jsonResponse(200, []);
+      if (path === "walks") return jsonResponse(200, []);
+      if (path === "patterns") return jsonResponse(200, []);
+      if (path === "feedings") return jsonResponse(200, []);
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const { syncPushTombstone } = await setupStorageModule();
+    const result = await syncPushTombstone("DOG7", {
+      id: "walk-dead",
+      kind: "walk",
+      deletedAt: "2026-04-03T09:00:00.000Z",
+      updatedAt: "2026-04-03T09:00:00.000Z",
+      revision: 11,
+    }, { id: "DOG7", dogName: "Skye" });
+
+    expect(result.ok).toBe(true);
+    expect(postedBodies).toHaveLength(2);
+    expect(postedBodies[0]).toEqual({
+      id: "walk-dead",
+      dog_id: "DOG7",
+      deleted_at: "2026-04-03T09:00:00.000Z",
+      revision: 11,
+      updated_at: "2026-04-03T09:00:00.000Z",
+    });
+    expect(postedBodies[1]).toMatchObject({
+      id: "walk-dead",
+      dog_id: "DOG7",
+      deleted_at: "2026-04-03T09:00:00.000Z",
+      revision: 11,
+      updated_at: "2026-04-03T09:00:00.000Z",
+      date: "2026-04-03T09:00:00.000Z",
+      duration: 0,
+      walk_type: "regular_walk",
+    });
+  });
+
+  it("keeps delete tombstones durable when strict-schema fallback is used", async () => {
+    const postedBodies = [];
+    global.fetch = vi.fn(async (url, options = {}) => {
+      const { path } = getPathAndParams(url);
+      if (path === "dogs") return jsonResponse(201, {});
+      if (path === "feedings" && (options.method || "GET") === "POST") {
+        const payload = JSON.parse(options.body || "{}");
+        postedBodies.push(payload);
+        if (postedBodies.length === 1) {
+          return jsonResponse(400, { message: "null value in column \"date\" of relation \"feedings\" violates not-null constraint" });
+        }
+        return jsonResponse(201, {});
+      }
+      if (path === "sessions") return jsonResponse(200, []);
+      if (path === "walks") return jsonResponse(200, []);
+      if (path === "patterns") return jsonResponse(200, []);
+      if (path === "feedings") return jsonResponse(200, []);
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const { syncPushTombstone } = await setupStorageModule();
+    const result = await syncPushTombstone("DOG8", {
+      id: "feeding-dead",
+      kind: "feeding",
+      deletedAt: "2026-04-04T08:30:00.000Z",
+      revision: 3,
+    }, { id: "DOG8", dogName: "Mochi" });
+
+    expect(result.ok).toBe(true);
+    expect(postedBodies).toHaveLength(2);
+    expect(postedBodies[1]).toMatchObject({
+      id: "feeding-dead",
+      dog_id: "DOG8",
+      deleted_at: "2026-04-04T08:30:00.000Z",
+      date: "2026-04-04T08:30:00.000Z",
+      food_type: "tombstone",
+      amount: "0",
+      revision: 3,
+      updated_at: "2026-04-04T08:30:00.000Z",
+    });
+  });
 });


### PR DESCRIPTION
### Motivation
- Tombstone upserts previously sent only deletion metadata (`id`, `dog_id`, `deleted_at`, `revision`, `updated_at`) which can fail against remote schemas that declare other columns `NOT NULL`, risking non-durable remote deletes.
- The change must preserve existing delete semantics and avoid modifying application business logic or session/progression/recovery behaviors.

### Description
- Added `buildSchemaCompatibleTombstonePayload` to construct per-kind schema-compatible tombstone rows for `session`, `walk`, `pattern`, and `feeding` that include required non-null columns while preserving `deleted_at`, `revision`, and `updated_at` metadata.
- Updated `syncPushTombstone` to first attempt the lightweight metadata-only upsert and then detect not-null constraint failures via `isStrictSchemaNotNullError` and retry with the schema-compatible payload; also normalized tombstone `revision` fallback to `0` instead of `null` to avoid not-null failures.
- Introduced `isStrictSchemaNotNullError` helper and a small `pushPayload` wrapper to reuse the POST logic; no business logic outside sync pathways was changed.
- Modified files: `src/features/app/storage.js` (tombstone helpers and retry flow) and `tests/syncFetchRuntime.test.js` (added strict-schema tombstone tests and durability checks).

### Testing
- Ran `npm test -- tests/syncFetchRuntime.test.js` and the suite passed: 9 tests, all green.
- Added tests verifying the retry path: `retries tombstone push with strict-schema compatible payload after not-null failure` and durability test `keeps delete tombstones durable when strict-schema fallback is used`, and both passed. 
- Verified existing tombstone push test (`syncPushTombstone sends deletion markers to remote rows`) still passes after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfced3640c83329f186c2db0ce62aa)