### PR TITLE
Handle unsupported tombstones in partial-capability sync

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -617,12 +617,28 @@ export default function PawTimer() {
           );
         });
 
+        const pendingTombstoneEntries = mergedTombstones
+          .filter((entry) => entry.pendingSync)
+          .map((entry) => ({ kind: entry.kind, entry }));
+        const {
+          supported: supportedPendingTombstones,
+          unsupported: unsupportedPendingTombstones,
+        } = partitionPendingOutboundByCapability(pendingTombstoneEntries, remote?.syncCapability);
+        unsupportedPendingTombstones.forEach(({ entry }) => {
+          setTombstoneSyncState(
+            entry.id,
+            entry.kind,
+            SYNC_STATE.UNSUPPORTED,
+            "Delete marker blocked by current backend capability profile; retained locally until table support is available.",
+          );
+        });
+
         let allPendingFlushed = true;
         for (const { kind, entry } of supportedPendingEntries) {
           const pushed = await pushPendingEntry(kind, entry, dogSettings);
           allPendingFlushed = allPendingFlushed && pushed;
         }
-        for (const tombstone of mergedTombstones.filter((entry) => entry.pendingSync)) {
+        for (const { entry: tombstone } of supportedPendingTombstones) {
           const pushed = await pushPendingTombstone(tombstone, dogSettings);
           allPendingFlushed = allPendingFlushed && pushed;
         }
@@ -643,7 +659,10 @@ export default function PawTimer() {
           },
         }));
         const isPartialSync = remote?.syncCapability?.mode === "partial";
-        const partialSyncMessage = buildPartialCapabilitySyncMessage(remote?.syncCapability, unsupportedPendingEntries.length);
+        const partialSyncMessage = buildPartialCapabilitySyncMessage(
+          remote?.syncCapability,
+          unsupportedPendingEntries.length + unsupportedPendingTombstones.length,
+        );
         setSyncError(error || partialSyncMessage);
         setSyncStatus(error ? "err" : isPartialSync ? "partial" : "ok");
       } finally {

--- a/tests/syncCapability.test.js
+++ b/tests/syncCapability.test.js
@@ -47,6 +47,59 @@ describe("sync capability outbound enforcement", () => {
     expect(message).toContain("2 local changes cannot sync");
   });
 
+  it("treats pattern tombstones as unsupported when patterns table is missing", () => {
+    const pending = [{ kind: "pattern", entry: { id: "pat-deleted", kind: "pattern", pendingSync: true } }];
+    const partitioned = partitionPendingOutboundByCapability(pending, partialCapability);
+    expect(partitioned.supported).toHaveLength(0);
+    expect(partitioned.unsupported).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "pattern", entry: expect.objectContaining({ id: "pat-deleted" }) }),
+    ]));
+  });
+
+  it("treats feeding tombstones as unsupported when feedings table is missing", () => {
+    const pending = [{ kind: "feeding", entry: { id: "feed-deleted", kind: "feeding", pendingSync: true } }];
+    const partitioned = partitionPendingOutboundByCapability(pending, partialCapability);
+    expect(partitioned.supported).toHaveLength(0);
+    expect(partitioned.unsupported).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "feeding", entry: expect.objectContaining({ id: "feed-deleted" }) }),
+    ]));
+  });
+
+  it("keeps supported tombstones eligible for normal push", () => {
+    const pending = [{ kind: "session", entry: { id: "sess-deleted", kind: "session", pendingSync: true } }];
+    const partitioned = partitionPendingOutboundByCapability(pending, partialCapability);
+    expect(partitioned.supported).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "session", entry: expect.objectContaining({ id: "sess-deleted" }) }),
+    ]));
+    expect(partitioned.unsupported).toHaveLength(0);
+  });
+
+  it("does not requeue unsupported tombstones for retry across sync cycles", () => {
+    const pending = [{ kind: "pattern", entry: { id: "pat-deleted", kind: "pattern", pendingSync: true } }];
+    const firstCycle = partitionPendingOutboundByCapability(pending, partialCapability);
+    const secondCycle = partitionPendingOutboundByCapability(firstCycle.unsupported, partialCapability);
+    expect(firstCycle.supported).toHaveLength(0);
+    expect(secondCycle.supported).toHaveLength(0);
+    expect(secondCycle.unsupported).toHaveLength(1);
+  });
+
+  it("keeps sync summary explicitly partial for unsupported tombstones", () => {
+    const summary = computeSyncSummary({
+      syncEnabled: true,
+      sessions: [],
+      walks: [],
+      patterns: [],
+      feedings: [],
+      tombstones: [{ id: "pat-deleted", kind: "pattern", pendingSync: true, syncState: SYNC_STATE.UNSUPPORTED }],
+      syncStatus: "partial",
+      syncError: "Partial sync active: patterns unavailable. 1 local change cannot sync until those tables are available.",
+    });
+
+    expect(summary.badgeState).toBe("idle");
+    expect(summary.label).toBe("Partial sync");
+    expect(summary.detail).toContain("cannot sync");
+  });
+
   it("reports partial status cleanly when unsupported local entries are present", () => {
     const summary = computeSyncSummary({
       syncEnabled: true,


### PR DESCRIPTION
### Motivation
- Tombstones for unsupported entity kinds bypassed capability partitioning and were retried every sync cycle, causing endless retry/error churn; capability partitioning was only applied to normal outbound rows, not tombstones.
- The intent is to make partial-capability handling consistent so tombstones for missing optional tables are blocked (not retried) while supported tombstones continue to push normally.

### Description
- Route pending tombstones through `partitionPendingOutboundByCapability(...)` so tombstones are classified identical to normal outbound rows before any push attempts.
- Mark tombstones for unsupported kinds with `SYNC_STATE.UNSUPPORTED` via `setTombstoneSyncState(...)` and a clear capability-blocked message instead of leaving them in the retry loop.
- Only attempt `syncPushTombstone(...)` for tombstones classified as supported, preserving existing push/verification behavior for supported kinds.
- Include unsupported tombstone counts in the partial-sync message built by `buildPartialCapabilitySyncMessage(...)` so sync status and error messaging remain explicit and deterministic, and add tests covering these cases.

### Testing
- Added and updated tests in `tests/syncCapability.test.js` to cover pattern/feedings tombstone blocking, supported tombstone pass-through, retry suppression semantics, and explicit partial-state summary behavior, and ran `npm test -- tests/syncCapability.test.js` which passed.
- Ran `npm test -- tests/syncOrchestration.test.js` to ensure existing tombstone push behavior and orchestration semantics remain correct, which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0129e4ca0833283d6094b260dc356)