### PR TITLE
Add sync orchestration runtime tests and tombstone-aware sync health

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import { sortValidDateAsc } from "./lib/dateSort";
 import { selectAppData } from "./features/app/selectors";
 import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeMutationSafeSyncCollection, mergeSessionWithDerivedFields, mergeTombstonesByEntityKey, normalizeDogSyncMetadata, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, pruneTombstonesForRetention, resolveDogSettingsConflict, save, sessKey, stampLocalDogSettings, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
 import { markCollectionStorageError, persistJoinedDogState, persistValue } from "./features/app/persistence";
+import { computeSyncSummary } from "./features/app/syncSummary";
 import { fmt, fmtClock, getOutcomeTone, normalizeWalkType, walkTypeLabel } from "./features/app/helpers";
 import { CameraIcon, ChartIcon, HistoryIcon, HomeIcon, PawIcon, SettingsIcon } from "./features/app/ui.jsx";
 import { DogSelect, Onboarding } from "./features/setup/SetupScreens";
@@ -926,60 +927,16 @@ export default function PawTimer() {
     });
   }, [activeDogId, recommendation?.details?.recoveryState]);
 
-  const syncSummary = useMemo(() => {
-    const allEntries = [...sessions, ...walks, ...patterns, ...feedings];
-    const counts = allEntries.reduce((acc, entry) => {
-      const state = entry?.syncState || (entry?.pendingSync ? SYNC_STATE.LOCAL : SYNC_STATE.SYNCED);
-      acc[state] = (acc[state] || 0) + 1;
-      return acc;
-    }, { [SYNC_STATE.LOCAL]: 0, [SYNC_STATE.SYNCING]: 0, [SYNC_STATE.SYNCED]: 0, [SYNC_STATE.ERROR]: 0 });
-
-    if (!SYNC_ENABLED) {
-      return {
-        badgeState: "idle",
-        label: "Local only",
-        detail: "Sync is disabled. Entries stay on this device until sync is configured.",
-      };
-    }
-
-    if (counts[SYNC_STATE.ERROR] > 0 || syncStatus === "err") {
-      return {
-        badgeState: "err",
-        label: `${counts[SYNC_STATE.ERROR] || 1} need sync`,
-        detail: syncError || "Some changes are only local because the last sync failed.",
-      };
-    }
-
-    if (counts[SYNC_STATE.SYNCING] > 0 || syncStatus === "syncing") {
-      return {
-        badgeState: "syncing",
-        label: `${counts[SYNC_STATE.SYNCING] || 1} syncing`,
-        detail: "Recent changes are being confirmed with the server.",
-      };
-    }
-
-    if (counts[SYNC_STATE.LOCAL] > 0) {
-      return {
-        badgeState: "idle",
-        label: `${counts[SYNC_STATE.LOCAL]} local only`,
-        detail: "These changes are stored locally and will stay visible until the server confirms them.",
-      };
-    }
-
-    if (syncStatus === "partial") {
-      return {
-        badgeState: "idle",
-        label: "Partial sync",
-        detail: syncError || "Some optional activity tables are unavailable on the server, so sync coverage is incomplete.",
-      };
-    }
-
-    return {
-      badgeState: "ok",
-      label: allEntries.length ? "All confirmed" : "Ready",
-      detail: allEntries.length ? "All visible activity is confirmed by the server." : "No local changes are waiting for sync.",
-    };
-  }, [feedings, patterns, sessions, syncError, syncStatus, walks]);
+  const syncSummary = useMemo(() => computeSyncSummary({
+    syncEnabled: SYNC_ENABLED,
+    sessions,
+    walks,
+    patterns,
+    feedings,
+    tombstones,
+    syncStatus,
+    syncError,
+  }), [feedings, patterns, sessions, syncError, syncStatus, tombstones, walks]);
 
   const CustomDot = ({ cx, cy, payload }) => {
     const c = getOutcomeTone(payload.distressLevel).color;

--- a/src/features/app/syncSummary.js
+++ b/src/features/app/syncSummary.js
@@ -1,0 +1,70 @@
+export const SYNC_STATE = {
+  LOCAL: "local",
+  SYNCING: "syncing",
+  SYNCED: "synced",
+  ERROR: "error",
+};
+
+export const computeSyncSummary = ({
+  syncEnabled,
+  sessions = [],
+  walks = [],
+  patterns = [],
+  feedings = [],
+  tombstones = [],
+  syncStatus = "idle",
+  syncError = "",
+}) => {
+  const allEntries = [...sessions, ...walks, ...patterns, ...feedings, ...tombstones];
+  const counts = allEntries.reduce((acc, entry) => {
+    const state = entry?.syncState || (entry?.pendingSync ? SYNC_STATE.LOCAL : SYNC_STATE.SYNCED);
+    acc[state] = (acc[state] || 0) + 1;
+    return acc;
+  }, { [SYNC_STATE.LOCAL]: 0, [SYNC_STATE.SYNCING]: 0, [SYNC_STATE.SYNCED]: 0, [SYNC_STATE.ERROR]: 0 });
+
+  if (!syncEnabled) {
+    return {
+      badgeState: "idle",
+      label: "Local only",
+      detail: "Sync is disabled. Entries stay on this device until sync is configured.",
+    };
+  }
+
+  if (counts[SYNC_STATE.ERROR] > 0 || syncStatus === "err") {
+    return {
+      badgeState: "err",
+      label: `${counts[SYNC_STATE.ERROR] || 1} need sync`,
+      detail: syncError || "Some changes are only local because the last sync failed.",
+    };
+  }
+
+  if (counts[SYNC_STATE.SYNCING] > 0 || syncStatus === "syncing") {
+    return {
+      badgeState: "syncing",
+      label: `${counts[SYNC_STATE.SYNCING] || 1} syncing`,
+      detail: "Recent changes are being confirmed with the server.",
+    };
+  }
+
+  if (counts[SYNC_STATE.LOCAL] > 0) {
+    return {
+      badgeState: "idle",
+      label: `${counts[SYNC_STATE.LOCAL]} local only`,
+      detail: "These changes are stored locally and will stay visible until the server confirms them.",
+    };
+  }
+
+  if (syncStatus === "partial") {
+    return {
+      badgeState: "idle",
+      label: "Partial sync",
+      detail: syncError || "Some optional activity tables are unavailable on the server, so sync coverage is incomplete.",
+    };
+  }
+
+  return {
+    badgeState: "ok",
+    label: allEntries.length ? "All confirmed" : "Ready",
+    detail: allEntries.length ? "All visible activity is confirmed by the server." : "No local changes are waiting for sync.",
+  };
+};

--- a/tests/syncOrchestration.test.js
+++ b/tests/syncOrchestration.test.js
@@ -1,0 +1,338 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { computeSyncSummary, SYNC_STATE } from "../src/features/app/syncSummary";
+import { formatStorageWriteError, markCollectionStorageError, persistValue } from "../src/features/app/persistence";
+import {
+  applyTombstonesToCollection,
+  hydrateDogFromLocal,
+  save,
+  sessKey,
+  tombKey,
+} from "../src/features/app/storage";
+
+const jsonResponse = (status, payload) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  statusText: status >= 200 && status < 300 ? "OK" : "Bad Request",
+  text: async () => (typeof payload === "string" ? payload : JSON.stringify(payload)),
+});
+
+const setupStorageModule = async () => {
+  vi.resetModules();
+  vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+  vi.stubEnv("VITE_SUPABASE_ANON_KEY", "test-anon-key");
+  return import("../src/features/app/storage");
+};
+
+const getPath = (urlString) => new URL(urlString).pathname.replace("/rest/v1/", "");
+
+const createMemoryStorage = (setItemImpl = null) => {
+  const db = new Map();
+  return {
+    getItem: vi.fn((key) => (db.has(key) ? db.get(key) : null)),
+    setItem: vi.fn((key, value) => {
+      if (setItemImpl) return setItemImpl(key, value);
+      db.set(key, value);
+      return undefined;
+    }),
+    removeItem: vi.fn((key) => db.delete(key)),
+    clear: vi.fn(() => db.clear()),
+  };
+};
+
+describe("sync orchestration runtime cases", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("handles fetch-success with partial push failures across mixed kinds", async () => {
+    global.fetch = vi.fn(async (url, options = {}) => {
+      const path = getPath(url);
+      if (path === "dogs" && (options.method || "GET") === "GET") return jsonResponse(200, []);
+      if (path === "dogs" && (options.method || "GET") === "POST") return jsonResponse(201, {});
+      if (path === "sessions" && (options.method || "GET") === "POST") return jsonResponse(201, {});
+      if (path === "walks" && (options.method || "GET") === "POST") return jsonResponse(503, { message: "walk table timeout" });
+      if (path === "feedings" && (options.method || "GET") === "POST") return jsonResponse(201, {});
+      return jsonResponse(200, []);
+    });
+
+    const { syncPush } = await setupStorageModule();
+    const dog = { id: "DOG-ORCH", dogName: "Nori" };
+
+    const sessionPush = await syncPush("dog-orch", "session", {
+      id: "sess-1",
+      date: "2026-04-10T09:00:00.000Z",
+      plannedDuration: 120,
+      actualDuration: 120,
+      distressLevel: "none",
+      result: "success",
+    }, dog);
+    const walkPush = await syncPush("dog-orch", "walk", {
+      id: "walk-1",
+      date: "2026-04-10T10:00:00.000Z",
+      duration: 900,
+      type: "regular_walk",
+    }, dog);
+    const feedingPush = await syncPush("dog-orch", "feeding", {
+      id: "feed-1",
+      date: "2026-04-10T11:00:00.000Z",
+      foodType: "meal",
+      amount: "small",
+    }, dog);
+
+    expect(sessionPush.ok).toBe(true);
+    expect(walkPush.ok).toBe(false);
+    expect(feedingPush.ok).toBe(true);
+
+    const summary = computeSyncSummary({
+      syncEnabled: true,
+      sessions: [{ id: "sess-1", pendingSync: false, syncState: SYNC_STATE.SYNCED }],
+      walks: [{ id: "walk-1", pendingSync: true, syncState: SYNC_STATE.ERROR, syncError: walkPush.error }],
+      feedings: [{ id: "feed-1", pendingSync: false, syncState: SYNC_STATE.SYNCED }],
+      patterns: [],
+      tombstones: [],
+      syncStatus: "err",
+      syncError: walkPush.error,
+    });
+
+    expect(summary.badgeState).toBe("err");
+    expect(summary.label).toMatch(/need sync/);
+  });
+
+  it("recovers from interrupted mid-flight sync on retry and reconciles remote state", async () => {
+    let shouldFailSessionPush = true;
+    const remoteSessions = [];
+
+    global.fetch = vi.fn(async (url, options = {}) => {
+      const path = getPath(url);
+      const method = (options.method || "GET").toUpperCase();
+      if (path === "dogs" && method === "GET") return jsonResponse(200, []);
+      if (path === "dogs" && method === "POST") return jsonResponse(201, {});
+      if (path === "sessions" && method === "POST") {
+        if (shouldFailSessionPush) {
+          shouldFailSessionPush = false;
+          return jsonResponse(500, { message: "network interrupted" });
+        }
+        remoteSessions.push(JSON.parse(options.body || "{}"));
+        return jsonResponse(201, {});
+      }
+      if (path === "sessions" && method === "GET") return jsonResponse(200, remoteSessions);
+      return jsonResponse(200, []);
+    });
+
+    const { syncPush, mergeMutationSafeSyncCollection } = await setupStorageModule();
+    const dog = { id: "DOG-RETRY", dogName: "Miso" };
+
+    const localSession = {
+      id: "sess-retry",
+      date: "2026-04-11T09:00:00.000Z",
+      plannedDuration: 180,
+      actualDuration: 150,
+      distressLevel: "subtle",
+      result: "distress",
+      pendingSync: true,
+      syncState: SYNC_STATE.LOCAL,
+    };
+
+    const firstAttempt = await syncPush("DOG-RETRY", "session", localSession, dog);
+    expect(firstAttempt.ok).toBe(false);
+
+    const erroredLocal = [{ ...localSession, syncState: SYNC_STATE.ERROR, syncError: firstAttempt.error, pendingSync: true }];
+    const failureSummary = computeSyncSummary({
+      syncEnabled: true,
+      sessions: erroredLocal,
+      walks: [],
+      patterns: [],
+      feedings: [],
+      tombstones: [],
+      syncStatus: "err",
+      syncError: firstAttempt.error,
+    });
+    expect(failureSummary.badgeState).toBe("err");
+
+    const retryAttempt = await syncPush("DOG-RETRY", "session", localSession, dog);
+    expect(retryAttempt.ok).toBe(true);
+    expect(remoteSessions).toHaveLength(1);
+
+    const localAfterRetry = [{ ...erroredLocal[0], pendingSync: false, syncState: SYNC_STATE.SYNCED, syncError: "" }];
+    const reconciled = mergeMutationSafeSyncCollection({
+      currentItems: localAfterRetry,
+      remoteItems: [{
+        id: "sess-retry",
+        date: "2026-04-11T09:00:00.000Z",
+        plannedDuration: 180,
+        actualDuration: 150,
+        distressLevel: "subtle",
+        result: "distress",
+      }],
+      tombstones: [],
+      kind: "session",
+      mapLocalItem: (entry) => entry,
+      mapRemoteItem: (entry) => ({ ...entry, pendingSync: false, syncState: SYNC_STATE.SYNCED, syncError: "" }),
+    });
+
+    expect(reconciled[0]).toEqual(expect.objectContaining({
+      id: "sess-retry",
+      pendingSync: false,
+      syncState: SYNC_STATE.SYNCED,
+    }));
+
+    const successSummary = computeSyncSummary({
+      syncEnabled: true,
+      sessions: reconciled,
+      walks: [],
+      patterns: [],
+      feedings: [],
+      tombstones: [],
+      syncStatus: "ok",
+      syncError: "",
+    });
+    expect(successSummary.badgeState).toBe("ok");
+  });
+
+  it("hydrates pending tombstones from reload and preserves retry semantics until confirmed", async () => {
+    const storage = createMemoryStorage();
+    vi.stubGlobal("localStorage", storage);
+
+    save(tombKey("DOG-HYDRATE"), [{
+      id: "walk-dead",
+      kind: "walk",
+      deletedAt: "2026-04-12T08:00:00.000Z",
+      revision: 4,
+      pendingSync: true,
+      syncState: SYNC_STATE.ERROR,
+      syncError: "Delete marker push failed",
+    }]);
+    save(sessKey("DOG-HYDRATE"), [{
+      id: "walk-dead",
+      date: "2026-04-12T07:30:00.000Z",
+      plannedDuration: 120,
+      actualDuration: 90,
+      distressLevel: "subtle",
+      result: "distress",
+    }]);
+
+    const hydrated = hydrateDogFromLocal("DOG-HYDRATE");
+    const filteredSessions = applyTombstonesToCollection(hydrated.sessions, hydrated.tombstones, "session");
+
+    expect(hydrated.tombstones).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "walk-dead", pendingSync: true, syncState: SYNC_STATE.ERROR }),
+    ]));
+    expect(filteredSessions).toHaveLength(1);
+
+    const pendingSummary = computeSyncSummary({
+      syncEnabled: true,
+      sessions: hydrated.sessions,
+      walks: [],
+      patterns: [],
+      feedings: [],
+      tombstones: hydrated.tombstones,
+      syncStatus: "ok",
+      syncError: "",
+    });
+    expect(pendingSummary.badgeState).toBe("err");
+
+    global.fetch = vi.fn(async (url, options = {}) => {
+      const path = getPath(url);
+      if (path === "dogs" && (options.method || "GET") === "GET") return jsonResponse(200, []);
+      if (path === "dogs" && (options.method || "GET") === "POST") return jsonResponse(201, {});
+      if (path === "walks" && (options.method || "GET") === "POST") return jsonResponse(201, {});
+      return jsonResponse(200, []);
+    });
+
+    const { syncPushTombstone } = await setupStorageModule();
+    const pushResult = await syncPushTombstone("DOG-HYDRATE", hydrated.tombstones[0], { id: "DOG-HYDRATE", dogName: "Echo" });
+    expect(pushResult.ok).toBe(true);
+
+    const confirmedSummary = computeSyncSummary({
+      syncEnabled: true,
+      sessions: hydrated.sessions,
+      walks: [],
+      patterns: [],
+      feedings: [],
+      tombstones: [{ ...hydrated.tombstones[0], pendingSync: false, syncState: SYNC_STATE.SYNCED, syncError: "" }],
+      syncStatus: "ok",
+      syncError: "",
+    });
+    expect(confirmedSummary.badgeState).toBe("ok");
+  });
+
+  it("surfaces explicit error states when localStorage.setItem throws", () => {
+    const storage = createMemoryStorage(() => {
+      throw new Error("quota exceeded");
+    });
+    vi.stubGlobal("localStorage", storage);
+
+    const rawSave = save(sessKey("DOG-STORE-ERR"), [{ id: "sess-err" }]);
+    expect(rawSave.ok).toBe(false);
+
+    const persisted = persistValue(sessKey("DOG-STORE-ERR"), [{ id: "sess-err" }], save);
+    expect(persisted.ok).toBe(false);
+    expect(persisted.error).toContain("Unable to save local data");
+
+    const erroredEntries = markCollectionStorageError([{ id: "sess-err", pendingSync: false, syncState: SYNC_STATE.SYNCED }], persisted.error);
+    expect(erroredEntries[0]).toEqual(expect.objectContaining({
+      id: "sess-err",
+      pendingSync: true,
+      syncState: SYNC_STATE.ERROR,
+      syncError: expect.stringContaining("Unable to save local data"),
+    }));
+
+    const summary = computeSyncSummary({
+      syncEnabled: true,
+      sessions: erroredEntries,
+      walks: [],
+      patterns: [],
+      feedings: [],
+      tombstones: [],
+      syncStatus: "ok",
+      syncError: persisted.error,
+    });
+    expect(summary.badgeState).toBe("err");
+    expect(summary.detail).toContain("Unable to save local data");
+
+    expect(formatStorageWriteError(new Error("quota exceeded"), sessKey("DOG-STORE-ERR"))).toContain(sessKey("DOG-STORE-ERR"));
+  });
+
+  it("never reports healthy status while pending or errored sync artifacts remain", () => {
+    const withLocalPending = computeSyncSummary({
+      syncEnabled: true,
+      sessions: [{ id: "sess-local", pendingSync: true, syncState: SYNC_STATE.LOCAL }],
+      walks: [],
+      patterns: [],
+      feedings: [],
+      tombstones: [],
+      syncStatus: "ok",
+      syncError: "",
+    });
+    expect(withLocalPending.badgeState).not.toBe("ok");
+
+    const withErroredTombstone = computeSyncSummary({
+      syncEnabled: true,
+      sessions: [],
+      walks: [],
+      patterns: [],
+      feedings: [],
+      tombstones: [{ id: "dead-1", kind: "session", pendingSync: true, syncState: SYNC_STATE.ERROR, syncError: "network" }],
+      syncStatus: "ok",
+      syncError: "",
+    });
+    expect(withErroredTombstone.badgeState).toBe("err");
+
+    const healthyOnlyWhenClean = computeSyncSummary({
+      syncEnabled: true,
+      sessions: [{ id: "sess-synced", pendingSync: false, syncState: SYNC_STATE.SYNCED }],
+      walks: [],
+      patterns: [],
+      feedings: [],
+      tombstones: [{ id: "dead-1", kind: "session", pendingSync: false, syncState: SYNC_STATE.SYNCED }],
+      syncStatus: "ok",
+      syncError: "",
+    });
+    expect(healthyOnlyWhenClean.badgeState).toBe("ok");
+  });
+});


### PR DESCRIPTION
### Motivation

- Make sync badge/status logic testable and tombstone-aware so the UI never reports healthy while pending/error sync artifacts remain. 
- Capture real-world orchestration behaviors (mixed push outcomes, interrupted in-flight syncs, tombstone hydration) with focused runtime/integration-like tests. 
- Surface local persistence failures (e.g., `localStorage.setItem` throwing) as explicit error states so they influence sync health.

### Description

- Extracted the sync-summary computation into `src/features/app/syncSummary.js` as `computeSyncSummary` and exported `SYNC_STATE` for reuse. 
- Updated `src/App.jsx` to consume `computeSyncSummary` and include `tombstones` in the health calculation so pending/error tombstones block a healthy status. 
- Added `tests/syncOrchestration.test.js` with runtime-style cases covering: mixed-kind push successes/failures, interrupted sync + retry reconciliation, hydration with pending tombstones and retry semantics, localStorage write-failure surfacing, and explicit healthy/not-healthy assertions. 
- Kept existing storage-level behavior intact; tests interact with `syncPush`/`syncPushTombstone`, `hydrateDogFromLocal`, persistence helpers, and a memory `localStorage` mock.

### Testing

- Ran `npm test -- tests/syncOrchestration.test.js` and the new orchestration suite passed. 
- Also exercised related suites during development: `tests/persistenceWriteFailures.test.js` and `tests/syncFetchRuntime.test.js` (these passed after an initial failing expectation in the orchestration test that was fixed). 
- The combined validation sequence was: initial combined run surfaced a failing expectation which was corrected, and subsequent runs show the targeted tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfde90e1108332974c597bce048982)