### PR TITLE
Fix SYNC-006: conservative tombstone retention and safe GC

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import { PROTOCOL, explainNextTarget, normalizeDistressLevel, suggestNext, sugge
 import { sortByDateAsc } from "./lib/activityDateTime";
 import { sortValidDateAsc } from "./lib/dateSort";
 import { selectAppData } from "./features/app/selectors";
-import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeMutationSafeSyncCollection, mergeSessionWithDerivedFields, mergeTombstonesByEntityKey, normalizeDogSyncMetadata, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, resolveDogSettingsConflict, save, sessKey, stampLocalDogSettings, syncDelete, syncDeleteSessionsForDog, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
+import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeMutationSafeSyncCollection, mergeSessionWithDerivedFields, mergeTombstonesByEntityKey, normalizeDogSyncMetadata, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, pruneTombstonesForRetention, resolveDogSettingsConflict, save, sessKey, stampLocalDogSettings, syncDelete, syncDeleteSessionsForDog, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
 import { fmt, fmtClock, getOutcomeTone, normalizeWalkType, walkTypeLabel } from "./features/app/helpers";
 import { CameraIcon, ChartIcon, HistoryIcon, HomeIcon, PawIcon, SettingsIcon } from "./features/app/ui.jsx";
 import { DogSelect, Onboarding } from "./features/setup/SetupScreens";
@@ -167,6 +167,7 @@ export default function PawTimer() {
       deletedAt,
       updatedAt: deletedAt,
       revision: previousRevision + 1,
+      replicationConfirmed: false,
       pendingSync: syncState !== SYNC_STATE.SYNCED,
       syncState,
       syncError: syncState === SYNC_STATE.ERROR ? syncErrorMessage : "",
@@ -453,7 +454,10 @@ export default function PawTimer() {
 
         const mergedTombstones = commitTombstones((prev) => mergeTombstonesByEntityKey(
           normalizeTombstones(prev).map(withHydratedSyncState),
-          normalizeTombstones(remote.tombstones).map(markRemoteEntryConfirmed),
+          normalizeTombstones(remote.tombstones).map((entry) => ({
+            ...markRemoteEntryConfirmed(entry),
+            replicationConfirmed: true,
+          })),
         ));
         const mergedSessions = syncHelpersRef.current.commitSessions((prev) => mergeMutationSafeSyncCollection({
           currentItems: prev,
@@ -514,6 +518,14 @@ export default function PawTimer() {
           setSyncStatus("err");
           return;
         }
+        commitTombstones((prev) => pruneTombstonesForRetention(prev, {
+          activityByKind: {
+            session: mergedSessions,
+            walk: mergedWalks,
+            pattern: mergedPatterns,
+            feeding: mergedFeedings,
+          },
+        }));
         setSyncError(error || "");
         setSyncStatus(error ? "err" : "ok");
       } finally {

--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -598,6 +598,7 @@ export const normalizeTombstones = (rows = []) => ensureArray(rows)
     deletedAt: row?.deletedAt ?? row?.deleted_at ?? row?.updatedAt ?? row?.updated_at ?? null,
     revision: normalizeRevision(row?.revision),
     updatedAt: normalizeUpdatedAt(row),
+    replicationConfirmed: Boolean(row?.replicationConfirmed),
     pendingSync: Boolean(row?.pendingSync),
     syncState: row?.syncState,
     syncError: row?.syncError ?? "",
@@ -624,6 +625,27 @@ export const applyTombstonesToCollection = (items = [], tombstones = [], kind = 
     return !isEntrySuppressedByTombstone(entry, tombstone);
   });
 };
+
+export const TOMBSTONE_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+const hasConflictingActiveEntity = (entry, activityByKind = {}) => {
+  const activeRows = ensureArray(activityByKind?.[entry?.kind]);
+  return activeRows.some((row) => String(row?.id || "") === entry.id);
+};
+
+export const pruneTombstonesForRetention = (rows = [], {
+  now = Date.now(),
+  retentionMs = TOMBSTONE_RETENTION_MS,
+  activityByKind = {},
+} = {}) => normalizeTombstones(rows).filter((entry) => {
+  if (!entry.replicationConfirmed) return true;
+  if (entry.pendingSync) return true;
+  if (entry.syncState && entry.syncState !== "synced") return true;
+  if (hasConflictingActiveEntity(entry, activityByKind)) return true;
+  const deletedAtTs = toTimestamp(entry.deletedAt);
+  if (!deletedAtTs) return true;
+  return (now - deletedAtTs) < retentionMs;
+});
 
 export const SESSION_SYNC_FETCH_FIELD_MAP = {
   plannedDuration: "planned_duration",

--- a/tests/syncConflict.test.js
+++ b/tests/syncConflict.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyTombstonesToCollection, mergeMutationSafeSyncCollection, mergeTombstonesByEntityKey, resolveDogSettingsConflict, resolveSyncConflict } from "../src/features/app/storage";
+import { applyTombstonesToCollection, mergeMutationSafeSyncCollection, mergeTombstonesByEntityKey, pruneTombstonesForRetention, resolveDogSettingsConflict, resolveSyncConflict, TOMBSTONE_RETENTION_MS } from "../src/features/app/storage";
 
 const iso = (hour) => `2026-04-01T${String(hour).padStart(2, "0")}:00:00.000Z`;
 
@@ -203,6 +203,60 @@ describe("mergeMutationSafeSyncCollection concurrent edits", () => {
 
     expect(filteredSessions.map((row) => row.id)).toEqual(["session-live"]);
     expect(filteredFeedings.map((row) => row.id)).toEqual(["shared-2"]);
+  });
+});
+
+describe("tombstone retention/GC policy", () => {
+  it("retains confirmed tombstones until retention TTL elapses", () => {
+    const now = Date.parse("2026-05-15T00:00:00.000Z");
+    const tombstones = [
+      {
+        id: "session-ttl",
+        kind: "session",
+        deletedAt: new Date(now - TOMBSTONE_RETENTION_MS + 10_000).toISOString(),
+        updatedAt: new Date(now - TOMBSTONE_RETENTION_MS + 10_000).toISOString(),
+        revision: 4,
+        replicationConfirmed: true,
+        pendingSync: false,
+        syncState: "synced",
+      },
+    ];
+
+    const retained = pruneTombstonesForRetention(tombstones, { now });
+    expect(retained).toHaveLength(1);
+    expect(retained[0].id).toBe("session-ttl");
+  });
+
+  it("prunes only confirmed + synced tombstones after retention TTL", () => {
+    const now = Date.parse("2026-06-20T00:00:00.000Z");
+    const oldDate = new Date(now - TOMBSTONE_RETENTION_MS - 1_000).toISOString();
+    const tombstones = [
+      { id: "session-old-confirmed", kind: "session", deletedAt: oldDate, updatedAt: oldDate, revision: 7, replicationConfirmed: true, pendingSync: false, syncState: "synced" },
+      { id: "session-old-unconfirmed", kind: "session", deletedAt: oldDate, updatedAt: oldDate, revision: 7, replicationConfirmed: false, pendingSync: false, syncState: "synced" },
+      { id: "session-old-pending", kind: "session", deletedAt: oldDate, updatedAt: oldDate, revision: 7, replicationConfirmed: true, pendingSync: true, syncState: "syncing" },
+    ];
+
+    const retained = pruneTombstonesForRetention(tombstones, { now });
+    expect(retained.map((entry) => entry.id)).toEqual(["session-old-unconfirmed", "session-old-pending"]);
+  });
+
+  it("prevents resurrection by keeping tombstone when same id is still present in active collection", () => {
+    const now = Date.parse("2026-06-20T00:00:00.000Z");
+    const oldDate = new Date(now - TOMBSTONE_RETENTION_MS - 1_000).toISOString();
+    const tombstones = [
+      { id: "walk-restore-risk", kind: "walk", deletedAt: oldDate, updatedAt: oldDate, revision: 3, replicationConfirmed: true, pendingSync: false, syncState: "synced" },
+    ];
+    const activeWalks = [{ id: "walk-restore-risk", date: iso(10), revision: 1, updatedAt: iso(10), duration: 300 }];
+
+    const retained = pruneTombstonesForRetention(tombstones, {
+      now,
+      activityByKind: {
+        walk: activeWalks,
+      },
+    });
+
+    expect(retained).toHaveLength(1);
+    expect(retained[0].id).toBe("walk-restore-risk");
   });
 });
 


### PR DESCRIPTION
### Motivation
- Current behavior: tombstones were normalized, merged, and persisted but never pruned, causing unbounded tombstone growth and long-term suppression drift. 
- Goal: introduce a conservative, deterministic GC policy that bounds tombstone growth while preserving delete durability and avoiding resurrecting deleted entities.

### Description
- Added a `replicationConfirmed` flag to normalized tombstones and a `TOMBSTONE_RETENTION_MS` constant (30 days) and exported `pruneTombstonesForRetention` in `src/features/app/storage.js` to implement TTL-based, conservative pruning logic. 
- `pruneTombstonesForRetention` keeps a tombstone unless it is replication-confirmed, not pending, in `synced` state, older than the TTL, and there is no conflicting active entity with the same `{kind,id}`; it also accepts `activityByKind` to guard against resurrection. 
- Mark remote-fetched tombstones as `replicationConfirmed: true` during the sync merge and ensure locally-created tombstones start with `replicationConfirmed: false`, then run the prune step in the sync loop only after all pending entries and tombstone pushes are flushed; changes in `src/App.jsx` and `src/features/app/storage.js`. 
- Added unit tests in `tests/syncConflict.test.js` covering confirmed tombstone retention until TTL, pruning only after confirmed+synced+TTL, and the no-resurrection guard; no application business logic, recommendation, session, progression, or recovery code was modified.

### Testing
- Added tests: `tombstone retention/GC policy` cases in `tests/syncConflict.test.js` for TTL retention, safe prune, and no-resurrection behavior. 
- Ran `npm test -- tests/syncConflict.test.js` and the single-file suite passed, and ran the full suite with `npm test` with all tests passing. 
- All automated tests succeeded (full test suite green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd5a29d2c83328f40abd299e2ff79)