### PR TITLE
Reduce clock-skew risk in same-revision conflict tie-breaks (SYNC-008)

### DIFF
--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -184,6 +184,7 @@ const getRecordRevision = (item = {}) => {
 const getRecordUpdatedAt = (item = {}) => item.updatedAt ?? item.updated_at ?? item.localUpdatedAt ?? item.local_updated_at ?? null;
 const getRecordDeletedAt = (item = {}) => item.deletedAt ?? item.deleted_at ?? null;
 const isFiniteNumber = (value) => Number.isFinite(Number(value));
+const LOCAL_SYNC_STATES = new Set(["local", "syncing", "error"]);
 
 const stableStringify = (value) => {
   if (Array.isArray(value)) return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
@@ -192,6 +193,26 @@ const stableStringify = (value) => {
     return `{${sortedKeys.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
   }
   return JSON.stringify(value);
+};
+
+const rankSyncCausality = (item = {}) => {
+  const pendingSyncScore = Boolean(item?.pendingSync) ? 2 : 0;
+  const syncStateScore = LOCAL_SYNC_STATES.has(item?.syncState) ? 1 : 0;
+  const replicationScore = item?.replicationConfirmed === false ? 1 : 0;
+  return pendingSyncScore + syncStateScore + replicationScore;
+};
+
+const buildDeterministicConflictFingerprint = (item = {}) => {
+  if (!item || typeof item !== "object") return stableStringify(item);
+  const clone = { ...item };
+  delete clone.updatedAt;
+  delete clone.updated_at;
+  delete clone.localUpdatedAt;
+  delete clone.local_updated_at;
+  delete clone.deletedAt;
+  delete clone.deleted_at;
+  delete clone.date;
+  return stableStringify(clone);
 };
 
 export const normalizeDogSyncMetadata = (dog = {}) => {
@@ -249,6 +270,11 @@ export const resolveSyncConflict = (left = {}, right = {}) => {
   if (leftRevision !== null && rightRevision !== null && leftRevision !== rightRevision) {
     return leftRevision > rightRevision ? left : right;
   }
+
+  const leftCausalRank = rankSyncCausality(left);
+  const rightCausalRank = rankSyncCausality(right);
+  if (leftCausalRank !== rightCausalRank) return leftCausalRank > rightCausalRank ? left : right;
+
   if (leftDeletedAt || rightDeletedAt) {
     if (leftDeletedAt !== rightDeletedAt) return leftDeletedAt > rightDeletedAt ? left : right;
     if (leftDeletedAt && rightDeletedAt) return leftDeletedAt >= rightDeletedAt ? left : right;
@@ -272,7 +298,10 @@ export const resolveSyncConflict = (left = {}, right = {}) => {
     return (left?.syncState === "local" || left?.syncState === "syncing") ? left : right;
   }
 
-  return right;
+  const leftFingerprint = buildDeterministicConflictFingerprint(left);
+  const rightFingerprint = buildDeterministicConflictFingerprint(right);
+  if (leftFingerprint === rightFingerprint) return right;
+  return leftFingerprint > rightFingerprint ? left : right;
 };
 
 // Merge two arrays by id using sync-aware conflict resolution and preserves chronological order

--- a/tests/syncConflict.test.js
+++ b/tests/syncConflict.test.js
@@ -18,6 +18,58 @@ describe("resolveSyncConflict", () => {
     expect(resolveSyncConflict(local, remote)).toBe(remote);
   });
 
+  it("prefers causal local change markers over skewed clocks when revisions match", () => {
+    const local = {
+      id: "session-1",
+      revision: 4,
+      updatedAt: iso(8),
+      note: "local edit",
+      pendingSync: true,
+      syncState: "syncing",
+    };
+    const remote = {
+      id: "session-1",
+      revision: 4,
+      updatedAt: iso(12),
+      note: "remote echo",
+      pendingSync: false,
+      syncState: "synced",
+    };
+
+    expect(resolveSyncConflict(local, remote)).toBe(local);
+  });
+
+  it("keeps local newer content with bad clock using pending causal metadata", () => {
+    const local = {
+      id: "pattern-1",
+      revision: 10,
+      updatedAt: iso(6),
+      type: "keys",
+      pendingSync: true,
+      syncState: "local",
+    };
+    const remote = {
+      id: "pattern-1",
+      revision: 10,
+      updatedAt: iso(13),
+      type: "jacket",
+      pendingSync: false,
+      syncState: "synced",
+    };
+
+    expect(resolveSyncConflict(local, remote)).toBe(local);
+  });
+
+  it("returns a deterministic winner when same revision has no causal metadata", () => {
+    const left = { id: "session-2", revision: 5, updatedAt: iso(9), date: iso(8), note: "alpha", result: "distress" };
+    const right = { id: "session-2", revision: 5, updatedAt: iso(10), date: iso(9), note: "beta", result: "success" };
+
+    const forwardWinner = resolveSyncConflict(left, right);
+    const reverseWinner = resolveSyncConflict(right, left);
+
+    expect(forwardWinner).toEqual(reverseWinner);
+  });
+
   it("prefers deletion tombstones over stale updates", () => {
     const localDelete = { id: "session-1", revision: 6, updatedAt: iso(12), deletedAt: iso(12) };
     const remoteActive = { id: "session-1", revision: 5, updatedAt: iso(13), result: "success" };


### PR DESCRIPTION
### Motivation
- Revision-first behavior must be preserved but same-revision ties currently defer to wall-clock fields (`deletedAt`, `updatedAt`, `date`), making outcomes vulnerable to client clock skew. 
- The goal is to prefer causal metadata when present and otherwise fall back to a deterministic, non-clock-based choice to avoid selecting the wrong payload under skew.

### Description
- Kept the existing revision-first policy in `resolveSyncConflict` and added a causal-ranking step that prefers records with `pendingSync`, local/non-synced `syncState` (one of `local|syncing|error`), or `replicationConfirmed === false` before consulting timestamps. (changes in `src/features/app/storage.js`) 
- Introduced `rankSyncCausality` and `LOCAL_SYNC_STATES` helpers to compute a small integer causal score used as the first tie-break after revision. (new helper functions in `src/features/app/storage.js`) 
- Replaced the previous unconditional final fallback with `buildDeterministicConflictFingerprint` which excludes volatile clock fields (`updatedAt`, `deletedAt`, `date`) and compares stable fingerprints so winner selection is deterministic even when timestamps are absent or skewed. (new helper and final tie-break in `resolveSyncConflict`) 
- Kept all changes scoped to sync conflict handling; no changes were made to business logic, recommendation/session/progression/recovery logic, or UI.

### Testing
- Ran `npm test -- tests/syncConflict.test.js` and the file tests passed: 24 tests, 24 passed. 
- Ran full suite `npm test` and all tests passed: 175 tests across 12 files passed. 
- Added tests in `tests/syncConflict.test.js` covering: same-revision with skewed clocks and causal metadata, local-newer-with-bad-clock using pending/local markers, and deterministic winner behavior when no causal metadata exists; these tests passed in the above runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd9114404833285f22472e2dd36de)