### PR TITLE
Add sync runtime regression tests for high-risk scenarios

### DIFF
--- a/tests/syncConflict.test.js
+++ b/tests/syncConflict.test.js
@@ -209,6 +209,59 @@ describe("mergeMutationSafeSyncCollection concurrent edits", () => {
     expect(merged).toEqual([]);
   });
 
+
+
+  it("prefers local pending-sync mutation when remote echo has same revision but newer clock", () => {
+    const currentLocal = [{
+      id: "session-skew",
+      date: iso(8),
+      revision: 4,
+      updatedAt: iso(7),
+      result: "distress",
+      pendingSync: true,
+      syncState: "syncing",
+    }];
+    const remoteSessions = [{
+      id: "session-skew",
+      date: iso(8),
+      revision: 4,
+      updatedAt: iso(12),
+      result: "success",
+      pendingSync: false,
+      syncState: "synced",
+    }];
+
+    const merged = mergeMutationSafeSyncCollection({
+      currentItems: currentLocal,
+      remoteItems: remoteSessions,
+      kind: "session",
+    });
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].result).toBe("distress");
+    expect(merged[0].pendingSync).toBe(true);
+  });
+
+  it("keeps a local bulk-clear durable against stale remote rows via tombstones", () => {
+    const currentLocal = [];
+    const remoteSessions = [
+      { id: "bulk-1", date: iso(8), revision: 2, updatedAt: iso(8), result: "success" },
+      { id: "bulk-2", date: iso(9), revision: 2, updatedAt: iso(9), result: "distress" },
+    ];
+    const tombstones = [
+      { id: "bulk-1", kind: "session", deletedAt: iso(10), revision: 3, updatedAt: iso(10), pendingSync: true, syncState: "syncing" },
+      { id: "bulk-2", kind: "session", deletedAt: iso(10), revision: 3, updatedAt: iso(10), pendingSync: true, syncState: "syncing" },
+    ];
+
+    const merged = mergeMutationSafeSyncCollection({
+      currentItems: currentLocal,
+      remoteItems: remoteSessions,
+      tombstones,
+      kind: "session",
+    });
+
+    expect(merged).toEqual([]);
+  });
   it("keeps in-flight tombstone creation even when remote has no tombstone yet", () => {
     const localTombstones = [{ id: "feeding-1", kind: "feeding", deletedAt: iso(11), revision: 4, updatedAt: iso(11), pendingSync: true }];
     const remoteTombstones = [];
@@ -325,6 +378,13 @@ describe("resolveDogSettingsConflict", () => {
     const remoteDog = { id: "DOG-B", dogName: "Milo Remote", revision: 3, updatedAt: iso(10) };
 
     expect(resolveDogSettingsConflict(localDog, remoteDog)).toEqual(remoteDog);
+  });
+
+  it("prefers local pending sync dog settings when revisions tie under clock skew", () => {
+    const localDog = { id: "DOG-C", dogName: "Nova Local", goalSeconds: 1800, revision: 7, updatedAt: iso(7), pendingSync: true, syncState: "syncing" };
+    const remoteDog = { id: "DOG-C", dogName: "Nova Remote", goalSeconds: 2400, revision: 7, updatedAt: iso(13), pendingSync: false, syncState: "synced" };
+
+    expect(resolveDogSettingsConflict(localDog, remoteDog)).toEqual(localDog);
   });
 
   it("resolves concurrent same-metadata edits deterministically", () => {

--- a/tests/syncFetchRuntime.test.js
+++ b/tests/syncFetchRuntime.test.js
@@ -387,4 +387,76 @@ describe("syncFetch runtime fallbacks", () => {
       updated_at: "2026-04-04T08:30:00.000Z",
     });
   });
+
+  it("preserves same-id tombstones across kinds when fetched from different tables", async () => {
+    global.fetch = vi.fn(async (url) => {
+      const { path } = getPathAndParams(url);
+      if (path === "dogs") return jsonResponse(200, [{ id: "DOG9", settings: { dogName: "Pixel" } }]);
+      if (path === "sessions") {
+        return jsonResponse(200, [
+          { id: "shared-dead", dog_id: "DOG9", date: "2026-04-05T00:00:00.000Z", planned_duration: 60, actual_duration: 20, distress_level: "subtle", result: "distress", revision: 6, updated_at: "2026-04-05T04:00:00.000Z", deleted_at: "2026-04-05T04:00:00.000Z" },
+        ]);
+      }
+      if (path === "walks") {
+        return jsonResponse(200, [
+          { id: "shared-dead", dog_id: "DOG9", date: "2026-04-05T01:00:00.000Z", duration: 900, walk_type: "regular_walk", revision: 7, updated_at: "2026-04-05T05:00:00.000Z", deleted_at: "2026-04-05T05:00:00.000Z" },
+        ]);
+      }
+      if (path === "patterns") return jsonResponse(200, []);
+      if (path === "feedings") return jsonResponse(200, []);
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const { syncFetch } = await setupStorageModule();
+    const { result, error } = await syncFetch("DOG9");
+
+    expect(error).toBeNull();
+    expect(result.sessions).toEqual([]);
+    expect(result.walks).toEqual([]);
+    expect(result.tombstones).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "shared-dead", kind: "session", revision: 6 }),
+      expect.objectContaining({ id: "shared-dead", kind: "walk", revision: 7 }),
+    ]));
+  });
+
+  it("retries pattern tombstone push with strict-schema payload when metadata-only insert violates not-null", async () => {
+    const postedBodies = [];
+    global.fetch = vi.fn(async (url, options = {}) => {
+      const { path } = getPathAndParams(url);
+      if (path === "dogs") return jsonResponse(201, {});
+      if (path === "patterns" && (options.method || "GET") === "POST") {
+        const payload = JSON.parse(options.body || "{}");
+        postedBodies.push(payload);
+        if (postedBodies.length === 1) {
+          return jsonResponse(400, { message: "null value in column \"date\" of relation \"patterns\" violates not-null constraint" });
+        }
+        return jsonResponse(201, {});
+      }
+      if (path === "sessions") return jsonResponse(200, []);
+      if (path === "walks") return jsonResponse(200, []);
+      if (path === "patterns") return jsonResponse(200, []);
+      if (path === "feedings") return jsonResponse(200, []);
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const { syncPushTombstone } = await setupStorageModule();
+    const result = await syncPushTombstone("DOG10", {
+      id: "pattern-dead",
+      kind: "pattern",
+      deletedAt: "2026-04-06T09:30:00.000Z",
+      revision: 14,
+    }, { id: "DOG10", dogName: "Arlo" });
+
+    expect(result.ok).toBe(true);
+    expect(postedBodies).toHaveLength(2);
+    expect(postedBodies[1]).toMatchObject({
+      id: "pattern-dead",
+      dog_id: "DOG10",
+      deleted_at: "2026-04-06T09:30:00.000Z",
+      date: "2026-04-06T09:30:00.000Z",
+      type: "keys",
+      revision: 14,
+      updated_at: "2026-04-06T09:30:00.000Z",
+    });
+  });
 });


### PR DESCRIPTION
### Motivation
- Cover known high-risk sync runtime paths with regression tests so future changes will surface regressions early.  The plan is to add targeted unit tests for mutation-vs-remote races, tombstone push fallbacks, cross-kind tombstone collisions, dog-settings conflicts, and bulk-clear behavior.  
- Keep this change test-only and do not alter application business logic or sync runtime behavior.

### Description
- Added tests to `tests/syncConflict.test.js` that exercise in-flight/local-mutation resolution, bulk-clear durability via tombstones, and dog settings conflict behavior under clock skew (new tests use `mergeMutationSafeSyncCollection` and `resolveDogSettingsConflict`).
- Added tests to `tests/syncFetchRuntime.test.js` that validate same-id tombstone handling across different tables and verify tombstone push fallbacks for strict not-null schemas (new tests use `syncFetch` and `syncPushTombstone`).
- All new tests are regression coverage only; no runtime code or business logic was modified (`src/features/app/storage.js` unchanged).

### Testing
- Ran the focused test suites with `npm test -- tests/syncConflict.test.js tests/syncFetchRuntime.test.js` and all tests passed: `2 files, 38 tests, 38 passed`.
- Test plan executed: retries and fallback behaviors, tombstone creation/retention, conflict resolution heuristics, and bulk-clear semantics were validated by the added assertions.
- Noted limitation: `silent local persistence failure surfacing` could not be cleanly asserted because local persistence failures are swallowed by the existing `save` implementation (`save` wraps `localStorage.setItem` in a try/catch), so surfacing that condition would require changing runtime behavior which this PR intentionally avoids.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfda076410833298780b20c1119f45)