### PR TITLE
Fix LOGIC-002: prevent unknown distress rows from counting as calm evidence

### DIFF
--- a/src/features/app/storage.js
+++ b/src/features/app/storage.js
@@ -408,6 +408,16 @@ const EXPLICIT_DISTRESS_RESULT_ALIASES = new Set([
   "severe",
   "panic",
 ]);
+const KNOWN_DISTRESS_LEVEL_TOKENS = new Set([
+  "none",
+  "subtle",
+  "mild",
+  "passive",
+  "active",
+  "strong",
+  "severe",
+  "panic",
+]);
 
 const normalizeRawToken = (value) => {
   if (value == null) return null;
@@ -427,19 +437,33 @@ const inferDistressLevelFromRow = (row = {}) => {
   return null;
 };
 
+const isKnownDistressOutcomeToken = (value) => {
+  const token = normalizeRawToken(value);
+  return token != null && KNOWN_DISTRESS_LEVEL_TOKENS.has(token);
+};
+
 const resolveCanonicalDistress = (row = {}) => {
   const normalizedDistressType = row.distressType ?? row.distress_type ?? null;
   const normalizedDistressSeverity = row.distressSeverity ?? row.distress_severity ?? null;
+  const inferredDistressLevel = inferDistressLevelFromRow(row);
   const restoredLegacyDistress = decodeLegacyDistressFields({
-    distressLevel: inferDistressLevelFromRow(row),
+    distressLevel: inferredDistressLevel,
     distressType: normalizedDistressType,
     distressSeverity: normalizedDistressSeverity,
   });
   const canonicalDistressLevel = normalizeDistressLevel(restoredLegacyDistress.distressLevel);
+  const hasKnownDistressOutcome = (
+    isKnownDistressOutcomeToken(inferredDistressLevel)
+    || isKnownDistressOutcomeToken(row.distressLevel)
+    || isKnownDistressOutcomeToken(row.distress_level)
+    || isKnownDistressOutcomeToken(normalizedDistressSeverity)
+    || normalizeRawToken(restoredLegacyDistress.distressType) != null
+  );
   return {
     distressLevel: canonicalDistressLevel,
     distressSeverity: canonicalDistressLevel,
     distressType: restoredLegacyDistress.distressType,
+    hasKnownDistressOutcome,
   };
 };
 
@@ -490,6 +514,7 @@ export const normalizeSession = (row = {}) => {
       actualDuration,
       plannedDuration,
     }),
+    hasKnownDistressOutcome: canonicalDistress.hasKnownDistressOutcome,
     distressType: canonicalDistress.distressType,
     distressSeverity: canonicalDistress.distressSeverity,
     videoReview: {
@@ -509,6 +534,9 @@ export const normalizeSession = (row = {}) => {
       noiseEvent: hasValue(environment.noiseEvent) ? !!environment.noiseEvent : asBool(environment.noise_event),
     },
   };
+  if (canonicalDistress.hasKnownDistressOutcome === false) {
+    normalized.belowThreshold = false;
+  }
   return normalized;
 };
 

--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -159,7 +159,15 @@ function getLatestSessions(sessions, count) {
 function isCalmBelowThreshold(session = {}) {
   return (
     normalizeDistressLevel(session?.distressLevel) === DISTRESS_LEVELS.NONE
+    && session?.hasKnownDistressOutcome !== false
     && session?.belowThreshold === true
+  );
+}
+
+function isConfirmedCalmOutcome(session = {}) {
+  return (
+    normalizeDistressLevel(session?.distressLevel) === DISTRESS_LEVELS.NONE
+    && session?.hasKnownDistressOutcome !== false
   );
 }
 
@@ -290,9 +298,12 @@ function toRichSession(session = {}) {
     || session.distress_severity,
   );
   const distressType = getDistressType(level, session.distressType);
+  const hasKnownDistressOutcome = typeof session?.hasKnownDistressOutcome === "boolean"
+    ? session.hasKnownDistressOutcome
+    : true;
   const latency = Number.isFinite(session.latencyToFirstDistress)
     ? Math.max(0, Number(session.latencyToFirstDistress))
-    : level === DISTRESS_LEVELS.NONE
+    : (level === DISTRESS_LEVELS.NONE && hasKnownDistressOutcome)
       ? actual
       : Math.min(actual, planned);
   const inferredBelowThreshold = inferBelowThreshold({
@@ -301,7 +312,7 @@ function toRichSession(session = {}) {
     actualDuration: actual,
     plannedDuration: hasReliablePlan ? planned : null,
   });
-  const belowThreshold = (hasReliablePlan && level === DISTRESS_LEVELS.NONE)
+  const belowThreshold = (hasReliablePlan && level === DISTRESS_LEVELS.NONE && hasKnownDistressOutcome)
     ? inferredBelowThreshold
     : false;
   const progressionActualDuration = hasReliablePlan
@@ -319,6 +330,7 @@ function toRichSession(session = {}) {
     distressLevel: level,
     distressType,
     distressSeverity: level,
+    hasKnownDistressOutcome,
     latencyToFirstDistress: latency,
     belowThreshold,
     departureType,
@@ -369,6 +381,7 @@ function computeSafeAloneTime(sessions = []) {
     ? calmBelowThreshold
     : recentWindow
       .filter((s) => s.distressLevel === DISTRESS_LEVELS.NONE)
+      .filter((s) => s.hasKnownDistressOutcome !== false)
       .map((s) => {
         const ageDays = Math.max(0, (nowTime - (toTimestamp(s.date) ?? nowTime)) / DAY_MS);
         let recencyWeight = 0.08;
@@ -605,7 +618,7 @@ function getSessionDurationAnchor(session = null) {
 
 function getLastCalmSession(sessions = []) {
   for (let i = sessions.length - 1; i >= 0; i -= 1) {
-    if (sessions[i].distressLevel === DISTRESS_LEVELS.NONE) return sessions[i];
+    if (isConfirmedCalmOutcome(sessions[i])) return sessions[i];
   }
   return null;
 }
@@ -669,13 +682,13 @@ function getCompletionRatio(session = null) {
 
 function isCalmShortSession(session = null) {
   if (!session) return false;
-  if (normalizeDistressLevel(session.distressLevel) !== DISTRESS_LEVELS.NONE) return false;
+  if (!isConfirmedCalmOutcome(session)) return false;
   return getCompletionRatio(session) < 0.85;
 }
 
 function isCalmNearThresholdSession(session = null) {
   if (!session) return false;
-  if (normalizeDistressLevel(session.distressLevel) !== DISTRESS_LEVELS.NONE) return false;
+  if (!isConfirmedCalmOutcome(session)) return false;
   if (session.belowThreshold) return false;
   const completion = getCompletionRatio(session);
   return completion >= PROTOCOL.nearThresholdRatioMin && completion < PROTOCOL.nearThresholdRatioMaxExclusive;
@@ -683,7 +696,7 @@ function isCalmNearThresholdSession(session = null) {
 
 function isCalmVeryShortSession(session = null) {
   if (!session) return false;
-  if (normalizeDistressLevel(session.distressLevel) !== DISTRESS_LEVELS.NONE) return false;
+  if (!isConfirmedCalmOutcome(session)) return false;
   return getCompletionRatio(session) < 0.5;
 }
 
@@ -694,13 +707,13 @@ function hasThresholdConfirmation(window = []) {
   const requiredStreak = Math.max(1, Math.round(Number(PROTOCOL.thresholdConfirmationStreak) || 0));
   const latest = recent[recent.length - 1];
   const latestIsConfirmedSuccess = (
-    normalizeDistressLevel(latest.distressLevel) === DISTRESS_LEVELS.NONE
+    isConfirmedCalmOutcome(latest)
     && latest.belowThreshold === true
   );
   if (!latestIsConfirmedSuccess) return false;
   if (recent.length < requiredStreak) return false;
   const confirmedSuccessStreak = countStreak(recent, (session) => (
-    normalizeDistressLevel(session.distressLevel) === DISTRESS_LEVELS.NONE
+    isConfirmedCalmOutcome(session)
     && session.belowThreshold === true
   ));
   return confirmedSuccessStreak >= requiredStreak;
@@ -725,13 +738,14 @@ function clampRateChange(nextDuration, referenceDuration) {
 
 function computeFallbackFromCalmHistory(recentWindow = [], anchorDuration = null) {
   const calmBelowThresholdDurations = recentWindow
-    .filter((session) => session.distressLevel === DISTRESS_LEVELS.NONE && session.belowThreshold)
+    .filter((session) => isConfirmedCalmOutcome(session) && session.belowThreshold)
     .map((session) => getSessionDurationAnchor(session))
     .filter((value) => Number.isFinite(value) && value > 0);
   const calmDurations = calmBelowThresholdDurations.length
     ? calmBelowThresholdDurations
     : recentWindow
       .filter((session) => session.distressLevel === DISTRESS_LEVELS.NONE)
+      .filter((session) => session.hasKnownDistressOutcome !== false)
       .map((session) => getSessionDurationAnchor(session))
       .filter((value) => Number.isFinite(value) && value > 0);
 
@@ -858,7 +872,7 @@ function resolveRecoveryState(trainingSessions = [], recoveryState = null) {
   for (let i = trainingSessions.length - 1; i >= 0; i -= 1) {
     if ([DISTRESS_LEVELS.SUBTLE, DISTRESS_LEVELS.ACTIVE, DISTRESS_LEVELS.SEVERE].includes(trainingSessions[i]?.distressLevel)) {
       const afterTrigger = trainingSessions.slice(i + 1);
-      if (afterTrigger.length >= 3 && afterTrigger.slice(-3).every((session) => session.distressLevel === DISTRESS_LEVELS.NONE)) {
+      if (afterTrigger.length >= 3 && afterTrigger.slice(-3).every((session) => isConfirmedCalmOutcome(session))) {
         continue;
       }
       return buildRecoveryStateFromTrigger(trainingSessions, i, normalized);
@@ -915,7 +929,7 @@ function evaluatePersistentRecoveryMode(
     const looksLikeRecovery = [DISTRESS_LEVELS.ACTIVE, DISTRESS_LEVELS.SEVERE].includes(stressLevel)
       ? Number.isFinite(sessionDuration) && sessionDuration <= 120
       : subtleRecoveryAcceptsAnyCalmSession;
-    if (session.distressLevel === DISTRESS_LEVELS.NONE && looksLikeRecovery) consecutiveCalm += 1;
+    if (isConfirmedCalmOutcome(session) && looksLikeRecovery) consecutiveCalm += 1;
     else consecutiveCalm = 0;
   }
 
@@ -1098,7 +1112,7 @@ export function computeNextTarget(trainingSessions = [], options = {}) {
     };
   }
 
-  const calmStreak = countStreak(recentWindow, (session) => session.distressLevel === DISTRESS_LEVELS.NONE);
+  const calmStreak = countStreak(recentWindow, (session) => isConfirmedCalmOutcome(session));
   const lastCalmSession = getLastCalmSession(recentWindow);
   const anchorDuration = getProgressionReferenceDuration(lastCalmSession) ?? PROTOCOL.startDurationSeconds;
   const lastReferenceDuration = getProgressionReferenceDuration(lastSession) ?? anchorDuration;

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -192,6 +192,24 @@ describe("recommendation engine", () => {
     expect(rec.recommendedDuration).toBeLessThanOrEqual(36);
   });
 
+  it("does not treat unknown distress outcomes as promotive calm evidence", () => {
+    const explicitCalmHistory = [
+      { date: daysAgo(1), plannedDuration: 100, actualDuration: 100, distressLevel: "none", belowThreshold: true, hasKnownDistressOutcome: true },
+      { date: daysAgo(0), plannedDuration: 100, actualDuration: 100, distressLevel: "none", belowThreshold: true, hasKnownDistressOutcome: true },
+    ];
+    const malformedHistory = [
+      { date: daysAgo(1), plannedDuration: 100, actualDuration: 100, distressLevel: "none", belowThreshold: true, hasKnownDistressOutcome: true },
+      { date: daysAgo(0), plannedDuration: 100, actualDuration: 100, distressLevel: "none", belowThreshold: true, hasKnownDistressOutcome: false },
+    ];
+
+    const explicitRec = buildRecommendation(explicitCalmHistory, { goalSeconds: 3600 });
+    const malformedRec = buildRecommendation(malformedHistory, { goalSeconds: 3600 });
+
+    expect(explicitRec.recommendedDuration).toBe(115);
+    expect(malformedRec.recommendedDuration).toBeLessThan(explicitRec.recommendedDuration);
+    expect(malformedRec.recommendationType).not.toBe("increase_duration");
+  });
+
 
 
   it("uses latest calm success +15% when last 5 sessions are all calm", () => {

--- a/tests/storageNormalization.test.js
+++ b/tests/storageNormalization.test.js
@@ -57,20 +57,26 @@ describe("storage normalization", () => {
     const session = normalizeSession({
       id: "s-missing-both",
       plannedDuration: 120,
-      actualDuration: 60,
+      actualDuration: 120,
     });
 
     expect(session.distressLevel).toBe("none");
+    expect(session.hasKnownDistressOutcome).toBe(false);
+    expect(session.belowThreshold).toBe(false);
   });
 
   it("keeps explicit known distress levels", () => {
     const session = normalizeSession({
       id: "s-explicit-severe",
+      plannedDuration: 120,
+      actualDuration: 120,
       distressLevel: "severe",
       result: "distress",
     });
 
     expect(session.distressLevel).toBe("severe");
+    expect(session.hasKnownDistressOutcome).toBe(true);
+    expect(session.belowThreshold).toBe(false);
   });
 
   it("normalizes known legacy distress aliases", () => {
@@ -88,10 +94,14 @@ describe("storage normalization", () => {
     const session = normalizeSession({
       id: "s-success",
       result: "success",
+      plannedDuration: 120,
+      actualDuration: 120,
       distressLevel: "none",
     });
 
     expect(session.distressLevel).toBe("none");
+    expect(session.hasKnownDistressOutcome).toBe(true);
+    expect(session.belowThreshold).toBe(true);
   });
 
   it("uses explicit distress metadata when result contradicts it", () => {
@@ -115,6 +125,7 @@ describe("storage normalization", () => {
 
     expect(session.distressLevel).toBe("none");
     expect(session.distressSeverity).toBe("none");
+    expect(session.hasKnownDistressOutcome).toBe(false);
   });
 
   it("canonicalizes explicit distress rows from distressLevel", () => {


### PR DESCRIPTION
### Motivation
- Root cause: rows with no explicit distress tokens or result flowed through existing normalization and `normalizeDistressLevel(null)` canonicalized to `"none"`, making unknown-outcome rows appear as calm and eligible as promotive calm evidence.
- Goal: treat unknown/malformed distress outcomes conservatively so they cannot inflate progression or recommendation increases while preserving legacy alias handling and conservative planned-duration behavior.

### Description
- Added conservative outcome reliability tracking during normalization by introducing `hasKnownDistressOutcome` (determined from explicit distress/result tokens, legacy severity/type signals, and known aliases) in `src/features/app/storage.js` and exposed it on normalized sessions.
- Forced `belowThreshold = false` during normalization when `hasKnownDistressOutcome` is false to prevent unknown rows from counting as confirmed below-threshold calm.
- Updated protocol logic in `src/lib/protocol.js` to require confirmed calm outcomes (`hasKnownDistressOutcome !== false`) before using calm rows as promotive evidence in safe-alone computation, fallback-from-calm history, calm/below-threshold checks, calm streaks, recovery counting, and last-calm-session selection; added helper `isConfirmedCalmOutcome` to centralize the rule.
- Preserved legacy alias and severity decoding and left planned-duration reliability behavior unchanged; changes are limited to normalization and downstream progression checks only.

### Testing
- Updated and added unit tests in `tests/storageNormalization.test.js` and `tests/protocol.test.js` to cover: malformed rows (missing distress + missing result) are marked `hasKnownDistressOutcome: false` and do not set `belowThreshold`, explicit calm rows remain promotive, explicit distress rows remain distress, legacy alias normalization still works, and mixed valid+malformed history cannot trigger an increase.
- Ran: `npm test -- tests/storageNormalization.test.js tests/protocol.test.js` and all tests passed: 105 tests succeeded (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0aa9cbfa48332b31e2beefdbb94a4)