### PR TITLE
Prefer confirmed tombstones in conflict resolution and avoid unconfirmed replication weight

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -307,7 +307,8 @@ export default function PawTimer() {
     return created;
   }, [commitTombstones, makeLocalTombstone]);
 
-  const setTombstoneSyncState = useCallback((entryId, kind, nextSyncState, errorMessage = "") => {
+  const setTombstoneSyncState = useCallback((entryId, kind, nextSyncState, errorMessage = "", options = {}) => {
+    const { replicationConfirmed } = options;
     commitTombstones((prev) => prev.map((row) => {
       if (row.id !== entryId || row.kind !== kind) return row;
       return {
@@ -315,6 +316,7 @@ export default function PawTimer() {
         pendingSync: nextSyncState !== SYNC_STATE.SYNCED,
         syncState: nextSyncState,
         syncError: nextSyncState === SYNC_STATE.ERROR ? errorMessage : "",
+        ...(typeof replicationConfirmed === "boolean" ? { replicationConfirmed } : {}),
       };
     }));
   }, [commitTombstones]);
@@ -415,7 +417,7 @@ export default function PawTimer() {
       setSyncDegradation(getSyncDegradationState());
       if (!live) return ok;
       if (ok) {
-        setTombstoneSyncState(entry.id, entry.kind, SYNC_STATE.SYNCED);
+        setTombstoneSyncState(entry.id, entry.kind, SYNC_STATE.SYNCED, "", { replicationConfirmed: true });
         return true;
       }
       setTombstoneSyncState(entry.id, entry.kind, SYNC_STATE.ERROR, error || "Delete marker push failed");

--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -198,7 +198,7 @@ const stableStringify = (value) => {
 const rankSyncCausality = (item = {}) => {
   const pendingSyncScore = Boolean(item?.pendingSync) ? 2 : 0;
   const syncStateScore = LOCAL_SYNC_STATES.has(item?.syncState) ? 1 : 0;
-  const replicationScore = item?.replicationConfirmed === false ? 1 : 0;
+  const replicationScore = item?.replicationConfirmed === false && Boolean(item?.pendingSync) ? 1 : 0;
   return pendingSyncScore + syncStateScore + replicationScore;
 };
 
@@ -277,7 +277,12 @@ export const resolveSyncConflict = (left = {}, right = {}) => {
 
   if (leftDeletedAt || rightDeletedAt) {
     if (leftDeletedAt !== rightDeletedAt) return leftDeletedAt > rightDeletedAt ? left : right;
-    if (leftDeletedAt && rightDeletedAt) return leftDeletedAt >= rightDeletedAt ? left : right;
+    if (leftDeletedAt && rightDeletedAt) {
+      const leftConfirmed = left?.replicationConfirmed === true;
+      const rightConfirmed = right?.replicationConfirmed === true;
+      if (leftConfirmed !== rightConfirmed) return leftConfirmed ? left : right;
+      return leftDeletedAt >= rightDeletedAt ? left : right;
+    }
     return leftDeletedAt ? left : right;
   }
 

--- a/tests/syncConflict.test.js
+++ b/tests/syncConflict.test.js
@@ -83,6 +83,31 @@ describe("resolveSyncConflict", () => {
 
     expect(resolveSyncConflict(localDelete, remoteActive)).toBe(remoteActive);
   });
+
+  it("prefers a confirmed remote tombstone over an otherwise-equal local unconfirmed tombstone", () => {
+    const localDelete = {
+      id: "session-1",
+      kind: "session",
+      revision: 6,
+      updatedAt: iso(12),
+      deletedAt: iso(12),
+      pendingSync: false,
+      syncState: "synced",
+      replicationConfirmed: false,
+    };
+    const remoteDelete = {
+      id: "session-1",
+      kind: "session",
+      revision: 6,
+      updatedAt: iso(12),
+      deletedAt: iso(12),
+      pendingSync: false,
+      syncState: "synced",
+      replicationConfirmed: true,
+    };
+
+    expect(resolveSyncConflict(localDelete, remoteDelete)).toBe(remoteDelete);
+  });
 });
 
 describe("mergeMutationSafeSyncCollection concurrent edits", () => {
@@ -288,6 +313,34 @@ describe("mergeMutationSafeSyncCollection concurrent edits", () => {
       expect.objectContaining({ id: "shared-1", kind: "session" }),
       expect.objectContaining({ id: "shared-1", kind: "walk" }),
     ]));
+  });
+
+  it("marks local tombstone as confirmed after successful push plus remote fetch merge", () => {
+    const localAfterPush = [{
+      id: "session-1",
+      kind: "session",
+      deletedAt: iso(12),
+      updatedAt: iso(12),
+      revision: 6,
+      pendingSync: false,
+      syncState: "synced",
+      replicationConfirmed: false,
+    }];
+    const remoteAfterFetch = [{
+      id: "session-1",
+      kind: "session",
+      deletedAt: iso(12),
+      updatedAt: iso(12),
+      revision: 6,
+      pendingSync: false,
+      syncState: "synced",
+      replicationConfirmed: true,
+    }];
+
+    const mergedTombstones = mergeTombstonesByEntityKey(localAfterPush, remoteAfterFetch);
+
+    expect(mergedTombstones).toHaveLength(1);
+    expect(mergedTombstones[0].replicationConfirmed).toBe(true);
   });
 
   it("suppresses only matching kind when id is shared across kinds", () => {


### PR DESCRIPTION
### Motivation
- Prevent an unconfirmed `replicationConfirmed:false` tombstone from outranking an otherwise-equal remote tombstone that has `replicationConfirmed:true` once local push is no longer in-flight. 
- Preserve the original local-causality preference for true in-flight local edits (`pendingSync:true`).
- Make tombstone confirmation immediate after successful push to reduce unnecessary round-trips and avoid transient resurrection/flip-flop.

### Description
- Adjusted `rankSyncCausality` so `replicationConfirmed:false` contributes to causal ranking only when the record is still `pendingSync:true`, by changing replication scoring to `item?.replicationConfirmed === false && Boolean(item?.pendingSync)` in `src/features/app/storage.js`.
- Added tombstone-specific tie-breaking in `resolveSyncConflict` so when two tombstones have equal `deletedAt`/revision, a `replicationConfirmed:true` tombstone wins over `replicationConfirmed:false` before falling back to timestamp ordering in `src/features/app/storage.js`.
- Extended `setTombstoneSyncState` in `src/App.jsx` to accept an `options` object and apply `replicationConfirmed` when provided, and set `replicationConfirmed:true` immediately after a successful tombstone push to avoid awaiting the fetch round-trip.
- Added tests in `tests/syncConflict.test.js` covering: a local unconfirmed vs remote confirmed tombstone with equal metadata (remote should win), and that a local tombstone becomes confirmed after successful push + merge.

### Testing
- Ran the sync conflict test suite with `npm test -- tests/syncConflict.test.js` and all tests passed: `29 passed (29)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfdc66f2f88332955f4f8dbfd5c7ab)