### PR TITLE
Enforce partial-capability mode for outbound sync

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import { sortValidDateAsc } from "./lib/dateSort";
 import { selectAppData } from "./features/app/selectors";
 import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeMutationSafeSyncCollection, mergeSessionWithDerivedFields, mergeTombstonesByEntityKey, normalizeDogSyncMetadata, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, pruneTombstonesForRetention, resolveDogSettingsConflict, save, sessKey, stampLocalDogSettings, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
 import { markCollectionStorageError, persistJoinedDogState, persistValue } from "./features/app/persistence";
+import { buildPartialCapabilitySyncMessage, partitionPendingOutboundByCapability } from "./features/app/syncCapability";
 import { computeSyncSummary } from "./features/app/syncSummary";
 import { fmt, fmtClock, getOutcomeTone, normalizeWalkType, walkTypeLabel } from "./features/app/helpers";
 import { CameraIcon, ChartIcon, HistoryIcon, HomeIcon, PawIcon, SettingsIcon } from "./features/app/ui.jsx";
@@ -24,6 +25,7 @@ const SYNC_STATE = {
   SYNCING: "syncing",
   SYNCED: "synced",
   ERROR: "error",
+  UNSUPPORTED: "unsupported",
 };
 
 function recoveryStateEqual(a, b) {
@@ -388,7 +390,7 @@ export default function PawTimer() {
       ...item,
       pendingSync: nextSyncState !== SYNC_STATE.SYNCED,
       syncState: nextSyncState,
-      syncError: nextSyncState === SYNC_STATE.ERROR ? errorMessage : "",
+      syncError: (nextSyncState === SYNC_STATE.ERROR || nextSyncState === SYNC_STATE.UNSUPPORTED) ? errorMessage : "",
     }));
   }, [updateCollectionEntry]);
 
@@ -549,8 +551,18 @@ export default function PawTimer() {
           ...mergedFeedings.filter((entry) => entry.pendingSync).map((entry) => ({ kind: "feeding", entry })),
         ];
 
+        const { supported: supportedPendingEntries, unsupported: unsupportedPendingEntries } = partitionPendingOutboundByCapability(pendingEntries, remote?.syncCapability);
+        unsupportedPendingEntries.forEach(({ kind, entry }) => {
+          syncHelpersRef.current.setEntrySyncState(
+            kind,
+            entry.id,
+            SYNC_STATE.UNSUPPORTED,
+            "Unsupported in current backend capability profile; retained locally until table support is available.",
+          );
+        });
+
         let allPendingFlushed = true;
-        for (const { kind, entry } of pendingEntries) {
+        for (const { kind, entry } of supportedPendingEntries) {
           const pushed = await pushPendingEntry(kind, entry, dogSettings);
           allPendingFlushed = allPendingFlushed && pushed;
         }
@@ -575,9 +587,7 @@ export default function PawTimer() {
           },
         }));
         const isPartialSync = remote?.syncCapability?.mode === "partial";
-        const partialSyncMessage = isPartialSync
-          ? `Partial sync active: ${ensureArray(remote?.syncCapability?.missingOptionalTables).join(", ")} unavailable.`
-          : "";
+        const partialSyncMessage = buildPartialCapabilitySyncMessage(remote?.syncCapability, unsupportedPendingEntries.length);
         setSyncError(error || partialSyncMessage);
         setSyncStatus(error ? "err" : isPartialSync ? "partial" : "ok");
       } finally {

--- a/src/features/app/syncCapability.js
+++ b/src/features/app/syncCapability.js
@@ -1,0 +1,59 @@
+import { ensureArray, ensureObject } from "./storage";
+
+const DEFAULT_TABLE_SUPPORT = {
+  sessions: { supported: true, optional: false },
+  walks: { supported: true, optional: false },
+  patterns: { supported: true, optional: true },
+  feedings: { supported: true, optional: true },
+};
+
+const KIND_TO_TABLE = {
+  session: "sessions",
+  walk: "walks",
+  pattern: "patterns",
+  feeding: "feedings",
+};
+
+export const normalizeSyncCapabilityProfile = (syncCapability = null) => {
+  const profile = ensureObject(syncCapability);
+  const tableSupport = { ...DEFAULT_TABLE_SUPPORT, ...ensureObject(profile.tableSupport) };
+  const missingOptionalTables = ensureArray(profile.missingOptionalTables).filter((table) => typeof table === "string" && table.trim());
+  const mode = profile.mode === "partial" || missingOptionalTables.length ? "partial" : "full";
+  return {
+    mode,
+    missingOptionalTables,
+    tableSupport,
+  };
+};
+
+export const isKindSupportedForOutboundSync = (kind, syncCapability = null) => {
+  const profile = normalizeSyncCapabilityProfile(syncCapability);
+  const table = KIND_TO_TABLE[kind];
+  if (!table) return true;
+  return profile.tableSupport?.[table]?.supported !== false;
+};
+
+export const partitionPendingOutboundByCapability = (pendingEntries = [], syncCapability = null) => {
+  const supported = [];
+  const unsupported = [];
+  ensureArray(pendingEntries).forEach((pendingEntry) => {
+    if (!pendingEntry?.entry?.pendingSync) return;
+    if (isKindSupportedForOutboundSync(pendingEntry.kind, syncCapability)) {
+      supported.push(pendingEntry);
+      return;
+    }
+    unsupported.push(pendingEntry);
+  });
+  return { supported, unsupported };
+};
+
+export const buildPartialCapabilitySyncMessage = (syncCapability = null, unsupportedPendingCount = 0) => {
+  const profile = normalizeSyncCapabilityProfile(syncCapability);
+  if (profile.mode !== "partial") return "";
+  const unsupportedTables = ensureArray(profile.missingOptionalTables).join(", ");
+  const pendingSuffix = unsupportedPendingCount > 0
+    ? ` ${unsupportedPendingCount} local change${unsupportedPendingCount === 1 ? "" : "s"} cannot sync until those tables are available.`
+    : "";
+  return `Partial sync active: ${unsupportedTables} unavailable.${pendingSuffix}`;
+};
+

--- a/src/features/app/syncSummary.js
+++ b/src/features/app/syncSummary.js
@@ -3,6 +3,7 @@ export const SYNC_STATE = {
   SYNCING: "syncing",
   SYNCED: "synced",
   ERROR: "error",
+  UNSUPPORTED: "unsupported",
 };
 
 export const computeSyncSummary = ({
@@ -20,7 +21,7 @@ export const computeSyncSummary = ({
     const state = entry?.syncState || (entry?.pendingSync ? SYNC_STATE.LOCAL : SYNC_STATE.SYNCED);
     acc[state] = (acc[state] || 0) + 1;
     return acc;
-  }, { [SYNC_STATE.LOCAL]: 0, [SYNC_STATE.SYNCING]: 0, [SYNC_STATE.SYNCED]: 0, [SYNC_STATE.ERROR]: 0 });
+  }, { [SYNC_STATE.LOCAL]: 0, [SYNC_STATE.SYNCING]: 0, [SYNC_STATE.SYNCED]: 0, [SYNC_STATE.ERROR]: 0, [SYNC_STATE.UNSUPPORTED]: 0 });
 
   if (!syncEnabled) {
     return {
@@ -46,19 +47,19 @@ export const computeSyncSummary = ({
     };
   }
 
+  if (syncStatus === "partial" || counts[SYNC_STATE.UNSUPPORTED] > 0) {
+    return {
+      badgeState: "idle",
+      label: "Partial sync",
+      detail: syncError || "Some optional activity tables are unavailable on the server, so sync coverage is incomplete.",
+    };
+  }
+
   if (counts[SYNC_STATE.LOCAL] > 0) {
     return {
       badgeState: "idle",
       label: `${counts[SYNC_STATE.LOCAL]} local only`,
       detail: "These changes are stored locally and will stay visible until the server confirms them.",
-    };
-  }
-
-  if (syncStatus === "partial") {
-    return {
-      badgeState: "idle",
-      label: "Partial sync",
-      detail: syncError || "Some optional activity tables are unavailable on the server, so sync coverage is incomplete.",
     };
   }
 

--- a/tests/syncCapability.test.js
+++ b/tests/syncCapability.test.js
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { computeSyncSummary, SYNC_STATE } from "../src/features/app/syncSummary";
+import {
+  buildPartialCapabilitySyncMessage,
+  isKindSupportedForOutboundSync,
+  partitionPendingOutboundByCapability,
+} from "../src/features/app/syncCapability";
+
+describe("sync capability outbound enforcement", () => {
+  const partialCapability = {
+    mode: "partial",
+    missingOptionalTables: ["patterns", "feedings"],
+    tableSupport: {
+      sessions: { supported: true, optional: false },
+      walks: { supported: true, optional: false },
+      patterns: { supported: false, optional: true },
+      feedings: { supported: false, optional: true },
+    },
+  };
+
+  it("marks patterns as unsupported while keeping sessions supported", () => {
+    expect(isKindSupportedForOutboundSync("pattern", partialCapability)).toBe(false);
+    expect(isKindSupportedForOutboundSync("session", partialCapability)).toBe(true);
+  });
+
+  it("marks feedings as unsupported while keeping walks supported", () => {
+    expect(isKindSupportedForOutboundSync("feeding", partialCapability)).toBe(false);
+    expect(isKindSupportedForOutboundSync("walk", partialCapability)).toBe(true);
+  });
+
+  it("partitions pending outbound pushes so unsupported kinds are skipped", () => {
+    const pending = [
+      { kind: "session", entry: { id: "sess-1", pendingSync: true } },
+      { kind: "walk", entry: { id: "walk-1", pendingSync: true } },
+      { kind: "pattern", entry: { id: "pat-1", pendingSync: true } },
+      { kind: "feeding", entry: { id: "feed-1", pendingSync: true } },
+    ];
+    const partitioned = partitionPendingOutboundByCapability(pending, partialCapability);
+    expect(partitioned.supported.map((item) => item.kind)).toEqual(["session", "walk"]);
+    expect(partitioned.unsupported.map((item) => item.kind)).toEqual(["pattern", "feeding"]);
+  });
+
+  it("builds explicit partial-capability messaging including unsynced unsupported counts", () => {
+    const message = buildPartialCapabilitySyncMessage(partialCapability, 2);
+    expect(message).toContain("Partial sync active");
+    expect(message).toContain("patterns, feedings unavailable");
+    expect(message).toContain("2 local changes cannot sync");
+  });
+
+  it("reports partial status cleanly when unsupported local entries are present", () => {
+    const summary = computeSyncSummary({
+      syncEnabled: true,
+      sessions: [],
+      walks: [],
+      patterns: [{ id: "pat-1", pendingSync: true, syncState: SYNC_STATE.UNSUPPORTED }],
+      feedings: [],
+      tombstones: [],
+      syncStatus: "partial",
+      syncError: "Partial sync active: patterns unavailable.",
+    });
+
+    expect(summary.badgeState).toBe("idle");
+    expect(summary.label).toBe("Partial sync");
+    expect(summary.detail).toContain("Partial sync active");
+  });
+
+  it("keeps full capability outbound sync untouched for supported tables", () => {
+    const fullCapability = {
+      mode: "full",
+      missingOptionalTables: [],
+      tableSupport: {
+        sessions: { supported: true, optional: false },
+        walks: { supported: true, optional: false },
+        patterns: { supported: true, optional: true },
+        feedings: { supported: true, optional: true },
+      },
+    };
+    const pending = [
+      { kind: "session", entry: { id: "sess-1", pendingSync: true } },
+      { kind: "walk", entry: { id: "walk-1", pendingSync: true } },
+      { kind: "pattern", entry: { id: "pat-1", pendingSync: true } },
+      { kind: "feeding", entry: { id: "feed-1", pendingSync: true } },
+    ];
+    const partitioned = partitionPendingOutboundByCapability(pending, fullCapability);
+    expect(partitioned.unsupported).toHaveLength(0);
+    expect(partitioned.supported).toHaveLength(4);
+  });
+});
+

--- a/tests/syncFetchRuntime.test.js
+++ b/tests/syncFetchRuntime.test.js
@@ -146,6 +146,28 @@ describe("syncFetch runtime fallbacks", () => {
     expect(result.syncCapability.tableSupport.feedings.supported).toBe(true);
   });
 
+  it("degrades gracefully when only feedings table is missing", async () => {
+    global.fetch = vi.fn(async (url) => {
+      const { path } = getPathAndParams(url);
+      if (path === "dogs") return jsonResponse(200, [{ id: "DOG2B", settings: { dogName: "Milo" } }]);
+      if (path === "sessions") return jsonResponse(200, []);
+      if (path === "walks") return jsonResponse(200, []);
+      if (path === "patterns") return jsonResponse(200, []);
+      if (path === "feedings") return jsonResponse(400, { message: "relation \"feedings\" does not exist" });
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const { syncFetch } = await setupStorageModule();
+    const { result, error } = await syncFetch("DOG2B");
+
+    expect(error).toBeNull();
+    expect(result.feedings).toEqual([]);
+    expect(result.syncCapability.mode).toBe("partial");
+    expect(result.syncCapability.missingOptionalTables).toEqual(["feedings"]);
+    expect(result.syncCapability.tableSupport.feedings.supported).toBe(false);
+    expect(result.syncCapability.tableSupport.patterns.supported).toBe(true);
+  });
+
   it("requests walk sync metadata and preserves non-default walk types", async () => {
     const walkSelectAttempts = [];
     global.fetch = vi.fn(async (url) => {


### PR DESCRIPTION
### Motivation
- Root cause: `syncFetch` already detects partial capability when optional tables (e.g., `patterns`/`feedings`) are missing, but the sync orchestrator continued attempting outbound pushes for those kinds, causing permanent schema errors and endless retry loops. 
- Goal: make partial-capability an explicit runtime mode and ensure unsupported entity kinds are intentionally skipped from outbound pushes while preserving truthful local state.

### Description
- Added `src/features/app/syncCapability.js` to normalize capability profiles, map entity kinds to tables, partition pending outbound entries into `supported` vs `unsupported`, and build consistent partial-mode messages. 
- Updated `src/App.jsx` sync orchestration to partition pending entries using the capability profile, mark unsupported entries with a new `SYNC_STATE.UNSUPPORTED` state and a clear error message, and skip outbound push attempts for unsupported kinds while continuing to push supported kinds and tombstones. 
- Updated `src/features/app/syncSummary.js` to account for `UNSUPPORTED` sync state and surface a clean `Partial sync` status and messaging when partial capability is active. 
- Preserved semantics: unsupported entries remain pending and are not incorrectly marked as synced; business/recommendation/session logic unchanged.

### Testing
- Added `tests/syncCapability.test.js` and extended `tests/syncFetchRuntime.test.js` to cover missing `patterns` and `feedings` cases and verify outbound partitioning behavior. 
- Ran the targeted test suite with `npm test -- tests/syncFetchRuntime.test.js tests/syncCapability.test.js tests/syncOrchestration.test.js`, and all tests passed (3 files, 23 tests). 
- Verified that supported tables continue to sync normally and that unsupported kinds are skipped outbound and reflected as partial-capability in sync status (no infinite retry loops observed in tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe1d0e64c833297bd9de0db58786c)