### PR TITLE
Prevent in-flight sync tombstone race by applying authoritative tombstones at commit

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import { PROTOCOL, explainNextTarget, normalizeDistressLevel, suggestNext, sugge
 import { sortByDateAsc } from "./lib/activityDateTime";
 import { sortValidDateAsc } from "./lib/dateSort";
 import { selectAppData } from "./features/app/selectors";
-import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeMutationSafeSyncCollection, mergeSessionWithDerivedFields, mergeTombstonesByEntityKey, normalizeDogSyncMetadata, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, pruneTombstonesForRetention, resolveDogSettingsConflict, save, sessKey, stampLocalDogSettings, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
+import { ACTIVE_DOG_KEY, DOGS_KEY, SB_BASE_URL, SB_KEY, SB_URL, SYNC_ENABLED, applyAuthoritativeTombstonesAtCommit, applyTombstonesToCollection, canonicalDogId, ensureArray, ensureObject, feedingKey, generateId, getSyncDegradationState, hydrateDogFromLocal, load, logSyncDebug, makeEntryId, mergeMutationSafeSyncCollection, mergeSessionWithDerivedFields, mergeTombstonesByEntityKey, normalizeDogSyncMetadata, normalizeFeedings, normalizeSessions, normalizeTombstones, patKey, patLblKey, photoKey, pruneTombstonesForRetention, resolveDogSettingsConflict, save, sessKey, stampLocalDogSettings, syncFetch, syncPush, syncPushTombstone, syncUpsertDog, toDateTimeLocalValue, tombKey, walkKey } from "./features/app/storage";
 import { markCollectionStorageError, persistJoinedDogState, persistValue } from "./features/app/persistence";
 import { buildPartialCapabilitySyncMessage, partitionPendingOutboundByCapability } from "./features/app/syncCapability";
 import { computeSyncSummary } from "./features/app/syncSummary";
@@ -96,6 +96,7 @@ export default function PawTimer() {
   const startRef = useRef(null);
   const syncInFlightRef = useRef(false);
   const syncSnapshotRef = useRef({ dogs: [], sessions: [], walks: [], patterns: [], feedings: [], tombstones: [] });
+  const tombstonesRef = useRef([]);
   const syncHelpersRef = useRef({
     commitSessions: null,
     commitWalks: null,
@@ -181,6 +182,10 @@ export default function PawTimer() {
   useEffect(() => {
     syncSnapshotRef.current = { dogs, sessions, walks, patterns, feedings, tombstones };
   }, [dogs, sessions, walks, patterns, feedings, tombstones]);
+
+  useEffect(() => {
+    tombstonesRef.current = tombstones;
+  }, [tombstones]);
 
   useEffect(() => { save(DOGS_KEY, dogs); }, [dogs]);
   useEffect(() => { save(ACTIVE_DOG_KEY, canonicalDogId(activeDogId)); }, [activeDogId]);
@@ -334,9 +339,11 @@ export default function PawTimer() {
         if (!writeResult.ok) {
           reportLocalWriteFailure(writeResult.error);
           committed = markCollectionStorageError(normalized, writeResult.error);
+          tombstonesRef.current = committed;
           return committed;
         }
       }
+      tombstonesRef.current = normalized;
       committed = normalized;
       return normalized;
     });
@@ -541,14 +548,25 @@ export default function PawTimer() {
           mapLocalItem: withHydratedSyncState,
           mapRemoteItem: markRemoteEntryConfirmed,
         }));
+        const latestSuppressedCollections = applyAuthoritativeTombstonesAtCommit({
+          sessions: mergedSessions,
+          walks: mergedWalks,
+          patterns: mergedPatterns,
+          feedings: mergedFeedings,
+          tombstones: tombstonesRef.current,
+        });
+        const committedSessions = syncHelpersRef.current.commitSessions(latestSuppressedCollections.sessions);
+        const committedWalks = syncHelpersRef.current.commitWalks(latestSuppressedCollections.walks);
+        const committedPatterns = syncHelpersRef.current.commitPatterns(latestSuppressedCollections.patterns);
+        const committedFeedings = syncHelpersRef.current.commitFeedings(latestSuppressedCollections.feedings);
 
         const currentDog = snapshot.dogs.find((d) => canonicalDogId(d.id) === canonicalDogId(activeDogId));
         const dogSettings = currentDog ? { ...currentDog, id: canonicalDogId(currentDog.id) } : remoteDog;
         const pendingEntries = [
-          ...mergedSessions.filter((entry) => entry.pendingSync).map((entry) => ({ kind: "session", entry })),
-          ...mergedWalks.filter((entry) => entry.pendingSync).map((entry) => ({ kind: "walk", entry })),
-          ...mergedPatterns.filter((entry) => entry.pendingSync).map((entry) => ({ kind: "pattern", entry })),
-          ...mergedFeedings.filter((entry) => entry.pendingSync).map((entry) => ({ kind: "feeding", entry })),
+          ...committedSessions.filter((entry) => entry.pendingSync).map((entry) => ({ kind: "session", entry })),
+          ...committedWalks.filter((entry) => entry.pendingSync).map((entry) => ({ kind: "walk", entry })),
+          ...committedPatterns.filter((entry) => entry.pendingSync).map((entry) => ({ kind: "pattern", entry })),
+          ...committedFeedings.filter((entry) => entry.pendingSync).map((entry) => ({ kind: "feeding", entry })),
         ];
 
         const { supported: supportedPendingEntries, unsupported: unsupportedPendingEntries } = partitionPendingOutboundByCapability(pendingEntries, remote?.syncCapability);
@@ -572,7 +590,7 @@ export default function PawTimer() {
         }
 
         const syncDog = remoteDog ?? currentDog;
-        syncHelpersRef.current.recomputeTarget(mergedSessions, mergedWalks, mergedPatterns, syncDog);
+        syncHelpersRef.current.recomputeTarget(committedSessions, committedWalks, committedPatterns, syncDog);
         if (!allPendingFlushed) {
           setSyncError("Some local changes are still waiting for confirmation.");
           setSyncStatus("err");
@@ -580,10 +598,10 @@ export default function PawTimer() {
         }
         commitTombstones((prev) => pruneTombstonesForRetention(prev, {
           activityByKind: {
-            session: mergedSessions,
-            walk: mergedWalks,
-            pattern: mergedPatterns,
-            feeding: mergedFeedings,
+            session: committedSessions,
+            walk: committedWalks,
+            pattern: committedPatterns,
+            feeding: committedFeedings,
           },
         }));
         const isPartialSync = remote?.syncCapability?.mode === "partial";

--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -665,6 +665,19 @@ export const applyTombstonesToCollection = (items = [], tombstones = [], kind = 
   });
 };
 
+export const applyAuthoritativeTombstonesAtCommit = ({
+  sessions = [],
+  walks = [],
+  patterns = [],
+  feedings = [],
+  tombstones = [],
+} = {}) => ({
+  sessions: applyTombstonesToCollection(sessions, tombstones, "session"),
+  walks: applyTombstonesToCollection(walks, tombstones, "walk"),
+  patterns: applyTombstonesToCollection(patterns, tombstones, "pattern"),
+  feedings: applyTombstonesToCollection(feedings, tombstones, "feeding"),
+});
+
 export const TOMBSTONE_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
 const hasConflictingActiveEntity = (entry, activityByKind = {}) => {

--- a/tests/syncConflict.test.js
+++ b/tests/syncConflict.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { applyTombstonesToCollection, mergeMutationSafeSyncCollection, mergeTombstonesByEntityKey, pruneTombstonesForRetention, resolveDogSettingsConflict, resolveSyncConflict, TOMBSTONE_RETENTION_MS } from "../src/features/app/storage";
+import { applyAuthoritativeTombstonesAtCommit, applyTombstonesToCollection, mergeMutationSafeSyncCollection, mergeTombstonesByEntityKey, pruneTombstonesForRetention, resolveDogSettingsConflict, resolveSyncConflict, TOMBSTONE_RETENTION_MS } from "../src/features/app/storage";
+import { selectAppData } from "../src/features/app/selectors";
 
 const iso = (hour) => `2026-04-01T${String(hour).padStart(2, "0")}:00:00.000Z`;
 
@@ -232,6 +233,64 @@ describe("mergeMutationSafeSyncCollection concurrent edits", () => {
     });
 
     expect(merged).toEqual([]);
+  });
+
+  it("applies authoritative tombstones at commit so late local deletes cannot be bypassed", () => {
+    const staleTombstones = [];
+    const mergedSessions = mergeMutationSafeSyncCollection({
+      currentItems: [],
+      remoteItems: [{ id: "session-race", date: iso(8), revision: 2, updatedAt: iso(8), result: "success", actualDuration: 240 }],
+      tombstones: staleTombstones,
+      kind: "session",
+    });
+    expect(mergedSessions.map((row) => row.id)).toEqual(["session-race"]);
+
+    const authoritativeTombstones = [{ id: "session-race", kind: "session", deletedAt: iso(10), revision: 3, updatedAt: iso(10), pendingSync: true }];
+    const committed = applyAuthoritativeTombstonesAtCommit({
+      sessions: mergedSessions,
+      walks: [],
+      patterns: [],
+      feedings: [],
+      tombstones: authoritativeTombstones,
+    });
+
+    expect(committed.sessions).toEqual([]);
+  });
+
+  it("keeps downstream recompute delete-consistent when tombstone is created after merge stage", () => {
+    const staleMergedSessions = [{
+      id: "session-recompute",
+      date: iso(8),
+      revision: 4,
+      updatedAt: iso(8),
+      distressLevel: "none",
+      actualDuration: 300,
+      plannedDuration: 300,
+      result: "success",
+    }];
+    const authoritativeTombstones = [{ id: "session-recompute", kind: "session", deletedAt: iso(10), revision: 5, updatedAt: iso(10), pendingSync: true }];
+
+    const committed = applyAuthoritativeTombstonesAtCommit({
+      sessions: staleMergedSessions,
+      walks: [],
+      patterns: [],
+      feedings: [],
+      tombstones: authoritativeTombstones,
+    });
+    const appData = selectAppData({
+      dogs: [{ id: "DOG-RACE", dogName: "Race Dog", goalSeconds: 2400 }],
+      activeDogId: "DOG-RACE",
+      sessions: committed.sessions,
+      walks: [],
+      patterns: [],
+      feedings: [],
+      target: 2400,
+      protoOverride: {},
+      recommendation: { duration: 2400, decisionState: null, explanation: "", details: {} },
+    });
+
+    expect(committed.sessions).toEqual([]);
+    expect(appData.daily.count).toBe(0);
   });
 
 


### PR DESCRIPTION
### Motivation

- Root cause: the sync pipeline merged tombstones once, then merged collections and applied suppression using that earlier snapshot, so a local tombstone created after the tombstone-merge but before collection commit could be missed and allow a remote row to briefly reappear during the same sync cycle.
- Goal: ensure commit-time state uses the latest authoritative tombstone set so locally-created tombstones during an in-flight sync cannot be bypassed in that same cycle while preserving durable tombstone semantics.

### Description

- Added `applyAuthoritativeTombstonesAtCommit(...)` in `src/features/app/storage.js` to perform a commit-time suppression pass for sessions/walks/patterns/feedings against an authoritative tombstone set.
- Introduced `tombstonesRef` in `src/App.jsx` and kept it in sync with `tombstones` state (including from `commitTombstones`) so the sync orchestration can read the latest tombstones during commit.
- Updated sync flow in `src/App.jsx` to: (1) perform normal merges, (2) re-apply suppression at commit using `tombstonesRef.current`, (3) commit those suppressed collections, and (4) use the committed (suppressed) collections for pending-push selection, recompute inputs, and tombstone retention checks — thereby closing the race window without changing business logic.
- Added tests in `tests/syncConflict.test.js` that simulate: late/local tombstone creation after merge, commit-time suppression preventing same-cycle resurrection, and downstream recompute observing deletion-consistent state; existing tombstone durability tests remain intact.

### Testing

- Ran `npm test -- tests/syncConflict.test.js` and the entire file passed (31 tests): success.
- Ran `npm test -- tests/syncOrchestration.test.js` and the file passed (5 tests): success.
- New unit tests validate that a tombstone created after collection-merge is applied at commit and that recompute inputs reflect the deletion (all new/updated tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe2f7dce48332bd34e3e58729a5cb)