### PR TITLE
Always persist delete intent for uncertain sync states (syncing/error) to avoid resurrection

### DIFF
--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -233,14 +233,16 @@ export function useHistoryEditing({
               updatedAt: item.updatedAt ?? null,
             })),
           });
-          const shouldTreatAsRemotePersisted = Boolean(
+          const hasUncertainRemotePersistence = Boolean(
             existing
-            && !existing.pendingSync
-            && existing.syncState !== "local"
-            && existing.syncState !== "syncing"
-            && existing.syncState !== "error",
+            && (existing.syncState === "syncing" || existing.syncState === "error"),
           );
-          if (existing && matchingById.length <= 1 && shouldTreatAsRemotePersisted) {
+          const shouldCreateDeleteTombstone = Boolean(
+            existing
+            && matchingById.length <= 1
+            && (!existing.pendingSync || hasUncertainRemotePersistence),
+          );
+          if (shouldCreateDeleteTombstone) {
             tombstoneToPush = addTombstone("session", existing);
           }
           const next = hasDetailedIdentity
@@ -273,7 +275,7 @@ export function useHistoryEditing({
               updatedAt: item.updatedAt ?? null,
             })),
             tombstoneSkippedDueToDuplicateId: Boolean(existing && matchingById.length > 1),
-            tombstoneSkippedAsLocalOnly: Boolean(existing && !shouldTreatAsRemotePersisted),
+            tombstoneSkippedAsLocalOnly: Boolean(existing && !shouldCreateDeleteTombstone),
           });
           return next;
         });

--- a/tests/historyDeleteMutations.test.js
+++ b/tests/historyDeleteMutations.test.js
@@ -313,6 +313,60 @@ describe("history delete mutations", () => {
     expect(addTombstone).not.toHaveBeenCalled();
   });
 
+  it("deletes immediately-created local sessions without remote tombstones", async () => {
+    const commitSessions = vi.fn();
+    const addTombstone = vi.fn();
+    const pushTombstoneWithSyncStatus = vi.fn(() => Promise.resolve({ ok: true }));
+    const justCreatedSession = {
+      ...baseSession,
+      id: "sess-new",
+      revision: 1,
+      pendingSync: true,
+      syncState: "local",
+      date: makeIso("2026-04-14T10:00:00Z"),
+    };
+    const { actions } = buildDeleteActions({
+      sessions: [justCreatedSession],
+      commitSessions,
+      addTombstone,
+      pushTombstoneWithSyncStatus,
+    });
+
+    actions.confirmHistoryDelete({ mode: "delete", kind: "session", id: "sess-new", label: "New local session" }, vi.fn());
+    const deleteUpdater = commitSessions.mock.calls[0][0];
+    expect(deleteUpdater([justCreatedSession])).toEqual([]);
+    await Promise.resolve();
+    expect(addTombstone).not.toHaveBeenCalled();
+    expect(pushTombstoneWithSyncStatus).not.toHaveBeenCalled();
+  });
+
+  it("deletes pre-first-sync sessions without unnecessary remote writes", async () => {
+    const commitSessions = vi.fn();
+    const addTombstone = vi.fn();
+    const pushTombstoneWithSyncStatus = vi.fn(() => Promise.resolve({ ok: true }));
+    const preFirstSyncSession = {
+      ...baseSession,
+      id: "sess-pre-first-sync",
+      revision: 3,
+      pendingSync: true,
+      syncState: "local",
+      date: makeIso("2026-04-14T11:00:00Z"),
+    };
+    const { actions } = buildDeleteActions({
+      sessions: [preFirstSyncSession],
+      commitSessions,
+      addTombstone,
+      pushTombstoneWithSyncStatus,
+    });
+
+    actions.confirmHistoryDelete({ mode: "delete", kind: "session", id: "sess-pre-first-sync", label: "Pre-sync session" }, vi.fn());
+    const deleteUpdater = commitSessions.mock.calls[0][0];
+    expect(deleteUpdater([preFirstSyncSession])).toEqual([]);
+    await Promise.resolve();
+    expect(addTombstone).not.toHaveBeenCalled();
+    expect(pushTombstoneWithSyncStatus).not.toHaveBeenCalled();
+  });
+
   it("deletes local-only rows without creating or pushing tombstones", async () => {
     const commitSessions = vi.fn();
     const addTombstone = vi.fn();
@@ -337,6 +391,59 @@ describe("history delete mutations", () => {
     await Promise.resolve();
     expect(addTombstone).not.toHaveBeenCalled();
     expect(pushTombstoneWithSyncStatus).not.toHaveBeenCalled();
+  });
+
+
+
+  it("creates tombstones for syncing sessions to preserve delete intent during in-flight pushes", async () => {
+    const tombstone = { id: "sess-syncing", kind: "session", deletedAt: makeIso("2026-04-13T11:30:00Z") };
+    const addTombstone = vi.fn(() => tombstone);
+    const pushTombstoneWithSyncStatus = vi.fn(() => Promise.resolve({ ok: true }));
+    const syncingSession = {
+      ...baseSession,
+      id: "sess-syncing",
+      pendingSync: true,
+      syncState: "syncing",
+      date: makeIso("2026-04-13T10:30:00Z"),
+    };
+    const commitSessions = vi.fn((updater) => (typeof updater === "function" ? updater([syncingSession]) : updater));
+    const { actions } = buildDeleteActions({
+      sessions: [syncingSession],
+      commitSessions,
+      addTombstone,
+      pushTombstoneWithSyncStatus,
+    });
+
+    actions.confirmHistoryDelete({ mode: "delete", kind: "session", id: "sess-syncing", label: "Syncing session" }, vi.fn());
+    await Promise.resolve();
+    expect(addTombstone).toHaveBeenCalledWith("session", expect.objectContaining({ id: "sess-syncing" }));
+    expect(pushTombstoneWithSyncStatus).toHaveBeenCalledWith(tombstone);
+  });
+
+  it("creates tombstones for error-state sessions to prevent remote resurrection after retries", async () => {
+    const tombstone = { id: "sess-error", kind: "session", deletedAt: makeIso("2026-04-13T12:30:00Z") };
+    const addTombstone = vi.fn(() => tombstone);
+    const pushTombstoneWithSyncStatus = vi.fn(() => Promise.resolve({ ok: true }));
+    const erroredSession = {
+      ...baseSession,
+      id: "sess-error",
+      pendingSync: true,
+      syncState: "error",
+      syncError: "network",
+      date: makeIso("2026-04-13T11:30:00Z"),
+    };
+    const commitSessions = vi.fn((updater) => (typeof updater === "function" ? updater([erroredSession]) : updater));
+    const { actions } = buildDeleteActions({
+      sessions: [erroredSession],
+      commitSessions,
+      addTombstone,
+      pushTombstoneWithSyncStatus,
+    });
+
+    actions.confirmHistoryDelete({ mode: "delete", kind: "session", id: "sess-error", label: "Errored session" }, vi.fn());
+    await Promise.resolve();
+    expect(addTombstone).toHaveBeenCalledWith("session", expect.objectContaining({ id: "sess-error" }));
+    expect(pushTombstoneWithSyncStatus).toHaveBeenCalledWith(tombstone);
   });
 
   it("creates and pushes tombstones immediately for remotely persisted rows", async () => {

--- a/tests/historyDeleteReloadHydration.test.js
+++ b/tests/historyDeleteReloadHydration.test.js
@@ -151,6 +151,29 @@ describe("history delete + reload hydration runtime", () => {
     expect(visibleAfterReload.map((row) => row.id)).toEqual(["sess-1", "sess-3"]);
   });
 
+  it("delete of syncing session stays deleted across stale reload + sync replay", () => {
+    const syncingSeed = [{
+      ...baseSessions[0],
+      id: "sess-syncing",
+      pendingSync: true,
+      syncState: "syncing",
+      revision: 7,
+      updatedAt: iso("2026-04-13T09:00:00Z"),
+    }];
+    const harness = buildDeleteHarness({ dogId: "DOG-SYNCING-DEL", sessionsSeed: syncingSeed });
+
+    harness.actions.confirmHistoryDelete({ mode: "delete", kind: "session", id: "sess-syncing", label: "Training session" }, vi.fn());
+
+    // Simulate stale sync/reload writing pre-delete session payload back to local storage.
+    save(sessKey(harness.dogId), syncingSeed);
+
+    const visibleAfterReload = harness.reloadVisibleSessions();
+    expect(visibleAfterReload).toEqual([]);
+    expect(harness.getTombstones()).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "sess-syncing", kind: "session", pendingSync: true }),
+    ]));
+  });
+
   it("delete multiple + reload preserves remaining sessions and keeps log populated", () => {
     const harness = buildDeleteHarness();
 


### PR DESCRIPTION
### Motivation
- Root cause: `confirmHistoryDelete` only created tombstones when a session was considered definitively remote-persisted, which skipped tombstones for `pendingSync` rows with `syncState` of `syncing` or `error`, allowing remote/in-flight rows to reappear after sync or reload. 
- Intent: make delete intent durable for any session that might exist remotely or be pushed later while keeping pure local-only deletes free of unnecessary remote writes.

### Description
- Tightened the delete/tombstone gating in `src/features/history/HistoryFeature.jsx` so a tombstone is created when a matching session is unambiguous (`matchingById.length <= 1`) and either `!existing.pendingSync` or the session is in an uncertain remote state (`syncState === "syncing" || syncState === "error"`).
- Preserved existing safeguards: duplicate-id ambiguity still prevents tombstones and local-only (`syncState: "local"` + `pendingSync: true`) deletes still skip tombstone creation to avoid remote writes.
- No changes to recommendation/progression logic or UX/UI were made; change is focused on delete durability and tombstone semantics.
- Tests added/updated to exercise the edge cases in `tests/historyDeleteMutations.test.js` and `tests/historyDeleteReloadHydration.test.js` (syncing/error deletes, immediate-create deletes, pre-first-sync deletes, and stale reload + sync replay for syncing deletes).

### Testing
- Ran focused unit tests: `npm test -- tests/historyDeleteMutations.test.js tests/historyDeleteReloadHydration.test.js` and `npm test -- tests/syncConflict.test.js`.
- Result: all targeted tests passed (19 tests in delete suites and 34 tests in `syncConflict`); no regressions observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0169eb21c8332bc604dcc511c94c0)