### PR TITLE
Handle local storage write failures across persistence and sync flows

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { sortByDateAsc } from "./lib/activityDateTime";
 import { sortValidDateAsc } from "./lib/dateSort";
 import { selectAppData } from "./features/app/selectors";
 import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeMutationSafeSyncCollection, mergeSessionWithDerivedFields, mergeTombstonesByEntityKey, normalizeDogSyncMetadata, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, pruneTombstonesForRetention, resolveDogSettingsConflict, save, sessKey, stampLocalDogSettings, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
+import { markCollectionStorageError, persistJoinedDogState, persistValue } from "./features/app/persistence";
 import { fmt, fmtClock, getOutcomeTone, normalizeWalkType, walkTypeLabel } from "./features/app/helpers";
 import { CameraIcon, ChartIcon, HistoryIcon, HomeIcon, PawIcon, SettingsIcon } from "./features/app/ui.jsx";
 import { DogSelect, Onboarding } from "./features/setup/SetupScreens";
@@ -233,68 +234,111 @@ export default function PawTimer() {
     setTarget((prev) => (prev === recommendation.duration ? prev : recommendation.duration));
   }, [recommendation.duration]);
 
+  const reportLocalWriteFailure = useCallback((errorMessage) => {
+    setSyncStatus("err");
+    setSyncError(errorMessage);
+  }, []);
+
   const commitSessions = useCallback((updater) => {
     let committed = [];
     setSessions((prev) => {
       const resolved = typeof updater === "function" ? updater(prev) : updater;
       const normalized = sortByDateAsc(normalizeSessions(ensureArray(resolved)).map(withHydratedSyncState));
-      if (activeDogId) save(sessKey(activeDogId), normalized);
+      if (activeDogId) {
+        const writeResult = persistValue(sessKey(activeDogId), normalized, save);
+        if (!writeResult.ok) {
+          reportLocalWriteFailure(writeResult.error);
+          committed = markCollectionStorageError(normalized, writeResult.error);
+          recomputeTarget(committed);
+          return committed;
+        }
+      }
       recomputeTarget(normalized);
       committed = normalized;
       return normalized;
     });
     return committed;
-  }, [activeDogId, recomputeTarget, withHydratedSyncState]);
+  }, [activeDogId, recomputeTarget, reportLocalWriteFailure, withHydratedSyncState]);
 
   const commitWalks = useCallback((updater) => {
     let committed = [];
     setWalks((prev) => {
       const resolved = typeof updater === "function" ? updater(prev) : updater;
       const normalized = sortByDateAsc(ensureArray(resolved).map((item) => ({ ...withHydratedSyncState(item), type: normalizeWalkType(item?.type) })));
-      if (activeDogId) save(walkKey(activeDogId), normalized);
+      if (activeDogId) {
+        const writeResult = persistValue(walkKey(activeDogId), normalized, save);
+        if (!writeResult.ok) {
+          reportLocalWriteFailure(writeResult.error);
+          committed = markCollectionStorageError(normalized, writeResult.error);
+          recomputeTarget(sessions, committed, patterns, activeDog || {});
+          return committed;
+        }
+      }
       recomputeTarget(sessions, normalized, patterns, activeDog || {});
       committed = normalized;
       return normalized;
     });
     return committed;
-  }, [activeDog, activeDogId, patterns, recomputeTarget, sessions, withHydratedSyncState]);
+  }, [activeDog, activeDogId, patterns, recomputeTarget, reportLocalWriteFailure, sessions, withHydratedSyncState]);
 
   const commitPatterns = useCallback((updater) => {
     let committed = [];
     setPatterns((prev) => {
       const resolved = typeof updater === "function" ? updater(prev) : updater;
       const normalized = sortByDateAsc(ensureArray(resolved).map(withHydratedSyncState));
-      if (activeDogId) save(patKey(activeDogId), normalized);
+      if (activeDogId) {
+        const writeResult = persistValue(patKey(activeDogId), normalized, save);
+        if (!writeResult.ok) {
+          reportLocalWriteFailure(writeResult.error);
+          committed = markCollectionStorageError(normalized, writeResult.error);
+          recomputeTarget(sessions, walks, committed, activeDog || {});
+          return committed;
+        }
+      }
       recomputeTarget(sessions, walks, normalized, activeDog || {});
       committed = normalized;
       return normalized;
     });
     return committed;
-  }, [activeDog, activeDogId, recomputeTarget, sessions, walks, withHydratedSyncState]);
+  }, [activeDog, activeDogId, recomputeTarget, reportLocalWriteFailure, sessions, walks, withHydratedSyncState]);
 
   const commitFeedings = useCallback((updater) => {
     let committed = [];
     setFeedings((prev) => {
       const resolved = typeof updater === "function" ? updater(prev) : updater;
       const normalized = normalizeFeedings(ensureArray(resolved)).map(withHydratedSyncState);
-      if (activeDogId) save(feedingKey(activeDogId), normalized);
+      if (activeDogId) {
+        const writeResult = persistValue(feedingKey(activeDogId), normalized, save);
+        if (!writeResult.ok) {
+          reportLocalWriteFailure(writeResult.error);
+          committed = markCollectionStorageError(normalized, writeResult.error);
+          return committed;
+        }
+      }
       committed = normalized;
       return normalized;
     });
     return committed;
-  }, [activeDogId, withHydratedSyncState]);
+  }, [activeDogId, reportLocalWriteFailure, withHydratedSyncState]);
 
   const commitTombstones = useCallback((updater) => {
     let committed = [];
     setTombstones((prev) => {
       const resolved = typeof updater === "function" ? updater(prev) : updater;
       const normalized = normalizeTombstones(ensureArray(resolved)).map(withHydratedSyncState);
-      if (activeDogId) save(tombKey(activeDogId), normalized);
+      if (activeDogId) {
+        const writeResult = persistValue(tombKey(activeDogId), normalized, save);
+        if (!writeResult.ok) {
+          reportLocalWriteFailure(writeResult.error);
+          committed = markCollectionStorageError(normalized, writeResult.error);
+          return committed;
+        }
+      }
       committed = normalized;
       return normalized;
     });
     return committed;
-  }, [activeDogId, withHydratedSyncState]);
+  }, [activeDogId, reportLocalWriteFailure, withHydratedSyncState]);
 
   const addTombstone = useCallback((kind, entry) => {
     if (!entry?.id) return null;
@@ -444,7 +488,8 @@ export default function PawTimer() {
               ? resolveDogSettingsConflict(normalizeDogSyncMetadata(existingDog), remoteDog)
               : remoteDog;
             const next = [...prev.filter((d) => canonicalDogId(d.id) !== remoteDog.id), resolvedDog];
-            save(DOGS_KEY, next);
+            const writeResult = persistValue(DOGS_KEY, next, save);
+            if (!writeResult.ok) reportLocalWriteFailure(writeResult.error);
             return next;
           });
         }
@@ -542,7 +587,7 @@ export default function PawTimer() {
     sync();
     const timer = setInterval(sync, 15_000);
     return () => { live = false; syncInFlightRef.current = false; clearInterval(timer); };
-  }, [activeDogId, commitTombstones, markRemoteEntryConfirmed, setTombstoneSyncState, withHydratedSyncState]);
+  }, [activeDogId, commitTombstones, markRemoteEntryConfirmed, reportLocalWriteFailure, setTombstoneSyncState, withHydratedSyncState]);
 
   useEffect(() => {
     if (!SYNC_ENABLED || !activeDogId) return;
@@ -639,14 +684,23 @@ export default function PawTimer() {
 
   const clearDogActivityState = useCallback((dogId) => {
     const normalizedId = canonicalDogId(dogId);
-    if (!normalizedId) return;
-    save(sessKey(normalizedId), []);
-    save(walkKey(normalizedId), []);
-    save(patKey(normalizedId), []);
-    save(feedingKey(normalizedId), []);
-    save(tombKey(normalizedId), []);
-    save(patLblKey(normalizedId), {});
-    save(photoKey(normalizedId), null);
+    if (!normalizedId) return false;
+    const writes = [
+      { key: sessKey(normalizedId), value: [] },
+      { key: walkKey(normalizedId), value: [] },
+      { key: patKey(normalizedId), value: [] },
+      { key: feedingKey(normalizedId), value: [] },
+      { key: tombKey(normalizedId), value: [] },
+      { key: patLblKey(normalizedId), value: {} },
+      { key: photoKey(normalizedId), value: null },
+    ];
+    for (const write of writes) {
+      const writeResult = persistValue(write.key, write.value, save);
+      if (!writeResult.ok) {
+        reportLocalWriteFailure(writeResult.error);
+        return false;
+      }
+    }
     setSessions([]);
     setWalks([]);
     setPatterns([]);
@@ -654,7 +708,8 @@ export default function PawTimer() {
     setTombstones([]);
     setPatLabels({});
     setDogPhoto(null);
-  }, []);
+    return true;
+  }, [reportLocalWriteFailure]);
 
   const openDog = (dog) => { logSyncDebug("openDog", { dogId: canonicalDogId(dog?.id) }); setOnboardingState(null); setActiveDogId(canonicalDogId(dog.id)); setScreen("app"); };
 
@@ -687,11 +742,25 @@ export default function PawTimer() {
       setWalks(visibleJoinedWalks);
       setPatterns(visibleJoinedPatterns);
       setFeedings(visibleJoinedFeedings);
-      save(sessKey(normalizedId), visibleJoinedSessions);
-      save(walkKey(normalizedId), visibleJoinedWalks);
-      save(patKey(normalizedId), visibleJoinedPatterns);
-      save(feedingKey(normalizedId), visibleJoinedFeedings);
-      save(tombKey(normalizedId), joinedTombstones);
+      const joinPersistResult = persistJoinedDogState({
+        dogId: normalizedId,
+        sessions: visibleJoinedSessions,
+        walks: visibleJoinedWalks,
+        patterns: visibleJoinedPatterns,
+        feedings: visibleJoinedFeedings,
+        tombstones: joinedTombstones,
+        saveFn: save,
+      });
+      if (!joinPersistResult.ok) {
+        const localWriteError = joinPersistResult.error || `Unable to persist joined profile ${normalizedId}`;
+        reportLocalWriteFailure(localWriteError);
+        setSessions(markCollectionStorageError(visibleJoinedSessions, localWriteError));
+        setWalks(markCollectionStorageError(visibleJoinedWalks, localWriteError));
+        setPatterns(markCollectionStorageError(visibleJoinedPatterns, localWriteError));
+        setFeedings(markCollectionStorageError(visibleJoinedFeedings, localWriteError));
+        setTombstones(markCollectionStorageError(joinedTombstones, localWriteError));
+        showToast(`Joined ${normalizedId}, but local save failed.`);
+      }
       if (error) {
         setSyncStatus("err");
         setSyncError(error);
@@ -725,7 +794,7 @@ export default function PawTimer() {
       dogName: data.dogName,
       createdAt: new Date().toISOString(),
     }, previousDog);
-    if (isFreshProfile) clearDogActivityState(id);
+    if (isFreshProfile && !clearDogActivityState(id)) return;
     setDogs((prev) => [...prev.filter((d) => canonicalDogId(d.id) !== id), newDog]);
     setOnboardingState(null);
     setActiveDogId(id);

--- a/src/features/app/persistence.js
+++ b/src/features/app/persistence.js
@@ -1,0 +1,45 @@
+import { feedingKey, patKey, sessKey, tombKey, walkKey } from "./storage";
+
+export const formatStorageWriteError = (error, key) => {
+  const message = error instanceof Error ? error.message : String(error || "Unknown local storage error");
+  return `Unable to save local data (${key}): ${message}`;
+};
+
+export const markCollectionStorageError = (items, errorMessage) => items.map((item) => ({
+  ...item,
+  pendingSync: true,
+  syncState: "error",
+  syncError: errorMessage,
+}));
+
+export const persistValue = (key, value, saveFn) => {
+  const writer = typeof saveFn === "function" ? saveFn : () => ({ ok: false, error: "Missing save function" });
+  const result = writer(key, value);
+  if (result?.ok) return { ok: true, error: "" };
+  return { ok: false, error: formatStorageWriteError(result?.error, key) };
+};
+
+export const persistJoinedDogState = ({
+  dogId,
+  sessions,
+  walks,
+  patterns,
+  feedings,
+  tombstones,
+  saveFn,
+}) => {
+  const writes = [
+    { key: sessKey(dogId), value: sessions },
+    { key: walkKey(dogId), value: walks },
+    { key: patKey(dogId), value: patterns },
+    { key: feedingKey(dogId), value: feedings },
+    { key: tombKey(dogId), value: tombstones },
+  ];
+
+  for (const write of writes) {
+    const result = persistValue(write.key, write.value, saveFn);
+    if (!result.ok) return { ok: false, error: result.error, failedKey: write.key };
+  }
+
+  return { ok: true, error: "", failedKey: null };
+};

--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -22,7 +22,12 @@ export const load = (key, fallback) => {
   catch { return fallback; }
 };
 export const save = (key, val) => {
-  try { localStorage.setItem(key, JSON.stringify(val)); } catch {}
+  try {
+    localStorage.setItem(key, JSON.stringify(val));
+    return { ok: true, error: "" };
+  } catch (error) {
+    return { ok: false, error };
+  }
 };
 
 export const ensureArray = (value) => (Array.isArray(value) ? value : []);

--- a/tests/persistenceWriteFailures.test.js
+++ b/tests/persistenceWriteFailures.test.js
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { markCollectionStorageError, persistJoinedDogState, persistValue } from "../src/features/app/persistence";
+import { save } from "../src/features/app/storage";
+
+const makeStorageMock = (setItemImpl) => ({
+  getItem: vi.fn(() => null),
+  setItem: vi.fn(setItemImpl),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+});
+
+describe("local write failure handling", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns save failure details when localStorage.setItem throws", () => {
+    const storage = makeStorageMock(() => {
+      throw new Error("quota exceeded");
+    });
+    vi.stubGlobal("localStorage", storage);
+
+    const result = save("pawtimer_any", { value: 1 });
+
+    expect(result.ok).toBe(false);
+    expect(String(result.error?.message || result.error)).toContain("quota exceeded");
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks mutation entries as unsynced error on persistence failure", () => {
+    const storage = makeStorageMock(() => {
+      throw new Error("disk full");
+    });
+    vi.stubGlobal("localStorage", storage);
+
+    const persisted = persistValue("pawtimer_sess_v5_DOG1", [{ id: "s1", pendingSync: false, syncState: "synced" }], save);
+    const errored = markCollectionStorageError([{ id: "s1", pendingSync: false, syncState: "synced", syncError: "" }], persisted.error);
+
+    expect(persisted.ok).toBe(false);
+    expect(errored).toEqual([
+      expect.objectContaining({
+        id: "s1",
+        pendingSync: true,
+        syncState: "error",
+        syncError: expect.stringContaining("Unable to save local data"),
+      }),
+    ]);
+  });
+
+  it("surfaces joined-sync persistence failure when any write throws", () => {
+    const storage = makeStorageMock(() => {
+      throw new Error("storage unavailable");
+    });
+    vi.stubGlobal("localStorage", storage);
+
+    const result = persistJoinedDogState({
+      dogId: "DOG1",
+      sessions: [{ id: "s1" }],
+      walks: [{ id: "w1" }],
+      patterns: [{ id: "p1" }],
+      feedings: [{ id: "f1" }],
+      tombstones: [{ id: "s1", kind: "session" }],
+      saveFn: save,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failedKey).toContain("pawtimer_sess_v5_DOG1");
+    expect(result.error).toContain("Unable to save local data");
+  });
+});


### PR DESCRIPTION
### Motivation
- Local `save` calls previously swallowed `localStorage` exceptions, hiding write failures and leaving sync state ambiguous. 
- The app needs to surface storage write failures so sync UI/state and activity entries remain accurate under storage pressure. 
- Join/hydration and mutation codepaths must preserve unsynced/error markers when writes fail so retries and diagnostics remain actionable.

### Description
- Refactored `save` in `src/features/app/storage.js` to return a structured `{ ok, error }` result instead of swallowing exceptions. 
- Added `src/features/app/persistence.js` implementing `formatStorageWriteError`, `markCollectionStorageError`, `persistValue`, and `persistJoinedDogState` to centralize persistence error handling. 
- Updated `src/App.jsx` mutation and sync commit paths to use `persistValue`/`persistJoinedDogState` and to react to write failures by setting `syncStatus: "err"` and a meaningful `syncError`, and by marking affected entries with `pendingSync: true`, `syncState: "error"`, and `syncError`. 
- Made `clearDogActivityState` abort if any local write fails and adjusted the onboarding/join flows to surface and propagate local-write failures instead of silently continuing. 

### Testing
- Added `tests/persistenceWriteFailures.test.js` which mocks `localStorage.setItem` to throw and verifies `save` returns failure details, `persistValue` + `markCollectionStorageError` mark items as errored, and `persistJoinedDogState` surfaces the failing key. 
- Ran the test file with `npm test -- tests/persistenceWriteFailures.test.js` and it passed (3 tests). 
- Ran the full suite with `npm test` and all tests passed (full suite succeeded, no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfdd469b7c83329826f9e6cde03b64)