### PR TITLE
Enforce threshold confirmation for plateau micro-increases (LOGIC-001)

### DIFF
--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -1105,7 +1105,10 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
 
   const plateauDuration = getPlateauDuration(recentWindow);
   if (Number.isFinite(plateauDuration) && plateauDuration > 0) {
-    const microIncrease = clampRateChange(Math.round(plateauDuration * 1.05), lastReferenceDuration);
+    let microIncrease = clampRateChange(Math.round(plateauDuration * 1.05), lastReferenceDuration);
+    if (microIncrease > lastReferenceDuration && !hasThresholdConfirmation(recentWindow)) {
+      microIncrease = lastReferenceDuration;
+    }
     const adjustedForGap = gapReduction > 0
       ? Math.round(microIncrease * (1 - gapReduction))
       : microIncrease;

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -436,7 +436,20 @@ describe("recommendation engine", () => {
     expect(rec.recoveryMode.active).toBe(true);
   });
 
-  it("uses non-hold recommendation type for a small increase after five-session plateau", () => {
+  it("holds after five-session plateau when threshold confirmation is not satisfied", () => {
+    const sessions = [
+      { date: daysAgo(4), plannedDuration: 600, actualDuration: 600, distressLevel: "none", belowThreshold: false },
+      { date: daysAgo(3), plannedDuration: 600, actualDuration: 600, distressLevel: "none", belowThreshold: false },
+      { date: daysAgo(2), plannedDuration: 600, actualDuration: 600, distressLevel: "none", belowThreshold: false },
+      { date: daysAgo(1), plannedDuration: 600, actualDuration: 600, distressLevel: "none", belowThreshold: false },
+      { date: hoursAgo(2), plannedDuration: 600, actualDuration: 600, distressLevel: "none", belowThreshold: false },
+    ];
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recommendedDuration).toBe(600);
+    expect(rec.recommendationType).toBe("keep_same_duration");
+  });
+
+  it("allows a small increase after five-session plateau when threshold confirmation is satisfied", () => {
     const sessions = [
       { date: daysAgo(4), plannedDuration: 600, actualDuration: 600, distressLevel: "none", belowThreshold: true },
       { date: daysAgo(3), plannedDuration: 600, actualDuration: 600, distressLevel: "none", belowThreshold: true },
@@ -454,6 +467,29 @@ describe("recommendation engine", () => {
     const sessions = [
       { date: daysAgo(2), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
       { date: daysAgo(1), plannedDuration: 900, actualDuration: 855, distressLevel: "none", belowThreshold: false },
+      { date: hoursAgo(1), plannedDuration: 900, actualDuration: 855, distressLevel: "none", belowThreshold: false },
+    ];
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recommendedDuration).toBe(900);
+    expect(rec.recommendationType).toBe("keep_same_duration");
+  });
+
+  it("keeps short-session hold behavior unchanged even after plateau guard update", () => {
+    const sessions = [
+      { date: daysAgo(2), plannedDuration: 900, actualDuration: 300, distressLevel: "none", belowThreshold: false },
+      { date: daysAgo(1), plannedDuration: 900, actualDuration: 300, distressLevel: "none", belowThreshold: false },
+      { date: hoursAgo(2), plannedDuration: 900, actualDuration: 300, distressLevel: "none", belowThreshold: false },
+    ];
+    const rec = buildRecommendation(sessions, { goalSeconds: 3600 });
+    expect(rec.recommendedDuration).toBe(900);
+    expect(rec.recommendationType).toBe("repeat_current_duration");
+  });
+
+  it("keeps near-threshold plateau holds unchanged after plateau guard update", () => {
+    const sessions = [
+      { date: daysAgo(2), plannedDuration: 900, actualDuration: 900, distressLevel: "none", belowThreshold: true },
+      { date: daysAgo(1), plannedDuration: 900, actualDuration: 855, distressLevel: "none", belowThreshold: false },
+      { date: hoursAgo(2), plannedDuration: 900, actualDuration: 855, distressLevel: "none", belowThreshold: false },
       { date: hoursAgo(1), plannedDuration: 900, actualDuration: 855, distressLevel: "none", belowThreshold: false },
     ];
     const rec = buildRecommendation(sessions, { goalSeconds: 3600 });


### PR DESCRIPTION
### Motivation
- Root cause: the plateau branch in `computeNextTarget` computed a +5% `microIncrease` and returned before the generic threshold-confirmation gate ran, creating a hidden increase path that could bypass `hasThresholdConfirmation(recentWindow)`. 
- Goal: ensure no increase (including plateau micro-increases) can occur unless the configured threshold-confirmation policy is satisfied while preserving existing hold/recovery precedence and short-session behavior.

### Description
- Added an explicit threshold-confirmation guard inside the plateau branch of `computeNextTarget` so that when `microIncrease > lastReferenceDuration` and `!hasThresholdConfirmation(recentWindow)`, we force `microIncrease = lastReferenceDuration` (no increase before confirmation). 
- This change keeps plateau behavior able to hold but prevents any hidden progression path; the existing smoothed/progressive path already enforced the same `hasThresholdConfirmation` gate and remains unchanged. 
- Files changed: `src/lib/protocol.js` (plateau guard) and `tests/protocol.test.js` (updated plateau test and added regression checks for short-session and near-threshold hold behavior). 
- Policy outcome: plateau may HOLD as before and may only INCREASE when `hasThresholdConfirmation` is satisfied, making plateau semantics consistent with other progression paths.

### Testing
- Added/updated unit tests in `tests/protocol.test.js` covering: a five-session plateau without threshold confirmation must `keep_same_duration`, a five-session plateau with confirmed threshold success may `increase_duration`, short-session hold behavior remains (`repeat_current_duration`), and near-threshold plateau holds remain unchanged. 
- Ran `npm test -- tests/protocol.test.js` and the full suite with `npm test`, both of which completed successfully (`tests/protocol.test.js` 88 tests passed; full suite 17 files / 229 tests passed). 
- Verification: the plateau micro-increase path can no longer produce an increase without `hasThresholdConfirmation`, and all automated tests passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a9ca25388332800b8c706e393187)