### PR TITLE
Add reusable UI primitives library (AppShell, ScreenHeader, buttons, cards, sheets, etc.)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import SettingsScreen from "./features/settings/SettingsScreen";
 import { HistoryScreen, useHistoryEditing } from "./features/history/HistoryFeature";
 import "./styles/theme.css";
 import "./styles/shared.css";
+import "./styles/primitives.css";
 import "./styles/app.css";
 
 const LEGACY_SW_PATHS = ["/service-worker.js", "/serviceworker.js", "/workbox-sw.js"];

--- a/src/components/EmptyState.jsx
+++ b/src/components/EmptyState.jsx
@@ -1,24 +1,5 @@
-export default function EmptyState({ media, icon, mediaLabel, title, body, ctaLabel, onCta }) {
-  const mediaNode = media ?? icon ?? null;
-  const hasMedia = Boolean(mediaNode);
+import { EmptyState as PrimitiveEmptyState } from "./primitives";
 
-  return (
-    <div className={`empty-state${hasMedia ? " empty-state--with-media" : ""}`}>
-      {hasMedia ? (
-        <div
-          className="es-media"
-          aria-label={mediaLabel || undefined}
-          aria-hidden={mediaLabel ? undefined : "true"}
-          role={mediaLabel ? "img" : undefined}
-        >
-          {mediaNode}
-        </div>
-      ) : null}
-      <div className="es-title">{title}</div>
-      <div className="es-body">{body}</div>
-      {ctaLabel && onCta ? (
-        <button className="es-cta button-size-primary-cta" onClick={onCta}>{ctaLabel}</button>
-      ) : null}
-    </div>
-  );
+export default function EmptyState(props) {
+  return <PrimitiveEmptyState {...props} />;
 }

--- a/src/components/primitives/Primitives.jsx
+++ b/src/components/primitives/Primitives.jsx
@@ -1,0 +1,265 @@
+import { useEffect, useId, useMemo, useState } from "react";
+
+function cx(...parts) {
+  return parts.filter(Boolean).join(" ");
+}
+
+export function AppShell({ header, children, bottomNav, className = "", contentClassName = "", as: Tag = "div" }) {
+  return (
+    <Tag className={cx("pt-app-shell", className)}>
+      {header ? <div className="pt-app-shell__header">{header}</div> : null}
+      <main className={cx("pt-app-shell__content", contentClassName)}>{children}</main>
+      {bottomNav ? <div className="pt-app-shell__bottom-nav">{bottomNav}</div> : null}
+    </Tag>
+  );
+}
+
+export function ScreenHeader({
+  title,
+  subtitle,
+  eyebrow,
+  leading,
+  trailing,
+  className = "",
+  align = "left",
+}) {
+  return (
+    <header className={cx("pt-screen-header", `pt-screen-header--${align}`, className)}>
+      {leading ? <div className="pt-screen-header__leading">{leading}</div> : null}
+      <div className="pt-screen-header__copy">
+        {eyebrow ? <p className="pt-screen-header__eyebrow">{eyebrow}</p> : null}
+        {title ? <h1 className="pt-screen-header__title">{title}</h1> : null}
+        {subtitle ? <p className="pt-screen-header__subtitle">{subtitle}</p> : null}
+      </div>
+      {trailing ? <div className="pt-screen-header__trailing">{trailing}</div> : null}
+    </header>
+  );
+}
+
+function BaseButton({ variant, children, className = "", leadingIcon, trailingIcon, ...props }) {
+  return (
+    <button className={cx("pt-button", `pt-button--${variant}`, className)} {...props}>
+      {leadingIcon ? <span className="pt-button__icon">{leadingIcon}</span> : null}
+      <span className="pt-button__label">{children}</span>
+      {trailingIcon ? <span className="pt-button__icon">{trailingIcon}</span> : null}
+    </button>
+  );
+}
+
+export function PrimaryButton(props) {
+  return <BaseButton variant="primary" {...props} />;
+}
+
+export function SecondaryButton(props) {
+  return <BaseButton variant="secondary" {...props} />;
+}
+
+export function SurfaceCard({ children, className = "", interactive = false, as: Tag = "section", ...props }) {
+  return (
+    <Tag className={cx("pt-surface-card", interactive && "pt-surface-card--interactive", className)} {...props}>
+      {children}
+    </Tag>
+  );
+}
+
+export function CollapsibleSection({
+  title,
+  children,
+  defaultOpen = false,
+  open,
+  onOpenChange,
+  className = "",
+  contentClassName = "",
+  trailing,
+  id,
+}) {
+  const generatedId = useId();
+  const panelId = id || `collapsible-${generatedId}`;
+  const isControlled = typeof open === "boolean";
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const isOpen = isControlled ? open : internalOpen;
+
+  const toggle = () => {
+    const next = !isOpen;
+    if (!isControlled) setInternalOpen(next);
+    onOpenChange?.(next);
+  };
+
+  return (
+    <section className={cx("pt-collapsible", isOpen && "is-open", className)}>
+      <button
+        type="button"
+        className="pt-collapsible__trigger"
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        onClick={toggle}
+      >
+        <span className="pt-collapsible__title">{title}</span>
+        <span className="pt-collapsible__meta">{trailing}</span>
+        <span className="pt-collapsible__chevron" aria-hidden="true">⌄</span>
+      </button>
+      <div id={panelId} className="pt-collapsible__panel-wrap" aria-hidden={!isOpen}>
+        <div className={cx("pt-collapsible__panel", contentClassName)}>{children}</div>
+      </div>
+    </section>
+  );
+}
+
+export function BottomNav({ items = [], activeKey, onChange, className = "", ariaLabel = "Bottom navigation" }) {
+  return (
+    <nav className={cx("pt-bottom-nav", className)} aria-label={ariaLabel}>
+      {items.map((item) => {
+        const active = item.key === activeKey;
+        const handleSelect = () => {
+          item.onClick?.(item.key);
+          onChange?.(item.key);
+        };
+        return (
+          <button
+            key={item.key}
+            type="button"
+            className={cx("pt-bottom-nav__item", active && "is-active")}
+            aria-current={active ? "page" : undefined}
+            onClick={handleSelect}
+          >
+            {item.icon ? <span className="pt-bottom-nav__icon">{item.icon}</span> : null}
+            <span className="pt-bottom-nav__label">{item.label}</span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+export function Toggle({ checked, onCheckedChange, label, description, className = "", disabled = false, id }) {
+  const generatedId = useId();
+  const controlId = id || `toggle-${generatedId}`;
+  return (
+    <label className={cx("pt-toggle", disabled && "is-disabled", className)} htmlFor={controlId}>
+      <span className="pt-toggle__text">
+        {label ? <span className="pt-toggle__label">{label}</span> : null}
+        {description ? <span className="pt-toggle__description">{description}</span> : null}
+      </span>
+      <span className="pt-toggle__control-wrap">
+        <input
+          id={controlId}
+          type="checkbox"
+          className="pt-toggle__control"
+          checked={checked}
+          disabled={disabled}
+          onChange={(event) => onCheckedChange?.(event.target.checked)}
+        />
+        <span className="pt-toggle__track" aria-hidden="true">
+          <span className="pt-toggle__thumb" />
+        </span>
+      </span>
+    </label>
+  );
+}
+
+export function BottomSheet({
+  open,
+  onOpenChange,
+  title,
+  children,
+  className = "",
+  contentClassName = "",
+  closeLabel = "Close panel",
+  detachBackdrop = false,
+}) {
+  useEffect(() => {
+    if (!open) return undefined;
+    const onEscape = (event) => {
+      if (event.key === "Escape") onOpenChange?.(false);
+    };
+    window.addEventListener("keydown", onEscape);
+    return () => window.removeEventListener("keydown", onEscape);
+  }, [open, onOpenChange]);
+
+  return (
+    <div className={cx("pt-bottom-sheet-host", open && "is-open", detachBackdrop && "pt-bottom-sheet-host--no-backdrop")}>
+      <button
+        type="button"
+        className="pt-bottom-sheet__backdrop"
+        aria-label={closeLabel}
+        tabIndex={open ? 0 : -1}
+        onClick={() => onOpenChange?.(false)}
+      />
+      <section className={cx("pt-bottom-sheet", className)} aria-hidden={!open}>
+        <div className="pt-bottom-sheet__handle" aria-hidden="true" />
+        <div className="pt-bottom-sheet__header">
+          {title ? <h2 className="pt-bottom-sheet__title">{title}</h2> : null}
+          <SecondaryButton className="pt-bottom-sheet__close" onClick={() => onOpenChange?.(false)}>
+            Close
+          </SecondaryButton>
+        </div>
+        <div className={cx("pt-bottom-sheet__content", contentClassName)}>{children}</div>
+      </section>
+    </div>
+  );
+}
+
+export function ContextHint({ title, body, icon, className = "", tone = "default", action }) {
+  return (
+    <aside className={cx("pt-context-hint", `pt-context-hint--${tone}`, className)}>
+      {icon ? <div className="pt-context-hint__icon">{icon}</div> : null}
+      <div className="pt-context-hint__copy">
+        {title ? <p className="pt-context-hint__title">{title}</p> : null}
+        {body ? <p className="pt-context-hint__body">{body}</p> : null}
+      </div>
+      {action ? <div className="pt-context-hint__action">{action}</div> : null}
+    </aside>
+  );
+}
+
+export function InlineBanner({ title, body, tone = "info", icon, className = "", action, padded = true }) {
+  return (
+    <div className={cx("pt-inline-banner", `pt-inline-banner--${tone}`, padded && "pt-inline-banner--padded", className)}>
+      {icon ? <div className="pt-inline-banner__icon">{icon}</div> : null}
+      <div className="pt-inline-banner__copy">
+        {title ? <p className="pt-inline-banner__title">{title}</p> : null}
+        {body ? <p className="pt-inline-banner__body">{body}</p> : null}
+      </div>
+      {action ? <div className="pt-inline-banner__action">{action}</div> : null}
+    </div>
+  );
+}
+
+export const InsightCard = InlineBanner;
+
+export function EmptyState({
+  media,
+  icon,
+  mediaLabel,
+  title,
+  body,
+  ctaLabel,
+  onCta,
+  className = "",
+  cta,
+}) {
+  const mediaNode = media ?? icon ?? null;
+
+  return (
+    <div className={cx("pt-empty-state", className)}>
+      {mediaNode ? (
+        <div
+          className="pt-empty-state__media"
+          aria-label={mediaLabel || undefined}
+          aria-hidden={mediaLabel ? undefined : "true"}
+          role={mediaLabel ? "img" : undefined}
+        >
+          {mediaNode}
+        </div>
+      ) : null}
+      {title ? <h3 className="pt-empty-state__title">{title}</h3> : null}
+      {body ? <p className="pt-empty-state__body">{body}</p> : null}
+      {cta ? cta : ctaLabel && onCta ? <PrimaryButton onClick={onCta}>{ctaLabel}</PrimaryButton> : null}
+    </div>
+  );
+}
+
+export function useBottomSheetState(initialOpen = false) {
+  const [open, setOpen] = useState(initialOpen);
+  return useMemo(() => ({ open, setOpen }), [open]);
+}

--- a/src/components/primitives/index.js
+++ b/src/components/primitives/index.js
@@ -1,0 +1,16 @@
+export {
+  AppShell,
+  BottomNav,
+  BottomSheet,
+  CollapsibleSection,
+  ContextHint,
+  EmptyState,
+  InlineBanner,
+  InsightCard,
+  PrimaryButton,
+  ScreenHeader,
+  SecondaryButton,
+  SurfaceCard,
+  Toggle,
+  useBottomSheetState,
+} from "./Primitives.jsx";

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -1,0 +1,384 @@
+.pt-app-shell {
+  min-height: 100dvh;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.pt-app-shell__content {
+  width: min(100%, 720px);
+  margin: 0 auto;
+  padding: var(--space-card-padding-lg);
+  display: grid;
+  gap: var(--space-section-gap);
+}
+
+.pt-screen-header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-control-gap);
+  align-items: center;
+}
+
+.pt-screen-header--center .pt-screen-header__copy { text-align: center; }
+.pt-screen-header__title {
+  font-size: var(--type-page-heading-size);
+  line-height: var(--type-page-heading-line);
+  font-weight: var(--type-page-heading-weight);
+  letter-spacing: var(--type-page-heading-track);
+  color: var(--brown);
+}
+
+.pt-screen-header__subtitle {
+  margin-top: 2px;
+  color: var(--text-muted);
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-line);
+}
+
+.pt-screen-header__eyebrow {
+  text-transform: uppercase;
+  color: var(--text-subtle);
+  font-size: var(--type-overline-size);
+  letter-spacing: var(--type-overline-track);
+  line-height: var(--type-overline-line);
+  font-weight: var(--type-overline-weight);
+  margin-bottom: 2px;
+}
+
+.pt-button {
+  min-height: var(--control-touch-target-md);
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+  font-size: var(--type-button-size);
+  line-height: var(--type-button-line);
+  font-weight: var(--type-button-weight);
+  letter-spacing: var(--type-button-track);
+  padding: 0 var(--space-4);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-control-gap);
+  cursor: pointer;
+  transition:
+    transform var(--motion-press) var(--ease-standard),
+    background-color var(--motion-base) var(--ease-standard),
+    border-color var(--motion-base) var(--ease-standard),
+    box-shadow var(--motion-base) var(--ease-standard),
+    opacity var(--motion-fast) var(--ease-standard);
+}
+
+.pt-button:active { transform: scale(0.985); }
+.pt-button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.pt-button--primary {
+  background: var(--surface-streak-bg, linear-gradient(135deg, var(--green-dark) 0%, var(--green) 100%));
+  color: var(--text-on-accent);
+  box-shadow: var(--surface-streak-shadow, var(--shadow));
+}
+
+.pt-button--secondary {
+  background: var(--surface-gradient-soft);
+  border-color: var(--border);
+  color: var(--brown);
+}
+
+.pt-surface-card {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--surface-card-bg);
+  box-shadow: var(--shadow);
+  padding: var(--space-card-padding);
+}
+
+.pt-surface-card--interactive {
+  cursor: pointer;
+  transition: transform var(--motion-press) var(--ease-standard), box-shadow var(--motion-base) var(--ease-standard);
+}
+
+.pt-surface-card--interactive:active {
+  transform: scale(0.993);
+}
+
+.pt-collapsible {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--surface-gradient-soft);
+  overflow: clip;
+}
+
+.pt-collapsible__trigger {
+  width: 100%;
+  min-height: var(--control-touch-target-md);
+  padding: var(--space-inline-control-padding);
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: var(--space-control-gap);
+  align-items: center;
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.pt-collapsible__title { color: var(--brown); font-weight: var(--font-semibold); }
+.pt-collapsible__meta { color: var(--text-muted); font-size: var(--type-secondary-size); }
+.pt-collapsible__chevron { color: var(--text-muted); transition: transform var(--motion-base) var(--ease-standard); }
+.pt-collapsible.is-open .pt-collapsible__chevron { transform: rotate(180deg); }
+
+.pt-collapsible__panel-wrap {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--motion-dialog-enter) var(--ease-emphasized);
+}
+
+.pt-collapsible.is-open .pt-collapsible__panel-wrap { grid-template-rows: 1fr; }
+.pt-collapsible__panel { min-height: 0; overflow: hidden; padding: 0 var(--space-inline-control-padding) var(--space-inline-control-padding); }
+
+.pt-bottom-nav {
+  width: min(100%, 720px);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  gap: var(--space-card-row-gap);
+  padding: var(--space-2) var(--space-card-padding-lg);
+  background: color-mix(in srgb, var(--surface-frost) 92%, transparent);
+  border-top: 1px solid var(--border);
+  box-shadow: var(--surface-dock-shadow);
+  backdrop-filter: blur(14px);
+}
+
+.pt-bottom-nav__item {
+  border: none;
+  border-radius: var(--radius-sm);
+  min-height: var(--control-touch-target-md);
+  background: transparent;
+  color: var(--text-muted);
+  display: grid;
+  place-items: center;
+  gap: 2px;
+  cursor: pointer;
+  transition: transform var(--motion-press) var(--ease-standard), background-color var(--motion-fast) var(--ease-standard), color var(--motion-fast) var(--ease-standard);
+}
+
+.pt-bottom-nav__item:active { transform: scale(0.985); }
+.pt-bottom-nav__item.is-active {
+  color: var(--brown);
+  background: color-mix(in srgb, var(--softBlue) 55%, var(--surf));
+}
+
+.pt-bottom-nav__label {
+  font-size: var(--type-micro-text-size);
+  line-height: var(--type-micro-text-line);
+}
+
+.pt-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-control-gap);
+}
+
+.pt-toggle__text { display: grid; gap: 2px; }
+.pt-toggle__label { color: var(--brown); }
+.pt-toggle__description {
+  color: var(--text-muted);
+  font-size: var(--type-secondary-size);
+  line-height: var(--type-secondary-line);
+}
+
+.pt-toggle__control {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.pt-toggle__track {
+  width: 48px;
+  height: 30px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+  background: var(--surface-muted);
+  display: flex;
+  align-items: center;
+  padding: 3px;
+  transition: background-color var(--motion-base) var(--ease-standard), border-color var(--motion-base) var(--ease-standard);
+}
+
+.pt-toggle__thumb {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--surf);
+  box-shadow: var(--surface-focus-shadow-soft);
+  transition: transform var(--motion-base) var(--ease-emphasized), background-color var(--motion-fast) var(--ease-standard);
+}
+
+.pt-toggle__control:checked + .pt-toggle__track {
+  background: color-mix(in srgb, var(--green) 55%, var(--surf));
+  border-color: color-mix(in srgb, var(--green-dark) 35%, var(--border));
+}
+
+.pt-toggle__control:checked + .pt-toggle__track .pt-toggle__thumb {
+  transform: translateX(18px);
+  background: var(--green-dark);
+}
+
+.pt-bottom-sheet-host {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 55;
+}
+
+.pt-bottom-sheet__backdrop {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  margin: 0;
+  padding: 0;
+  background: var(--surface-overlay);
+  opacity: 0;
+  transition: opacity var(--motion-dialog-enter) var(--ease-standard);
+}
+
+.pt-bottom-sheet {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  border: 1px solid var(--border);
+  border-bottom: none;
+  background: var(--surface-gradient-raised);
+  box-shadow: var(--shadow-lg);
+  transform: translateY(102%);
+  opacity: 0.85;
+  transition: transform var(--motion-dialog-enter) var(--ease-emphasized), opacity var(--motion-base) var(--ease-standard);
+  max-height: min(82dvh, 720px);
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+}
+
+.pt-bottom-sheet-host.is-open { pointer-events: auto; }
+.pt-bottom-sheet-host.is-open .pt-bottom-sheet__backdrop { opacity: 1; }
+.pt-bottom-sheet-host.is-open .pt-bottom-sheet {
+  transform: translateY(0%);
+  opacity: 1;
+}
+
+.pt-bottom-sheet-host--no-backdrop .pt-bottom-sheet__backdrop {
+  background: transparent;
+}
+
+.pt-bottom-sheet__handle {
+  width: 44px;
+  height: 5px;
+  border-radius: var(--radius-pill);
+  background: var(--border);
+  margin: 10px auto 8px;
+}
+
+.pt-bottom-sheet__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-control-gap);
+  padding: 0 var(--space-card-padding) var(--space-card-row-gap);
+}
+
+.pt-bottom-sheet__title {
+  color: var(--brown);
+  font-size: var(--type-section-heading-size);
+  line-height: var(--type-section-heading-line);
+}
+
+.pt-bottom-sheet__content {
+  overflow: auto;
+  padding: 0 var(--space-card-padding) var(--space-card-padding-lg);
+}
+
+.pt-context-hint,
+.pt-inline-banner {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--surface-gradient-soft);
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-control-gap);
+  align-items: start;
+}
+
+.pt-context-hint { padding: var(--space-inline-control-padding); }
+.pt-inline-banner--padded { padding: var(--space-inline-control-padding); }
+
+.pt-context-hint__title,
+.pt-inline-banner__title {
+  color: var(--brown);
+  font-weight: var(--font-semibold);
+  margin-bottom: 2px;
+}
+
+.pt-context-hint__body,
+.pt-inline-banner__body {
+  color: var(--text-muted);
+  font-size: var(--type-secondary-size);
+  line-height: var(--type-secondary-line);
+}
+
+.pt-context-hint--info,
+.pt-inline-banner--info {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--softBlue) 60%, var(--surf)) 0%, var(--surf) 100%);
+  border-color: color-mix(in srgb, var(--softBlueBorder) 72%, var(--border));
+}
+
+.pt-context-hint--success,
+.pt-inline-banner--success {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--green) 22%, var(--surf)) 0%, var(--surf) 100%);
+  border-color: color-mix(in srgb, var(--green-dark) 22%, var(--border));
+}
+
+.pt-context-hint--warning,
+.pt-inline-banner--warning {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--warning) 14%, var(--surf)) 0%, var(--surf) 100%);
+  border-color: color-mix(in srgb, var(--warning) 28%, var(--border));
+}
+
+.pt-empty-state {
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--surface-gradient-soft);
+  text-align: center;
+  padding: var(--space-card-padding-lg);
+  display: grid;
+  gap: var(--space-card-row-gap);
+  place-items: center;
+}
+
+.pt-empty-state__title {
+  color: var(--brown);
+  font-size: var(--type-card-heading-size);
+  line-height: var(--type-card-heading-line);
+}
+
+.pt-empty-state__body {
+  color: var(--text-muted);
+  max-width: 42ch;
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-line);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pt-button,
+  .pt-surface-card--interactive,
+  .pt-collapsible__chevron,
+  .pt-collapsible__panel-wrap,
+  .pt-bottom-nav__item,
+  .pt-toggle__track,
+  .pt-toggle__thumb,
+  .pt-bottom-sheet__backdrop,
+  .pt-bottom-sheet {
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
### Motivation
- Centralize shared, screen-agnostic UI building blocks so screens can compose consistent primitives without embedding business logic.  
- Ensure all primitives use existing design tokens for color/spacing/typography/radius/shadows and favor soft motion and subtle tap feedback.  
- Provide smooth, premium-feeling interactions for collapsible content and bottom sheets while respecting reduced-motion preferences.

### Description
- Added a new primitives module `src/components/primitives/Primitives.jsx` that exports generic components: `AppShell`, `ScreenHeader`, `PrimaryButton`, `SecondaryButton`, `SurfaceCard`, `CollapsibleSection`, `BottomNav`, `Toggle`, `BottomSheet`, `ContextHint`, `InlineBanner` (plus `InsightCard` alias), `EmptyState`, and `useBottomSheetState` hook.  
- Introduced token-driven styles in `src/styles/primitives.css` for motion, touch targets, subtle tap feedback, soft shadows, smooth bottom-sheet transitions, collapsible reveal behavior, and reduced-motion handling.  
- Added a barrel export at `src/components/primitives/index.js` and refactored the existing `src/components/EmptyState.jsx` to delegate to the new primitive while preserving the same external API.  
- Wired the primitives stylesheet into app bootstrap by importing `src/styles/primitives.css` from `src/App.jsx`, and kept primitives intentionally generic (no screen-specific hacks); `Chip` was omitted for now as it wasn’t required.

### Testing
- Ran a production build with `npm run build`, which completed successfully.  
- Ran the test suite with `npm test` (Vitest), and all automated tests passed.  
- Ran the inline-style hygiene check with `npm run check:inline-styles`, which failed due to an existing inline style at `src/features/train/TrainComponents.jsx:106` that is unrelated to these new primitives.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b83be1cc83328ccd5db310877c04)