### PR TITLE
Fix SYNC-004: deterministic dog settings sync conflict resolution

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import { PROTOCOL, explainNextTarget, normalizeDistressLevel, suggestNext, sugge
 import { sortByDateAsc } from "./lib/activityDateTime";
 import { sortValidDateAsc } from "./lib/dateSort";
 import { selectAppData } from "./features/app/selectors";
-import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeMutationSafeSyncCollection, mergeSessionWithDerivedFields, mergeTombstonesByEntityKey, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, save, sessKey, syncDelete, syncDeleteSessionsForDog, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
+import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeMutationSafeSyncCollection, mergeSessionWithDerivedFields, mergeTombstonesByEntityKey, normalizeDogSyncMetadata, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, resolveDogSettingsConflict, save, sessKey, stampLocalDogSettings, syncDelete, syncDeleteSessionsForDog, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
 import { fmt, fmtClock, getOutcomeTone, normalizeWalkType, walkTypeLabel } from "./features/app/helpers";
 import { CameraIcon, ChartIcon, HistoryIcon, HomeIcon, PawIcon, SettingsIcon } from "./features/app/ui.jsx";
 import { DogSelect, Onboarding } from "./features/setup/SetupScreens";
@@ -433,10 +433,14 @@ export default function PawTimer() {
         if (!remote) { setSyncStatus("err"); setSyncError(error || "Unknown sync fetch error"); return; }
 
         const snapshot = syncSnapshotRef.current;
-        const remoteDog = remote.dog ? { ...remote.dog, id: canonicalDogId(remote.dog.id || activeDogId) } : null;
+        const remoteDog = remote.dog ? normalizeDogSyncMetadata({ ...remote.dog, id: canonicalDogId(remote.dog.id || activeDogId) }) : null;
         if (remoteDog) {
           setDogs((prev) => {
-            const next = [...prev.filter((d) => canonicalDogId(d.id) !== remoteDog.id), remoteDog];
+            const existingDog = prev.find((d) => canonicalDogId(d.id) === remoteDog.id) ?? null;
+            const resolvedDog = existingDog
+              ? resolveDogSettingsConflict(normalizeDogSyncMetadata(existingDog), remoteDog)
+              : remoteDog;
+            const next = [...prev.filter((d) => canonicalDogId(d.id) !== remoteDog.id), resolvedDog];
             save(DOGS_KEY, next);
             return next;
           });
@@ -643,8 +647,14 @@ export default function PawTimer() {
       const { result: remote, error } = await syncFetch(normalizedId);
       setSyncDegradation(getSyncDegradationState());
       if (!remote?.dog) { setSyncStatus("err"); setSyncError(error || `No shared dog account found for ${normalizedId}`); showToast(`No shared profile found for ${normalizedId} yet.`); return; }
-      const sharedDog = { ...remote.dog, id: normalizedId };
-      setDogs((prev) => [...prev.filter((d) => canonicalDogId(d.id) !== normalizedId), sharedDog]);
+      const sharedDog = normalizeDogSyncMetadata({ ...remote.dog, id: normalizedId });
+      setDogs((prev) => {
+        const existing = prev.find((d) => canonicalDogId(d.id) === normalizedId) ?? null;
+        const resolvedDog = existing
+          ? resolveDogSettingsConflict(normalizeDogSyncMetadata(existing), sharedDog)
+          : sharedDog;
+        return [...prev.filter((d) => canonicalDogId(d.id) !== normalizedId), resolvedDog];
+      });
       const joinedSessions = sortByDateAsc(normalizeSessions(remote.sessions).map(markRemoteEntryConfirmed));
       const joinedWalks = sortByDateAsc(ensureArray(remote.walks).map((item) => markRemoteEntryConfirmed({ ...item, type: normalizeWalkType(item?.type) })));
       const joinedPatterns = sortByDateAsc(ensureArray(remote.patterns).map(markRemoteEntryConfirmed));
@@ -679,14 +689,15 @@ export default function PawTimer() {
     const onboardingDogId = canonicalDogId(onboardingState?.dogId);
     const id = canonicalDogId(onboardingDogId || activeDogId || generateId(data.dogName));
     const isFreshProfile = onboardingState?.mode === "new";
-    const newDog = {
+    const previousDog = dogs.find((d) => canonicalDogId(d.id) === id) ?? null;
+    const newDog = stampLocalDogSettings({
       ...data,
       id,
       dogName: data.dogName,
       createdAt: new Date().toISOString(),
-    };
+    }, previousDog);
     if (isFreshProfile) clearDogActivityState(id);
-    setDogs((prev) => [...prev.filter((d) => d.id !== id), newDog]);
+    setDogs((prev) => [...prev.filter((d) => canonicalDogId(d.id) !== id), newDog]);
     setOnboardingState(null);
     setActiveDogId(id);
     setTab("home");
@@ -814,7 +825,7 @@ export default function PawTimer() {
         if (canonicalDogId(dog?.id) !== canonicalDogId(activeDogId)) return dog;
         if (recoveryStateEqual(dog?.recoveryState, nextRecoveryState)) return dog;
         changed = true;
-        return { ...dog, recoveryState: nextRecoveryState };
+        return stampLocalDogSettings({ ...dog, recoveryState: nextRecoveryState }, dog);
       });
       return changed ? updated : prev;
     });

--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -183,6 +183,63 @@ const getRecordRevision = (item = {}) => {
 
 const getRecordUpdatedAt = (item = {}) => item.updatedAt ?? item.updated_at ?? item.localUpdatedAt ?? item.local_updated_at ?? null;
 const getRecordDeletedAt = (item = {}) => item.deletedAt ?? item.deleted_at ?? null;
+const isFiniteNumber = (value) => Number.isFinite(Number(value));
+
+const stableStringify = (value) => {
+  if (Array.isArray(value)) return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  if (value && typeof value === "object") {
+    const sortedKeys = Object.keys(value).sort();
+    return `{${sortedKeys.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+};
+
+export const normalizeDogSyncMetadata = (dog = {}) => {
+  const id = canonicalDogId(dog?.id);
+  const revision = isFiniteNumber(dog?.revision) ? Number(dog.revision) : null;
+  const updatedAt = getRecordUpdatedAt(dog);
+  return {
+    ...(dog && typeof dog === "object" ? dog : {}),
+    id,
+    revision,
+    updatedAt: updatedAt || null,
+  };
+};
+
+export const stampLocalDogSettings = (nextDog = {}, previousDog = null) => {
+  const normalizedNext = normalizeDogSyncMetadata(nextDog);
+  const normalizedPrev = normalizeDogSyncMetadata(previousDog || {});
+  const previousRevision = Number.isFinite(normalizedPrev.revision)
+    ? normalizedPrev.revision
+    : Number.isFinite(normalizedNext.revision)
+      ? normalizedNext.revision
+      : 0;
+  return {
+    ...normalizedNext,
+    revision: previousRevision + 1,
+    updatedAt: new Date().toISOString(),
+  };
+};
+
+export const resolveDogSettingsConflict = (leftDog = {}, rightDog = {}) => {
+  const left = normalizeDogSyncMetadata(leftDog);
+  const right = normalizeDogSyncMetadata(rightDog);
+  if (!left.id && right.id) return right;
+  if (!right.id && left.id) return left;
+
+  const winner = resolveSyncConflict(left, right);
+  const loser = winner === left ? right : left;
+  const winnerRevision = getRecordRevision(winner);
+  const loserRevision = getRecordRevision(loser);
+  const winnerUpdatedAt = toTimestamp(getRecordUpdatedAt(winner));
+  const loserUpdatedAt = toTimestamp(getRecordUpdatedAt(loser));
+  if (winnerRevision !== loserRevision || winnerUpdatedAt !== loserUpdatedAt) return winner;
+
+  const leftFingerprint = stableStringify(left);
+  const rightFingerprint = stableStringify(right);
+  if (leftFingerprint === rightFingerprint) return right;
+  return leftFingerprint > rightFingerprint ? left : right;
+};
 
 export const resolveSyncConflict = (left = {}, right = {}) => {
   const leftDeletedAt = toTimestamp(getRecordDeletedAt(left));
@@ -822,11 +879,19 @@ export const syncFetch = async (dogId) => {
 
 
 export const syncUpsertDog = async (dog) => {
-  const id = canonicalDogId(dog?.id);
+  const localDog = normalizeDogSyncMetadata(dog);
+  const id = canonicalDogId(localDog?.id);
   if (!id) return { ok: false, error: "Dog ID missing" };
+  const remoteLookup = await sbReq(`dogs?id=eq.${encodeURIComponent(id)}&select=id,settings&limit=1`, { trigger: "syncUpsertDog:lookup" });
+  if (!remoteLookup.ok) return { ok: false, error: `Dog lookup failed before upsert: ${remoteLookup.error}` };
+  const remoteRow = Array.isArray(remoteLookup.data) ? remoteLookup.data[0] : null;
+  const remoteDog = remoteRow?.settings && typeof remoteRow.settings === "object"
+    ? normalizeDogSyncMetadata({ ...remoteRow.settings, id: canonicalDogId(remoteRow.id) })
+    : { id };
+  const mergedDog = resolveDogSettingsConflict(localDog, remoteDog);
   const res = await sbReq("dogs", {
     method: "POST",
-    body: JSON.stringify({ id, settings: { ...(dog || {}), id } }),
+    body: JSON.stringify({ id, settings: { ...mergedDog, id } }),
     prefer: "resolution=merge-duplicates,return=minimal",
   });
   return res.ok ? { ok: true, error: null } : { ok: false, error: `Dog upsert failed: ${res.error}` };

--- a/tests/syncConflict.test.js
+++ b/tests/syncConflict.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyTombstonesToCollection, mergeMutationSafeSyncCollection, mergeTombstonesByEntityKey, resolveSyncConflict } from "../src/features/app/storage";
+import { applyTombstonesToCollection, mergeMutationSafeSyncCollection, mergeTombstonesByEntityKey, resolveDogSettingsConflict, resolveSyncConflict } from "../src/features/app/storage";
 
 const iso = (hour) => `2026-04-01T${String(hour).padStart(2, "0")}:00:00.000Z`;
 
@@ -203,5 +203,32 @@ describe("mergeMutationSafeSyncCollection concurrent edits", () => {
 
     expect(filteredSessions.map((row) => row.id)).toEqual(["session-live"]);
     expect(filteredFeedings.map((row) => row.id)).toEqual(["shared-2"]);
+  });
+});
+
+describe("resolveDogSettingsConflict", () => {
+  it("keeps local settings when local metadata is newer", () => {
+    const localDog = { id: "DOG-A", dogName: "Luna", revision: 5, updatedAt: iso(11) };
+    const remoteDog = { id: "DOG-A", dogName: "Luna Remote", revision: 4, updatedAt: iso(12) };
+
+    expect(resolveDogSettingsConflict(localDog, remoteDog)).toEqual(localDog);
+  });
+
+  it("uses remote settings when remote metadata is newer", () => {
+    const localDog = { id: "DOG-B", dogName: "Milo", revision: 3, updatedAt: iso(9) };
+    const remoteDog = { id: "DOG-B", dogName: "Milo Remote", revision: 3, updatedAt: iso(10) };
+
+    expect(resolveDogSettingsConflict(localDog, remoteDog)).toEqual(remoteDog);
+  });
+
+  it("resolves concurrent same-metadata edits deterministically", () => {
+    const localDog = { id: "DOG-C", dogName: "Nova", goalSeconds: 1800, revision: 7, updatedAt: iso(13) };
+    const remoteDog = { id: "DOG-C", dogName: "Nova", goalSeconds: 2400, revision: 7, updatedAt: iso(13) };
+
+    const winnerFromLocalFirst = resolveDogSettingsConflict(localDog, remoteDog);
+    const winnerFromRemoteFirst = resolveDogSettingsConflict(remoteDog, localDog);
+
+    expect(winnerFromLocalFirst).toEqual(winnerFromRemoteFirst);
+    expect(winnerFromLocalFirst).toEqual(remoteDog);
   });
 });


### PR DESCRIPTION
### Motivation
- Dog settings were being overwritten by blind remote upserts and unconditional remote replacements during join/fetch, allowing stale remote data to silently overwrite newer local edits. 
- The goal is to make dog-settings sync deterministic and conflict-safe while keeping business logic, recommendation, and session semantics unchanged. 

### Description
- Added deterministic dog-settings sync utilities: `normalizeDogSyncMetadata`, `stampLocalDogSettings`, and `resolveDogSettingsConflict` which prefer `revision`, then `updatedAt`, then a stable content-based fingerprint tie-breaker for true concurrent ties. 
- Introduced helper functions `isFiniteNumber` and `stableStringify` to support deterministic fingerprinting and metadata normalization. 
- Hardened `syncUpsertDog` so it performs a remote lookup and upserts the conflict-resolved winner instead of blindly posting local settings. 
- Updated UI sync merge paths in `App.jsx` to: normalize remote dog payloads with `normalizeDogSyncMetadata`, merge local vs remote using `resolveDogSettingsConflict`, and `stampLocalDogSettings` when creating/updating local dog metadata (onboarding and recovery-state updates). 
- Added tests for dog-settings conflict handling and integrated them into existing sync conflict tests without changing other sync behavior. 

### Testing
- Ran `npm test -- --run tests/syncConflict.test.js tests/syncFetchRuntime.test.js` which executed the updated conflict tests and existing sync-fetch runtime tests. 
- All tests passed: both `tests/syncConflict.test.js` and `tests/syncFetchRuntime.test.js` completed successfully (total: 27 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd48dec148332a42088e94b49eb07)