### PR TITLE
Make optional-table degradation explicit as partial sync (SYNC-009)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -526,8 +526,12 @@ export default function PawTimer() {
             feeding: mergedFeedings,
           },
         }));
-        setSyncError(error || "");
-        setSyncStatus(error ? "err" : "ok");
+        const isPartialSync = remote?.syncCapability?.mode === "partial";
+        const partialSyncMessage = isPartialSync
+          ? `Partial sync active: ${ensureArray(remote?.syncCapability?.missingOptionalTables).join(", ")} unavailable.`
+          : "";
+        setSyncError(error || partialSyncMessage);
+        setSyncStatus(error ? "err" : isPartialSync ? "partial" : "ok");
       } finally {
         syncInFlightRef.current = false;
       }
@@ -686,8 +690,19 @@ export default function PawTimer() {
       save(patKey(normalizedId), visibleJoinedPatterns);
       save(feedingKey(normalizedId), visibleJoinedFeedings);
       save(tombKey(normalizedId), joinedTombstones);
-      if (error) { setSyncStatus("err"); setSyncError(error); showToast(`Joined ${normalizedId}, but related history failed to load.`); }
-      else { setSyncError(""); setSyncStatus("ok"); showToast(`Joined shared profile ${normalizedId}.`); }
+      if (error) {
+        setSyncStatus("err");
+        setSyncError(error);
+        showToast(`Joined ${normalizedId}, but related history failed to load.`);
+      } else {
+        const isPartialSync = remote?.syncCapability?.mode === "partial";
+        const partialSyncMessage = isPartialSync
+          ? `Partial sync active: ${ensureArray(remote?.syncCapability?.missingOptionalTables).join(", ")} unavailable.`
+          : "";
+        setSyncError(partialSyncMessage);
+        setSyncStatus(isPartialSync ? "partial" : "ok");
+        showToast(`Joined shared profile ${normalizedId}.`);
+      }
       openDog(sharedDog);
       return;
     }
@@ -877,6 +892,14 @@ export default function PawTimer() {
         badgeState: "idle",
         label: `${counts[SYNC_STATE.LOCAL]} local only`,
         detail: "These changes are stored locally and will stay visible until the server confirms them.",
+      };
+    }
+
+    if (syncStatus === "partial") {
+      return {
+        badgeState: "idle",
+        label: "Partial sync",
+        detail: syncError || "Some optional activity tables are unavailable on the server, so sync coverage is incomplete.",
       };
     }
 

--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -685,6 +685,7 @@ export const WALKS_SYNC_FETCH_SELECT = [
 
 export const PATTERNS_SYNC_FETCH_SELECT = "id,dog_id,date,type,revision,updated_at,deleted_at";
 export const FEEDINGS_SYNC_FETCH_SELECT = "id,dog_id,date,food_type,amount,revision,updated_at,deleted_at";
+const OPTIONAL_SYNC_TABLES = ["patterns", "feedings"];
 
 const mapSyncFetchSessionRow = (r) => ({
   id: r.id,
@@ -810,6 +811,29 @@ export const syncFetch = async (dogId) => {
   const walkRes = walksFetch.res;
   const patRes = patternsFetch.res;
   const feedingRes = feedingsFetch.res;
+  const missingOptionalTables = [patternsFetch, feedingsFetch]
+    .filter((fetchResult) => OPTIONAL_SYNC_TABLES.includes(fetchResult.table) && fetchResult.degraded)
+    .map((fetchResult) => fetchResult.table);
+
+  const syncCapability = {
+    mode: missingOptionalTables.length ? "partial" : "full",
+    missingOptionalTables,
+    tableSupport: {
+      sessions: { supported: true, optional: false },
+      walks: { supported: true, optional: false },
+      patterns: { supported: !missingOptionalTables.includes("patterns"), optional: true },
+      feedings: { supported: !missingOptionalTables.includes("feedings"), optional: true },
+    },
+  };
+  if (syncCapability.mode === "partial") {
+    const unsupportedTables = missingOptionalTables.join(", ");
+    recordSyncDegradation({
+      code: "partial_sync_capability",
+      operation: "fetch",
+      table: "sync",
+      message: `Sync is running with partial table support. Unsupported optional tables: ${unsupportedTables}.`,
+    });
+  }
 
   const resourceErrors = [
     { table: "sessions", res: sessRes, queryShape: sessionsFetch.select },
@@ -863,6 +887,7 @@ export const syncFetch = async (dogId) => {
     error: relatedErrors.length ? `Related data fetch failed (${relatedErrors.join(" | ")})` : null,
     degradation: getSyncDegradationState(),
     result: {
+      syncCapability,
       dog: matchedDog
         ? {
             ...(matchedDog.settings && typeof matchedDog.settings === "object" ? matchedDog.settings : {}),

--- a/tests/syncFetchRuntime.test.js
+++ b/tests/syncFetchRuntime.test.js
@@ -89,12 +89,25 @@ describe("syncFetch runtime fallbacks", () => {
     });
 
     const { syncFetch } = await setupStorageModule();
-    const { result, error } = await syncFetch("DOG1");
+    const { result, error, degradation } = await syncFetch("DOG1");
 
     expect(error).toBeNull();
     expect(result.sessions).toHaveLength(1);
     expect(result.patterns).toEqual([]);
     expect(result.feedings).toEqual([]);
+    expect(result.syncCapability).toEqual({
+      mode: "partial",
+      missingOptionalTables: ["patterns", "feedings"],
+      tableSupport: {
+        sessions: { supported: true, optional: false },
+        walks: { supported: true, optional: false },
+        patterns: { supported: false, optional: true },
+        feedings: { supported: false, optional: true },
+      },
+    });
+    expect(degradation?.isDegraded).toBe(true);
+    expect(degradation?.flags).toContain("missing_optional_table");
+    expect(degradation?.flags).toContain("partial_sync_capability");
   });
 
   it("returns activity-capable data even when an optional source fails", async () => {
@@ -128,6 +141,9 @@ describe("syncFetch runtime fallbacks", () => {
     expect(error).toBeNull();
     expect(result.sessions.some((session) => session.id === "s-activity")).toBe(true);
     expect(result.walks.some((walk) => walk.id === "w-activity")).toBe(true);
+    expect(result.syncCapability.mode).toBe("partial");
+    expect(result.syncCapability.missingOptionalTables).toEqual(["patterns"]);
+    expect(result.syncCapability.tableSupport.feedings.supported).toBe(true);
   });
 
   it("requests walk sync metadata and preserves non-default walk types", async () => {
@@ -168,6 +184,10 @@ describe("syncFetch runtime fallbacks", () => {
       revision: 7,
       updatedAt: "2026-03-01T03:01:00.000Z",
     }]);
+    expect(result.syncCapability.mode).toBe("full");
+    expect(result.syncCapability.missingOptionalTables).toEqual([]);
+    expect(result.syncCapability.tableSupport.patterns.supported).toBe(true);
+    expect(result.syncCapability.tableSupport.feedings.supported).toBe(true);
   });
 
   it("round-trips severe distress via legacy distress_level constraints without collapsing to active", async () => {


### PR DESCRIPTION
### Motivation
- Optional sync tables like `patterns`/`feedings` were silently converted to empty arrays when missing, which made a partial server capability masquerade as a healthy full sync.  
- The intent is to make partial sync capability explicit at runtime (status + result contract) while preserving optional-table support and not changing business logic.

### Description
- Added explicit optional-table list and a `syncCapability` contract in `syncFetch` describing `mode` (`full`|`partial`), `missingOptionalTables`, and per-table support.  
- When optional tables are degraded, record a distinct degradation event `partial_sync_capability` (in addition to existing `missing_optional_table`) so partial capability is surfaced in `getSyncDegradationState`.  
- Return `syncCapability` inside `syncFetch` result so callers can reason about runtime capability without inferring from empty arrays.  
- Updated runtime handling in `App.jsx` to set `syncStatus` to `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd7dffcf083328a909ca2b161e25e)