### PR TITLE
Fix SYNC-005: make clear-sessions sync contract tombstone-only

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import { PROTOCOL, explainNextTarget, normalizeDistressLevel, suggestNext, sugge
 import { sortByDateAsc } from "./lib/activityDateTime";
 import { sortValidDateAsc } from "./lib/dateSort";
 import { selectAppData } from "./features/app/selectors";
-import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeMutationSafeSyncCollection, mergeSessionWithDerivedFields, mergeTombstonesByEntityKey, normalizeDogSyncMetadata, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, pruneTombstonesForRetention, resolveDogSettingsConflict, save, sessKey, stampLocalDogSettings, syncDelete, syncDeleteSessionsForDog, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
+import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeMutationSafeSyncCollection, mergeSessionWithDerivedFields, mergeTombstonesByEntityKey, normalizeDogSyncMetadata, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, pruneTombstonesForRetention, resolveDogSettingsConflict, save, sessKey, stampLocalDogSettings, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
 import { fmt, fmtClock, getOutcomeTone, normalizeWalkType, walkTypeLabel } from "./features/app/helpers";
 import { CameraIcon, ChartIcon, HistoryIcon, HomeIcon, PawIcon, SettingsIcon } from "./features/app/ui.jsx";
 import { DogSelect, Onboarding } from "./features/setup/SetupScreens";
@@ -817,14 +817,11 @@ export default function PawTimer() {
     patLabels,
     showToast,
     pushWithSyncStatus,
-    syncDelete,
-    syncDeleteSessionsForDog,
     addTombstone,
     commitSessions,
     setWalks: commitWalks,
     setPatterns: commitPatterns,
     setFeedings: commitFeedings,
-    activeDogId,
     stampLocalEntry,
   });
 

--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -1139,11 +1139,6 @@ export const syncPushTombstone = async (dogId, tombstone, dogSettings = null) =>
   return res.ok ? { ok: true, error: null } : { ok: false, error: `${kind} tombstone push failed: ${res.error}` };
 };
 
-export const syncDeleteSessionsForDog = async (dogId) => {
-  const res = await sbReq(`sessions?dog_id=eq.${encodeURIComponent(canonicalDogId(dogId))}`, { method: "DELETE" });
-  return res.ok;
-};
-
 export const makeEntryId = (kind, dogId) => `${kind}-${canonicalDogId(dogId)}-${Date.now()}`;
 
 export const hydrateDogFromLocal = (dogId) => {

--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -55,14 +55,11 @@ export function useHistoryEditing({
   patLabels,
   showToast,
   pushWithSyncStatus,
-  syncDelete,
-  syncDeleteSessionsForDog,
   addTombstone,
   commitSessions,
   setWalks,
   setPatterns,
   setFeedings,
-  activeDogId,
   stampLocalEntry,
 }) {
   const openHistoryDurationEditor = (kind, entry, setHistoryModal) => {
@@ -210,6 +207,8 @@ export function useHistoryEditing({
     clearSessions: () => {
       if (window.confirm("Clear all training sessions?")) {
         commitSessions((prev) => {
+          // Canonical bulk-clear sync contract:
+          // clear locally and emit per-session tombstones for durable retry.
           prev.forEach((entry) => addTombstone("session", entry));
           return [];
         });

--- a/tests/historyDeleteMutations.test.js
+++ b/tests/historyDeleteMutations.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { suggestNextWithContext } from "../src/lib/protocol";
 import { useHistoryEditing } from "../src/features/history/HistoryFeature";
+import * as storage from "../src/features/app/storage";
 
 const makeIso = (value) => new Date(value).toISOString();
 
@@ -24,8 +25,6 @@ const buildDeleteActions = ({
   commitWalks,
   commitPatterns,
   commitFeedings,
-  syncDelete = vi.fn(() => Promise.resolve(true)),
-  syncDeleteSessionsForDog = vi.fn(() => Promise.resolve(true)),
   addTombstone = vi.fn(),
   showToast = vi.fn(),
 } = {}) => {
@@ -37,22 +36,17 @@ const buildDeleteActions = ({
     patLabels: {},
     showToast,
     pushWithSyncStatus: vi.fn(() => Promise.resolve({ ok: true })),
-    syncDelete,
-    syncDeleteSessionsForDog,
     addTombstone,
     commitSessions: commitSessions ?? vi.fn(),
     setWalks: commitWalks ?? vi.fn(),
     setPatterns: commitPatterns ?? vi.fn(),
     setFeedings: commitFeedings ?? vi.fn(),
-    activeDogId: "dog-1",
     stampLocalEntry: (entry) => ({ ...entry }),
   });
 
   return {
     actions,
     showToast,
-    syncDelete,
-    syncDeleteSessionsForDog,
     addTombstone,
     commitSessions: commitSessions ?? vi.fn(),
     commitWalks: commitWalks ?? vi.fn(),
@@ -62,10 +56,13 @@ const buildDeleteActions = ({
 };
 
 describe("history delete mutations", () => {
+  it("removes the dead remote bulk-delete session contract from sync API surface", () => {
+    expect(storage.syncDeleteSessionsForDog).toBeUndefined();
+  });
+
   it("creates tombstones for every session during bulk clear", () => {
     const commitSessions = vi.fn();
     const addTombstone = vi.fn();
-    const syncDeleteSessionsForDog = vi.fn(() => Promise.resolve(true));
     const originalWindow = globalThis.window;
     globalThis.window = { confirm: vi.fn(() => true) };
     const { actions } = buildDeleteActions({
@@ -75,7 +72,6 @@ describe("history delete mutations", () => {
       ],
       commitSessions,
       addTombstone,
-      syncDeleteSessionsForDog,
     });
 
     actions.clearSessions();
@@ -84,7 +80,37 @@ describe("history delete mutations", () => {
     expect(clearUpdater([{ ...baseSession, id: "sess-1" }, { ...baseSession, id: "sess-2" }])).toEqual([]);
     expect(addTombstone).toHaveBeenCalledTimes(2);
     expect(addTombstone.mock.calls.map((call) => call[0])).toEqual(["session", "session"]);
-    expect(syncDeleteSessionsForDog).not.toHaveBeenCalled();
+    globalThis.window = originalWindow;
+  });
+
+  it("keeps bulk clear retry-safe by only tombstoning sessions that still exist", () => {
+    const commitSessions = vi.fn();
+    const addTombstone = vi.fn();
+    const originalWindow = globalThis.window;
+    globalThis.window = { confirm: vi.fn(() => true) };
+    const { actions } = buildDeleteActions({
+      sessions: [
+        { ...baseSession, id: "sess-1" },
+        { ...baseSession, id: "sess-2", date: makeIso("2026-04-11T10:00:00Z") },
+      ],
+      commitSessions,
+      addTombstone,
+    });
+
+    actions.clearSessions();
+    actions.clearSessions();
+
+    const firstClearUpdater = commitSessions.mock.calls[0][0];
+    const secondClearUpdater = commitSessions.mock.calls[1][0];
+    const afterFirstClear = firstClearUpdater([
+      { ...baseSession, id: "sess-1" },
+      { ...baseSession, id: "sess-2", date: makeIso("2026-04-11T10:00:00Z") },
+    ]);
+    const afterSecondClear = secondClearUpdater(afterFirstClear);
+
+    expect(afterFirstClear).toEqual([]);
+    expect(afterSecondClear).toEqual([]);
+    expect(addTombstone.mock.calls.map((call) => call[1].id)).toEqual(["sess-1", "sess-2"]);
     globalThis.window = originalWindow;
   });
 


### PR DESCRIPTION
### Motivation
- There was an ambiguous split between local tombstone-based clears and an unused remote bulk-delete API (`syncDeleteSessionsForDog`), creating a hidden, dead sync contract and potential contract drift. 
- The goal is to make bulk-clear behavior explicit and durable without changing business logic or sync semantics for other flows.

### Description
- Chosen canonical contract: bulk clear is tombstone-only (local wipe + individual per-session tombstones) and is durable via the existing tombstone push/retry loop. 
- Removed the dead remote bulk-delete helper `syncDeleteSessionsForDog` from `src/features/app/storage.js` so no alternate bulk-delete contract remains. 
- Dropped unused `syncDelete`/`syncDeleteSessionsForDog` wiring from `useHistoryEditing` and the `App` callsite so the clear flow only uses tombstones. 
- Made the contract explicit by adding an inline comment at the `clearSessions` callsite and extended tests to assert behavior and idempotency.

### Testing
- Ran the unit tests: `npm test -- tests/historyDeleteMutations.test.js tests/historyDurationEditing.test.js`. 
- Test results: both test files passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd6e8ae008332912683347f9aadd9)