### PR TITLE
Fix runtime edit/history/progress regression by making commit flows synchronous

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -96,6 +96,10 @@ export default function PawTimer() {
   const startRef = useRef(null);
   const syncInFlightRef = useRef(false);
   const syncSnapshotRef = useRef({ dogs: [], sessions: [], walks: [], patterns: [], feedings: [], tombstones: [] });
+  const sessionsRef = useRef([]);
+  const walksRef = useRef([]);
+  const patternsRef = useRef([]);
+  const feedingsRef = useRef([]);
   const tombstonesRef = useRef([]);
   const syncHelpersRef = useRef({
     commitSessions: null,
@@ -183,6 +187,10 @@ export default function PawTimer() {
     syncSnapshotRef.current = { dogs, sessions, walks, patterns, feedings, tombstones };
   }, [dogs, sessions, walks, patterns, feedings, tombstones]);
 
+  useEffect(() => { sessionsRef.current = sessions; }, [sessions]);
+  useEffect(() => { walksRef.current = walks; }, [walks]);
+  useEffect(() => { patternsRef.current = patterns; }, [patterns]);
+  useEffect(() => { feedingsRef.current = feedings; }, [feedings]);
   useEffect(() => {
     tombstonesRef.current = tombstones;
   }, [tombstones]);
@@ -248,105 +256,95 @@ export default function PawTimer() {
   }, []);
 
   const commitSessions = useCallback((updater) => {
-    let committed = [];
-    setSessions((prev) => {
-      const resolved = typeof updater === "function" ? updater(prev) : updater;
-      const normalized = sortByDateAsc(normalizeSessions(ensureArray(resolved)).map(withHydratedSyncState));
-      if (activeDogId) {
-        const writeResult = persistValue(sessKey(activeDogId), normalized, save);
-        if (!writeResult.ok) {
-          reportLocalWriteFailure(writeResult.error);
-          committed = markCollectionStorageError(normalized, writeResult.error);
-          recomputeTarget(committed);
-          return committed;
-        }
+    const previous = ensureArray(sessionsRef.current);
+    const resolved = typeof updater === "function" ? updater(previous) : updater;
+    const normalized = sortByDateAsc(normalizeSessions(ensureArray(resolved)).map(withHydratedSyncState));
+    let committed = normalized;
+    if (activeDogId) {
+      const writeResult = persistValue(sessKey(activeDogId), normalized, save);
+      if (!writeResult.ok) {
+        reportLocalWriteFailure(writeResult.error);
+        committed = markCollectionStorageError(normalized, writeResult.error);
       }
-      recomputeTarget(normalized);
-      committed = normalized;
-      return normalized;
-    });
+    }
+    sessionsRef.current = committed;
+    syncSnapshotRef.current = { ...syncSnapshotRef.current, sessions: committed };
+    setSessions(committed);
+    recomputeTarget(committed, walksRef.current, patternsRef.current, activeDog || {});
     return committed;
-  }, [activeDogId, recomputeTarget, reportLocalWriteFailure, withHydratedSyncState]);
+  }, [activeDog, activeDogId, recomputeTarget, reportLocalWriteFailure, withHydratedSyncState]);
 
   const commitWalks = useCallback((updater) => {
-    let committed = [];
-    setWalks((prev) => {
-      const resolved = typeof updater === "function" ? updater(prev) : updater;
-      const normalized = sortByDateAsc(ensureArray(resolved).map((item) => ({ ...withHydratedSyncState(item), type: normalizeWalkType(item?.type) })));
-      if (activeDogId) {
-        const writeResult = persistValue(walkKey(activeDogId), normalized, save);
-        if (!writeResult.ok) {
-          reportLocalWriteFailure(writeResult.error);
-          committed = markCollectionStorageError(normalized, writeResult.error);
-          recomputeTarget(sessions, committed, patterns, activeDog || {});
-          return committed;
-        }
+    const previous = ensureArray(walksRef.current);
+    const resolved = typeof updater === "function" ? updater(previous) : updater;
+    const normalized = sortByDateAsc(ensureArray(resolved).map((item) => ({ ...withHydratedSyncState(item), type: normalizeWalkType(item?.type) })));
+    let committed = normalized;
+    if (activeDogId) {
+      const writeResult = persistValue(walkKey(activeDogId), normalized, save);
+      if (!writeResult.ok) {
+        reportLocalWriteFailure(writeResult.error);
+        committed = markCollectionStorageError(normalized, writeResult.error);
       }
-      recomputeTarget(sessions, normalized, patterns, activeDog || {});
-      committed = normalized;
-      return normalized;
-    });
+    }
+    walksRef.current = committed;
+    syncSnapshotRef.current = { ...syncSnapshotRef.current, walks: committed };
+    setWalks(committed);
+    recomputeTarget(sessionsRef.current, committed, patternsRef.current, activeDog || {});
     return committed;
-  }, [activeDog, activeDogId, patterns, recomputeTarget, reportLocalWriteFailure, sessions, withHydratedSyncState]);
+  }, [activeDog, activeDogId, recomputeTarget, reportLocalWriteFailure, withHydratedSyncState]);
 
   const commitPatterns = useCallback((updater) => {
-    let committed = [];
-    setPatterns((prev) => {
-      const resolved = typeof updater === "function" ? updater(prev) : updater;
-      const normalized = sortByDateAsc(ensureArray(resolved).map(withHydratedSyncState));
-      if (activeDogId) {
-        const writeResult = persistValue(patKey(activeDogId), normalized, save);
-        if (!writeResult.ok) {
-          reportLocalWriteFailure(writeResult.error);
-          committed = markCollectionStorageError(normalized, writeResult.error);
-          recomputeTarget(sessions, walks, committed, activeDog || {});
-          return committed;
-        }
+    const previous = ensureArray(patternsRef.current);
+    const resolved = typeof updater === "function" ? updater(previous) : updater;
+    const normalized = sortByDateAsc(ensureArray(resolved).map(withHydratedSyncState));
+    let committed = normalized;
+    if (activeDogId) {
+      const writeResult = persistValue(patKey(activeDogId), normalized, save);
+      if (!writeResult.ok) {
+        reportLocalWriteFailure(writeResult.error);
+        committed = markCollectionStorageError(normalized, writeResult.error);
       }
-      recomputeTarget(sessions, walks, normalized, activeDog || {});
-      committed = normalized;
-      return normalized;
-    });
+    }
+    patternsRef.current = committed;
+    syncSnapshotRef.current = { ...syncSnapshotRef.current, patterns: committed };
+    setPatterns(committed);
+    recomputeTarget(sessionsRef.current, walksRef.current, committed, activeDog || {});
     return committed;
-  }, [activeDog, activeDogId, recomputeTarget, reportLocalWriteFailure, sessions, walks, withHydratedSyncState]);
+  }, [activeDog, activeDogId, recomputeTarget, reportLocalWriteFailure, withHydratedSyncState]);
 
   const commitFeedings = useCallback((updater) => {
-    let committed = [];
-    setFeedings((prev) => {
-      const resolved = typeof updater === "function" ? updater(prev) : updater;
-      const normalized = normalizeFeedings(ensureArray(resolved)).map(withHydratedSyncState);
-      if (activeDogId) {
-        const writeResult = persistValue(feedingKey(activeDogId), normalized, save);
-        if (!writeResult.ok) {
-          reportLocalWriteFailure(writeResult.error);
-          committed = markCollectionStorageError(normalized, writeResult.error);
-          return committed;
-        }
+    const previous = ensureArray(feedingsRef.current);
+    const resolved = typeof updater === "function" ? updater(previous) : updater;
+    const normalized = normalizeFeedings(ensureArray(resolved)).map(withHydratedSyncState);
+    let committed = normalized;
+    if (activeDogId) {
+      const writeResult = persistValue(feedingKey(activeDogId), normalized, save);
+      if (!writeResult.ok) {
+        reportLocalWriteFailure(writeResult.error);
+        committed = markCollectionStorageError(normalized, writeResult.error);
       }
-      committed = normalized;
-      return normalized;
-    });
+    }
+    feedingsRef.current = committed;
+    syncSnapshotRef.current = { ...syncSnapshotRef.current, feedings: committed };
+    setFeedings(committed);
     return committed;
   }, [activeDogId, reportLocalWriteFailure, withHydratedSyncState]);
 
   const commitTombstones = useCallback((updater) => {
-    let committed = [];
-    setTombstones((prev) => {
-      const resolved = typeof updater === "function" ? updater(prev) : updater;
-      const normalized = normalizeTombstones(ensureArray(resolved)).map(withHydratedSyncState);
-      if (activeDogId) {
-        const writeResult = persistValue(tombKey(activeDogId), normalized, save);
-        if (!writeResult.ok) {
-          reportLocalWriteFailure(writeResult.error);
-          committed = markCollectionStorageError(normalized, writeResult.error);
-          tombstonesRef.current = committed;
-          return committed;
-        }
+    const previous = ensureArray(tombstonesRef.current);
+    const resolved = typeof updater === "function" ? updater(previous) : updater;
+    const normalized = normalizeTombstones(ensureArray(resolved)).map(withHydratedSyncState);
+    let committed = normalized;
+    if (activeDogId) {
+      const writeResult = persistValue(tombKey(activeDogId), normalized, save);
+      if (!writeResult.ok) {
+        reportLocalWriteFailure(writeResult.error);
+        committed = markCollectionStorageError(normalized, writeResult.error);
       }
-      tombstonesRef.current = normalized;
-      committed = normalized;
-      return normalized;
-    });
+    }
+    tombstonesRef.current = committed;
+    syncSnapshotRef.current = { ...syncSnapshotRef.current, tombstones: committed };
+    setTombstones(committed);
     return committed;
   }, [activeDogId, reportLocalWriteFailure, withHydratedSyncState]);
 
@@ -423,11 +421,24 @@ export default function PawTimer() {
     const hydratedWalks = sortByDateAsc(ensureArray(local.walks).map((item) => ({ ...withHydratedSyncState(item), type: normalizeWalkType(item?.type) })));
     const hydratedPatterns = sortByDateAsc(ensureArray(local.patterns).map(withHydratedSyncState));
     const hydratedFeedings = normalizeFeedings(local.feedings).map(withHydratedSyncState);
+    tombstonesRef.current = hydratedTombstones;
+    sessionsRef.current = applyTombstonesToCollection(hydratedSessions, hydratedTombstones, "session");
+    walksRef.current = applyTombstonesToCollection(hydratedWalks, hydratedTombstones, "walk");
+    patternsRef.current = applyTombstonesToCollection(hydratedPatterns, hydratedTombstones, "pattern");
+    feedingsRef.current = applyTombstonesToCollection(hydratedFeedings, hydratedTombstones, "feeding");
+    syncSnapshotRef.current = {
+      ...syncSnapshotRef.current,
+      tombstones: tombstonesRef.current,
+      sessions: sessionsRef.current,
+      walks: walksRef.current,
+      patterns: patternsRef.current,
+      feedings: feedingsRef.current,
+    };
     setTombstones(hydratedTombstones);
-    setSessions(applyTombstonesToCollection(hydratedSessions, hydratedTombstones, "session"));
-    setWalks(applyTombstonesToCollection(hydratedWalks, hydratedTombstones, "walk"));
-    setPatterns(applyTombstonesToCollection(hydratedPatterns, hydratedTombstones, "pattern"));
-    setFeedings(applyTombstonesToCollection(hydratedFeedings, hydratedTombstones, "feeding"));
+    setSessions(sessionsRef.current);
+    setWalks(walksRef.current);
+    setPatterns(patternsRef.current);
+    setFeedings(feedingsRef.current);
     setPatLabels(local.patLabels);
     setDogPhoto(local.photo);
     recomputeTarget(
@@ -735,6 +746,19 @@ export default function PawTimer() {
     setPatterns([]);
     setFeedings([]);
     setTombstones([]);
+    sessionsRef.current = [];
+    walksRef.current = [];
+    patternsRef.current = [];
+    feedingsRef.current = [];
+    tombstonesRef.current = [];
+    syncSnapshotRef.current = {
+      ...syncSnapshotRef.current,
+      sessions: [],
+      walks: [],
+      patterns: [],
+      feedings: [],
+      tombstones: [],
+    };
     setPatLabels({});
     setDogPhoto(null);
     return true;
@@ -766,6 +790,19 @@ export default function PawTimer() {
       const visibleJoinedWalks = applyTombstonesToCollection(joinedWalks, joinedTombstones, "walk");
       const visibleJoinedPatterns = applyTombstonesToCollection(joinedPatterns, joinedTombstones, "pattern");
       const visibleJoinedFeedings = applyTombstonesToCollection(joinedFeedings, joinedTombstones, "feeding");
+      tombstonesRef.current = joinedTombstones;
+      sessionsRef.current = visibleJoinedSessions;
+      walksRef.current = visibleJoinedWalks;
+      patternsRef.current = visibleJoinedPatterns;
+      feedingsRef.current = visibleJoinedFeedings;
+      syncSnapshotRef.current = {
+        ...syncSnapshotRef.current,
+        tombstones: joinedTombstones,
+        sessions: visibleJoinedSessions,
+        walks: visibleJoinedWalks,
+        patterns: visibleJoinedPatterns,
+        feedings: visibleJoinedFeedings,
+      };
       setTombstones(joinedTombstones);
       setSessions(visibleJoinedSessions);
       setWalks(visibleJoinedWalks);

--- a/tests/historyProgressEditRuntime.test.js
+++ b/tests/historyProgressEditRuntime.test.js
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useHistoryEditing } from "../src/features/history/HistoryFeature";
+import { selectAppData } from "../src/features/app/selectors";
+import { hydrateDogFromLocal, mergeMutationSafeSyncCollection, save, sessKey } from "../src/features/app/storage";
+
+const makeIso = (value) => new Date(value).toISOString();
+
+const baseSession = {
+  id: "sess-1",
+  date: makeIso("2026-04-10T10:00:00Z"),
+  plannedDuration: 180,
+  actualDuration: 180,
+  distressLevel: "none",
+  belowThreshold: true,
+  latencyToFirstDistress: 180,
+  result: "success",
+  revision: 1,
+  updatedAt: makeIso("2026-04-10T10:05:00Z"),
+};
+
+const buildHistoryHarness = (initialSessions = [baseSession]) => {
+  const showToast = vi.fn();
+  const setHistoryModal = vi.fn();
+  let state = [...initialSessions];
+  const commitSessions = vi.fn((updater) => {
+    state = typeof updater === "function" ? updater(state) : updater;
+    return state;
+  });
+  const actions = useHistoryEditing({
+    sessions: initialSessions,
+    walks: [],
+    patterns: [],
+    feedings: [],
+    patLabels: {},
+    showToast,
+    pushWithSyncStatus: vi.fn(() => Promise.resolve({ ok: true })),
+    addTombstone: vi.fn(),
+    commitSessions,
+    setWalks: vi.fn(),
+    setPatterns: vi.fn(),
+    setFeedings: vi.fn(),
+    stampLocalEntry: (next, prev) => ({ ...prev, ...next }),
+  });
+  return {
+    actions,
+    showToast,
+    setHistoryModal,
+    getState: () => state,
+  };
+};
+
+const makeAppData = (sessions) => selectAppData({
+  dogs: [{ id: "DOG-EDIT", dogName: "Mochi", goalSeconds: 3600 }],
+  activeDogId: "DOG-EDIT",
+  sessions,
+  walks: [],
+  patterns: [],
+  feedings: [],
+  target: 900,
+  protoOverride: {},
+  recommendation: { duration: 900, decisionState: null, details: {}, explanation: "" },
+});
+
+const createMemoryStorage = () => {
+  const db = new Map();
+  return {
+    getItem: vi.fn((key) => (db.has(key) ? db.get(key) : null)),
+    setItem: vi.fn((key, value) => {
+      db.set(key, value);
+      return undefined;
+    }),
+    removeItem: vi.fn((key) => db.delete(key)),
+    clear: vi.fn(() => db.clear()),
+  };
+};
+
+describe("runtime regression guard: edit duration -> history/progress/hydration", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("edits duration by writing the changed value into the stored session", () => {
+    const { actions, getState, setHistoryModal } = buildHistoryHarness();
+    actions.saveEditedActivityDuration({ mode: "duration", kind: "session", id: "sess-1", value: "2:10" }, setHistoryModal);
+
+    const edited = getState()[0];
+    expect(edited.actualDuration).toBe(130);
+    expect(edited.id).toBe("sess-1");
+  });
+
+  it("materializes History from edited data immediately after the edit commit", () => {
+    const { actions, getState } = buildHistoryHarness();
+    actions.saveEditedActivityDuration({ mode: "duration", kind: "session", id: "sess-1", value: "1:37" }, vi.fn());
+
+    const appData = makeAppData(getState());
+    expect(appData.timeline[0].kind).toBe("session");
+    expect(appData.timeline[0].data.actualDuration).toBe(97);
+  });
+
+  it("recomputes progress metrics from edited duration instead of pre-edit values", () => {
+    const { actions, getState } = buildHistoryHarness();
+    actions.saveEditedActivityDuration({ mode: "duration", kind: "session", id: "sess-1", value: "1:37" }, vi.fn());
+
+    const appData = makeAppData(getState());
+    expect(appData.chartData[0].durationSeconds).toBe(97);
+    expect(appData.aloneLastWeek).toBe(97);
+  });
+
+  it("keeps repeated edits stable without reverting to an earlier duration", () => {
+    const { actions, getState } = buildHistoryHarness();
+    actions.saveEditedActivityDuration({ mode: "duration", kind: "session", id: "sess-1", value: "1:37" }, vi.fn());
+    actions.saveEditedActivityDuration({ mode: "duration", kind: "session", id: "sess-1", value: "2:30" }, vi.fn());
+
+    expect(getState()[0].actualDuration).toBe(150);
+  });
+
+  it("keeps edited values through hydration and stale remote merge attempts", () => {
+    const storage = createMemoryStorage();
+    vi.stubGlobal("localStorage", storage);
+
+    const editedLocal = [{
+      ...baseSession,
+      actualDuration: 150,
+      belowThreshold: false,
+      latencyToFirstDistress: 150,
+      revision: 3,
+      updatedAt: makeIso("2026-04-10T10:15:00Z"),
+      pendingSync: true,
+      syncState: "local",
+      syncError: "",
+    }];
+    save(sessKey("DOG-EDIT"), editedLocal);
+
+    const hydrated = hydrateDogFromLocal("DOG-EDIT");
+    expect(hydrated.sessions[0].actualDuration).toBe(150);
+
+    const merged = mergeMutationSafeSyncCollection({
+      currentItems: hydrated.sessions,
+      remoteItems: [{
+        ...baseSession,
+        actualDuration: 120,
+        belowThreshold: false,
+        latencyToFirstDistress: 120,
+        revision: 2,
+        updatedAt: makeIso("2026-04-10T10:12:00Z"),
+      }],
+      tombstones: [],
+      kind: "session",
+    });
+
+    expect(merged[0].actualDuration).toBe(150);
+    expect(merged[0].revision).toBe(3);
+  });
+});


### PR DESCRIPTION
### Motivation
- Fix a runtime regression that broke history/materialization, progress recompute, and "edit duration" behavior by ensuring commits are reliably visible to downstream logic. 
- The failure stemmed from callers depending on immediate return values from React `setState` updaters that run asynchronously, causing recompute and sync paths to operate on stale collections.

### Description
- Replaced async updater-in-`setState` commit pattern with ref-backed synchronous commit flows for collections by adding `sessionsRef`, `walksRef`, `patternsRef`, and `feedingsRef` and updating them before calling `setState`. (changes in `src/App.jsx`).
- Rewrote `commitSessions`, `commitWalks`, `commitPatterns`, `commitFeedings`, and `commitTombstones` to resolve and persist normalized data synchronously, update refs and `syncSnapshotRef`, then call `setXxx` and `recomputeTarget` with the committed arrays. (`src/App.jsx`).
- Aligned hydration/join/clear flows to populate refs/`syncSnapshotRef` atomically so hydration or joining cannot reintroduce stale pre-edit state; kept existing recommendation/sync rules unchanged. (`src/App.jsx`).
- Added a regression test `tests/historyProgressEditRuntime.test.js` that validates edit-duration persistence, immediate history materialization, progress recompute, repeated-edit stability, and hydration/merge durability. 

### Testing
- Added `tests/historyProgressEditRuntime.test.js` and ran the targeted test files: `tests/historyProgressEditRuntime.test.js`, `tests/historyDurationEditing.test.js`, `tests/activityLogMaterialization.test.js`, `tests/sessionEditing.test.js`, and `tests/syncConflict.test.js`, all of which passed. 
- Ran the full test suite (`npm test`) and observed all tests passing: 204 tests across 16 files passed. 
- New regression tests confirm that editing session duration updates the stored session, history materializes the edited value immediately, progress/derived metrics recompute from edited values, repeated edits do not revert, and hydration/merge does not restore stale pre-edit values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe5cc40688332b38322b9a9ef6d7c)