### PR TITLE
Make tombstone keys entity-kind-aware (fix SYNC-003)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import { PROTOCOL, explainNextTarget, normalizeDistressLevel, suggestNext, sugge
 import { sortByDateAsc } from "./lib/activityDateTime";
 import { sortValidDateAsc } from "./lib/dateSort";
 import { selectAppData } from "./features/app/selectors";
-import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeById, mergeMutationSafeSyncCollection, mergeSessionWithDerivedFields, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, save, sessKey, syncDelete, syncDeleteSessionsForDog, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
+import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeMutationSafeSyncCollection, mergeSessionWithDerivedFields, mergeTombstonesByEntityKey, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, save, sessKey, syncDelete, syncDeleteSessionsForDog, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
 import { fmt, fmtClock, getOutcomeTone, normalizeWalkType, walkTypeLabel } from "./features/app/helpers";
 import { CameraIcon, ChartIcon, HistoryIcon, HomeIcon, PawIcon, SettingsIcon } from "./features/app/ui.jsx";
 import { DogSelect, Onboarding } from "./features/setup/SetupScreens";
@@ -301,7 +301,7 @@ export default function PawTimer() {
     commitTombstones((prev) => {
       const existing = prev.find((row) => row.id === entry.id && row.kind === kind) ?? null;
       created = makeLocalTombstone(kind, entry, existing);
-      return mergeById(prev, [created]);
+      return mergeTombstonesByEntityKey(prev, [created]);
     });
     return created;
   }, [commitTombstones, makeLocalTombstone]);
@@ -447,7 +447,7 @@ export default function PawTimer() {
         const remotePatterns = ensureArray(remote.patterns);
         const remoteFeedings = normalizeFeedings(remote.feedings);
 
-        const mergedTombstones = commitTombstones((prev) => mergeById(
+        const mergedTombstones = commitTombstones((prev) => mergeTombstonesByEntityKey(
           normalizeTombstones(prev).map(withHydratedSyncState),
           normalizeTombstones(remote.tombstones).map(markRemoteEntryConfirmed),
         ));

--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -229,6 +229,24 @@ export const mergeById = (a = [], b = [], pickWinner = resolveSyncConflict) => {
   return sortByDateAsc(Array.from(merged.values()));
 };
 
+export const tombstoneEntityKey = (entry = {}) => {
+  const kind = normalizeTombstoneKind(entry?.kind ?? entry?.type);
+  const id = String(entry?.id || "");
+  if (!kind || !id) return "";
+  return `${kind}:${id}`;
+};
+
+export const mergeTombstonesByEntityKey = (a = [], b = [], pickWinner = resolveSyncConflict) => {
+  const merged = new Map();
+  [...ensureArray(a), ...ensureArray(b)].forEach((item) => {
+    const key = tombstoneEntityKey(item);
+    if (!key) return;
+    const previous = merged.get(key);
+    merged.set(key, previous ? pickWinner(previous, item) : item);
+  });
+  return sortByDateAsc(Array.from(merged.values()));
+};
+
 export const mergeMutationSafeSyncCollection = ({
   currentItems = [],
   remoteItems = [],
@@ -542,9 +560,9 @@ const isEntrySuppressedByTombstone = (entry, tombstone) => {
 export const applyTombstonesToCollection = (items = [], tombstones = [], kind = "") => {
   const activeTombstones = normalizeTombstones(tombstones).filter((row) => row.kind === kind);
   if (!activeTombstones.length) return ensureArray(items);
-  const tombstoneById = new Map(activeTombstones.map((row) => [row.id, row]));
+  const tombstoneByEntity = new Map(activeTombstones.map((row) => [tombstoneEntityKey(row), row]));
   return ensureArray(items).filter((entry) => {
-    const tombstone = tombstoneById.get(entry?.id);
+    const tombstone = tombstoneByEntity.get(tombstoneEntityKey({ id: entry?.id, kind }));
     if (!tombstone) return true;
     return !isEntrySuppressedByTombstone(entry, tombstone);
   });

--- a/tests/syncConflict.test.js
+++ b/tests/syncConflict.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mergeMutationSafeSyncCollection, resolveSyncConflict } from "../src/features/app/storage";
+import { applyTombstonesToCollection, mergeMutationSafeSyncCollection, mergeTombstonesByEntityKey, resolveSyncConflict } from "../src/features/app/storage";
 
 const iso = (hour) => `2026-04-01T${String(hour).padStart(2, "0")}:00:00.000Z`;
 
@@ -170,5 +170,38 @@ describe("mergeMutationSafeSyncCollection concurrent edits", () => {
     });
 
     expect(mergedTombstones).toEqual(localTombstones);
+  });
+
+  it("keeps tombstones for different kinds when ids match", () => {
+    const localTombstones = [{ id: "shared-1", kind: "session", deletedAt: iso(9), revision: 2, updatedAt: iso(9), pendingSync: true }];
+    const remoteTombstones = [{ id: "shared-1", kind: "walk", deletedAt: iso(10), revision: 3, updatedAt: iso(10), pendingSync: false }];
+
+    const mergedTombstones = mergeTombstonesByEntityKey(localTombstones, remoteTombstones);
+
+    expect(mergedTombstones).toHaveLength(2);
+    expect(mergedTombstones).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "shared-1", kind: "session" }),
+      expect.objectContaining({ id: "shared-1", kind: "walk" }),
+    ]));
+  });
+
+  it("suppresses only matching kind when id is shared across kinds", () => {
+    const tombstones = [
+      { id: "shared-2", kind: "session", deletedAt: iso(12), revision: 4, updatedAt: iso(12) },
+      { id: "shared-2", kind: "walk", deletedAt: iso(13), revision: 5, updatedAt: iso(13) },
+    ];
+    const sessions = [
+      { id: "shared-2", date: iso(8), revision: 1, updatedAt: iso(8), result: "success" },
+      { id: "session-live", date: iso(9), revision: 1, updatedAt: iso(9), result: "success" },
+    ];
+    const feedings = [
+      { id: "shared-2", date: iso(8), revision: 1, updatedAt: iso(8), foodType: "meal", amount: "small" },
+    ];
+
+    const filteredSessions = applyTombstonesToCollection(sessions, tombstones, "session");
+    const filteredFeedings = applyTombstonesToCollection(feedings, tombstones, "feeding");
+
+    expect(filteredSessions.map((row) => row.id)).toEqual(["session-live"]);
+    expect(filteredFeedings.map((row) => row.id)).toEqual(["shared-2"]);
   });
 });


### PR DESCRIPTION
### Motivation
- Tombstones were being merged and keyed by `id` only which allowed tombstones for different entity kinds to collide when they shared the same `id`, causing incorrect suppression/resurrection across kinds.
- The change confines behavior to the sync/tombstone layer only and preserves application business logic and recommendation/session/progression/recovery semantics.

### Description
- Introduced a composite tombstone key model `tombstoneEntityKey(entry)` which returns `"${kind}:${id}"` after normalizing `kind` and `id`.
- Added `mergeTombstonesByEntityKey` as a tombstone-specific merge helper that keys on the composite entity key and uses the existing conflict resolver (`resolveSyncConflict`).
- Switched tombstone merge callsites to the new helper (local tombstone creation and remote/local tombstone merge during sync) and changed suppression lookup in `applyTombstonesToCollection` to use the composite key map so suppression is kind-aware.
- Kept tombstone durability, sync retry, and all higher-level business logic unchanged; changes are localized to the sync/tombstone layer (`src/features/app/storage.js` and small call sites in `src/App.jsx`).

### Testing
- Added regression tests in `tests/syncConflict.test.js` that verify two different kinds can share the same `id` without tombstone collision and that suppression only affects the matching kind.
- Ran the modified test file with `npm test -- tests/syncConflict.test.js` and all tests passed (15 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd3199b2083328b3d39aa3fd92940)