### PR TITLE
Refactor IA hierarchy and screen tone around Train/History/Progress/Settings

### DIFF
--- a/IA_REFACTOR_PLAN_2026-04-16.md
+++ b/IA_REFACTOR_PLAN_2026-04-16.md
@@ -1,0 +1,75 @@
+# PawTimer IA Refactor Plan (2026-04-16)
+
+## Product model anchors
+- **Train = focus/action:** start, run, and close a single session with minimal distraction.
+- **History = story/timeline:** review meaningful events as an understandable narrative.
+- **Progress = emotional progress:** confidence trajectory and coaching context, not raw BI.
+- **Settings = calm control:** profile, behavior, defaults, and diagnostics in one premium-feeling control space.
+
+## Current-state IA audit
+
+### Train (Home)
+- Strengths: clear session control and completion flow.
+- Issues:
+  - Mixed in dashboard-style metrics rings (duplicated with Progress).
+  - "Today's logs" section naming made utility logging feel primary.
+  - Context hints could stack and compete with primary CTA.
+
+### History
+- Strengths: unified timeline across session/walk/pattern/feeding with edit/delete.
+- Issues:
+  - Framed as an "Activity Log" which reads as operational data, not story.
+  - Weak orientation at top; users enter a flat list without narrative framing.
+
+### Progress
+- Strengths: good recommendation context + chart + supporting metrics.
+- Issues:
+  - Section labels felt analytical and generic ("Key metrics", "Daily patterns").
+  - Emotional framing could be stronger for dog owners.
+
+### Settings
+- Strengths: broad control coverage and good grouping.
+- Issues:
+  - Main heading tone felt utilitarian; sections could feel more product-native.
+
+### Onboarding
+- Strengths: step flow and controls align with app system.
+- Issues:
+  - Copy tone partially disconnected from renamed core screen roles.
+
+## Responsibility map (target)
+
+| Screen | Must own | Must avoid | Cross-links |
+|---|---|---|---|
+| Train | Session focus, in-session controls, quick supportive routine logging | Dashboard analytics, long historical browsing | Link out to Progress/History only via deliberate navigation |
+| History | Narrative timeline and corrections (edit/delete) | Dense raw logs with no context | CTA to Train when empty |
+| Progress | Confidence status, trend, humane interpretation | Operational logs and settings controls | CTA to Train when no data |
+| Settings | Dog profile, reminders, controls, diagnostics | Live training actions and timeline interaction | N/A |
+
+## Duplication removal plan
+1. **Remove dashboard rings from Train** and keep a compact focus strip with one actionable signal (next calm session) and light context (today count).
+2. **Keep support logs lightweight in Train** by positioning as quick routine actions, not historical review.
+3. **Promote narrative framing in History** with story-first heading and compact summary chips to avoid "dump of logs" feel.
+4. **Retone Progress content** to emotional language while preserving existing metrics.
+5. **Retone Settings entry IA** with premium, calm-control copy and grouped section labels.
+6. **Align onboarding language** with the same four-screen model for conceptual continuity.
+
+## Move / collapse / group / remove recommendations
+
+### Move
+- Move "how am I doing?" visual status from Train to Progress (already represented by chart + confidence cards).
+
+### Collapse
+- Collapse Train context into one focus strip instead of two ring widgets.
+
+### Group
+- Group non-session actions in Train as **Support routines** (walk, pattern break, feeding).
+- Group settings labels by user intent: dog+routine, guidance+diagnostics, account+device.
+
+### Remove
+- Remove framing that implies Train is a dashboard or History is a raw event sink.
+
+## Guardrails
+- Logs never dominate Train hierarchy.
+- Hints remain short, contextual, and dismissible-by-flow (not permanent clutter blocks).
+- Dog-specific emotional tone is preserved in all headings and helper text.

--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -340,6 +340,9 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
   const durationIsValid = historyModal?.mode === "duration"
     ? Number.isFinite(parsedDuration) && (requiresPositiveDuration ? parsedDuration > 0 : parsedDuration >= 0)
     : true;
+  const recentCount = timeline.slice(0, 7).length;
+  const sessionCount = timeline.filter((item) => item.kind === "session").length;
+  const careCount = timeline.filter((item) => item.kind !== "session").length;
 
   const toggleExpandedItem = (itemKey) => {
     setExpandedItemKey((prev) => (prev === itemKey ? null : itemKey));
@@ -393,9 +396,19 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
       <div className="tab-content">
         <div className="section">
           <div className="history-section-head">
-            <div className="section-title">Activity Log</div>
+            <div>
+              <div className="section-title">Story timeline</div>
+              <div className="t-helper">A narrative of {name}'s training and support routines over time.</div>
+            </div>
             {sessions.length > 0 && <button className="clear-btn surface-text-button secondary-control secondary-control--inline-text" onClick={actions.clearSessions}>Clear sessions</button>}
           </div>
+          {timeline.length > 0 && (
+            <div className="history-story-summary">
+              <span>{recentCount} recent moments</span>
+              <span>{sessionCount} training sessions</span>
+              <span>{careCount} support routine logs</span>
+            </div>
+          )}
 
           {timeline.length === 0 ? (
             <EmptyState media={<TrendIcon />} title="No activity yet" body={`Start ${name}'s first session and your training history will appear here.`} ctaLabel="Go to Train →" onCta={() => setTab("home")} />

--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -1,5 +1,4 @@
 import { SessionControl, SessionRatingPanel, TrainProgressBar } from "../train/TrainComponents";
-import { METRIC_VARIANTS, StatsProgressRing } from "../stats/StatsComponents";
 import { DISTRESS_TYPES, PATTERN_TYPES, WALK_TYPE_OPTIONS, fmt, fmtClock, isToday, walkTypeLabel } from "../app/helpers";
 import { Img, ModalCloseButton } from "../app/ui";
 import { useState } from "react";
@@ -106,46 +105,18 @@ export default function HomeScreen(props) {
           distressTypes={DISTRESS_TYPES}
         />
 
-        {phase === "idle" && (() => {
-          const goalFrac = Math.min(goalPct / 100, 1);
-          const sessFrac = activeProto.sessionsPerDayMax > 0 ? Math.min(daily.count / activeProto.sessionsPerDayMax, 1) : 0;
-          const nextSessionLabel = fmtClock(target);
-          const ringMetricVariant = METRIC_VARIANTS.RING;
-          return (
-            <div
-              className={`stats-rings-card metric-surface metric-surface--${ringMetricVariant} ${recoveryMode?.active ? "stats-rings-card--recovery-active" : ""}`.trim()}
-              role={recoveryMode?.active ? "button" : undefined}
-              tabIndex={recoveryMode?.active ? 0 : undefined}
-              onClick={recoveryMode?.active ? () => setShowRecoveryInfo(true) : undefined}
-              onKeyDown={recoveryMode?.active ? (e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  setShowRecoveryInfo(true);
-                }
-              } : undefined}
-            >
-              <StatsProgressRing
-                value={nextSessionLabel}
-                numericValue={target}
-                formatValue={fmtClock}
-                label="Next session"
-                progress={goalFrac}
-                fillClassName="ring-fill-1"
-                className="ring-col--next-session"
-                ringWrapClassName={recoveryMode?.active ? "ring-wrap--recovery-pulse" : ""}
-                showRecoveryPulse={recoveryMode?.active}
-              />
-              <div className="ring-col-sep" />
-              <StatsProgressRing
-                value={daily.count}
-                numericValue={daily.count}
-                label="Sessions today"
-                progress={sessFrac}
-                fillClassName="ring-fill-2"
-              />
-            </div>
-          );
-        })()}
+        {phase === "idle" && (
+          <button
+            type="button"
+            className={`train-focus-strip ${recoveryMode?.active ? "train-focus-strip--recovery" : ""}`.trim()}
+            onClick={recoveryMode?.active ? () => setShowRecoveryInfo(true) : undefined}
+            disabled={!recoveryMode?.active}
+          >
+            <span className="train-focus-strip__label">Focus now</span>
+            <span className="train-focus-strip__value">{fmtClock(target)} calm session</span>
+            <span className="train-focus-strip__meta">{daily.count} logged today</span>
+          </button>
+        )}
         {showRecoveryInfo && recoveryMode?.active && (
           <div className="quick-modal-overlay" role="dialog" aria-modal="true" onClick={() => setShowRecoveryInfo(false)}>
             <div className="quick-modal-card modal-card modal-card--dialog-md recovery-explain-modal" onClick={(e) => e.stopPropagation()}>
@@ -187,7 +158,8 @@ export default function HomeScreen(props) {
         )}
 
         <div className="tool-group-card surface-card surface-card--tool-group">
-          <div className="section-title">Today's logs</div>
+          <div className="section-title">Support routines</div>
+          <div className="t-helper">Quick log items that support training, without leaving Train.</div>
           <div className="quick-actions-row">
             <button className="quick-action-btn" type="button" onClick={walkPhase === "idle" ? startWalk : undefined}>
               <span className="quick-action-label">Walk</span>

--- a/src/features/settings/SettingsScreen.jsx
+++ b/src/features/settings/SettingsScreen.jsx
@@ -82,10 +82,11 @@ export default function SettingsScreen(props) {
     <>
       <div className="tab-content">
         <div className="section">
-          <div className="section-title">Settings</div>
+          <div className="section-title">Calm control</div>
+          <div className="t-helper">Manage profile, routine defaults, and device behavior for {name}.</div>
 
           <div className="settings-nav-list" role="list" aria-label="Settings destinations">
-            <div className="settings-section-label">General</div>
+            <div className="settings-section-label">Dog + routine</div>
             <SettingsNavRow label="Dog profile" value={name} onClick={() => setActivePanel(SETTINGS_PANEL.PROFILE)} />
             <SettingsNavRow label="Reminders" value={reminderSummary} onClick={() => setActivePanel(SETTINGS_PANEL.REMINDERS)} />
             <SettingsNavRow label="Training settings" value={`Up to ${activeProto.sessionsPerDayMax}/day`} onClick={() => setTrainingSettingsOpen(true)} />
@@ -93,13 +94,13 @@ export default function SettingsScreen(props) {
           </div>
 
           <div className="settings-nav-list" role="list" aria-label="Support destinations">
-            <div className="settings-section-label">Support</div>
+            <div className="settings-section-label">Guidance + diagnostics</div>
             <SettingsNavRow label="Help" value="Guidance" onClick={() => setActivePanel(SETTINGS_PANEL.HELP)} />
             <SettingsNavRow label="Advanced" value="Diagnostics" onClick={() => setActivePanel(SETTINGS_PANEL.ADVANCED)} />
           </div>
 
           <div className="settings-nav-list" role="list" aria-label="Account destinations">
-            <div className="settings-section-label">Account</div>
+            <div className="settings-section-label">Account + device</div>
             <SettingsNavRow label="Account" value="Profile & device" onClick={() => setActivePanel(SETTINGS_PANEL.ACCOUNT)} />
           </div>
 

--- a/src/features/setup/SetupScreens.jsx
+++ b/src/features/setup/SetupScreens.jsx
@@ -23,7 +23,7 @@ export function Onboarding({ onComplete, onBack }) {
       <div className="ob-hero">
         <div className="ob-hero-icon"><PawIcon size={48} /></div>
         <div className="ob-title">PawTimer</div>
-        <div className="ob-subtitle">Set up {displayName}'s training plan in 4 steps.</div>
+        <div className="ob-subtitle">Set up {displayName}'s calm plan in 4 quick steps.</div>
         <div className="ob-step-indicator">
           {[0, 1, 2, 3].map((i) => <div key={i} className={`ob-step-dot ${i < step ? "done" : i === step ? "active" : ""}`} />)}
         </div>
@@ -32,12 +32,12 @@ export function Onboarding({ onComplete, onBack }) {
         {step === 0 && <>
           <div className="ob-question">What's your dog's name?</div>
           <div className="ob-note prose">Names are case-insensitive, and we'll keep your dog's natural spelling.</div>
-          <div className="ob-hint">Used to personalise messages throughout the app.</div>
+          <div className="ob-hint">Used across Train, History, Progress, and Settings.</div>
           <input className="ob-input" placeholder="e.g. Luna, Maximilian…" value={name} onChange={(e) => setName(e.target.value)} onKeyDown={(e) => e.key === "Enter" && canNext && handleNext()} autoFocus />
         </>}
         {step === 1 && <>
           <div className="ob-question">How often do you leave the house per day?</div>
-          <div className="ob-hint">Determines how many pattern-break exercises to recommend each day.</div>
+          <div className="ob-hint">Shapes daily support routine suggestions.</div>
           <div className="ob-options">
             {LEAVE_OPTIONS.map((o) => (
               <button key={o.value} className={`ob-option ${leaves === o.value ? "selected" : ""}`} onClick={() => setLeaves(o.value)}>
@@ -48,7 +48,7 @@ export function Onboarding({ onComplete, onBack }) {
         </>}
         {step === 2 && <>
           <div className="ob-question">How long can {displayName} stay calm alone now?</div>
-          <div className="ob-hint">The first target starts around 80% of this, then adapts using calm streaks, distress, and relapse risk.</div>
+          <div className="ob-hint">Train starts near 80% and adapts to calm streaks and stress signs.</div>
           <div className="ob-duration-grid">
             {CALM_DURATIONS.map((d) => (
               <button key={d.value} className={`ob-dur-btn ${calm === d.value ? "selected" : ""}`} onClick={() => setCalm(d.value)}>

--- a/src/features/stats/StatsScreen.jsx
+++ b/src/features/stats/StatsScreen.jsx
@@ -17,14 +17,14 @@ export default function StatsScreen({ name, totalCount, setTab, bestCalm, recomm
         {totalCount === 0 ? (
           <EmptyState media={<SproutIcon />} title="Progress starts here" body={`Complete your first session and ${name}'s progress, streak, and chart will appear here.`} ctaLabel="Go to Train →" onCta={() => setTab("home")} />
         ) : <>
-          <StatsSection title="Today" className="stats-section-priority">
+          <StatsSection title="Today’s feeling" className="stats-section-priority">
             <div className="stats-metric-anchor">
               <div
                 className={`stats-headline-card metric-surface metric-surface--${headlineMetricVariant} surface-state--${headlineSurfaceState}`.trim()}
                 data-metric-variant={headlineMetricVariant}
                 aria-label="Current recommendation"
               >
-                <span className="stats-headline-label">Current recommendation</span>
+                  <span className="stats-headline-label">Confidence recommendation</span>
                 <div className="stats-headline-main">
                   <span className="stats-headline-value">{fmt(target)}</span>
                   <span className="stats-headline-status">{headlineStatus}</span>
@@ -33,7 +33,7 @@ export default function StatsScreen({ name, totalCount, setTab, bestCalm, recomm
             </div>
           </StatsSection>
 
-          <StatsSection title="Key metrics">
+          <StatsSection title="Confidence signals">
             <div className="stats-row stats-row-core stats-row-core-trimmed">
               <StatsMetricCard
                 value={fmt(bestCalm)}
@@ -56,11 +56,11 @@ export default function StatsScreen({ name, totalCount, setTab, bestCalm, recomm
             </div>
           </StatsSection>
 
-          <StatsSection title="Progress chart">
+          <StatsSection title="Journey curve">
             <StatsChartSection chartData={chartData} goalSec={goalSec} CustomDot={CustomDot} setTab={setTab} name={name} distressLabel={distressLabel} fmt={fmt} insightLabel={chartTrendLabel} />
           </StatsSection>
 
-          <StatsSection title="Daily patterns" className="stats-section-supporting">
+          <StatsSection title="Daily rhythm" className="stats-section-supporting">
             <div className="stats-support-list">
               <StatsSupportRow label="Alone time per week" value={fmt(aloneLastWeek)} />
               <StatsSupportRow label="Average walk duration" value={avgWalkDuration != null ? fmt(avgWalkDuration, { hoursMinutesOnly: true }) : "—"} />

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -276,6 +276,27 @@
   /* ── Status message ── */
   .status-msg { margin:var(--space-card-row-gap) auto 0; max-width:360px; font-size:var(--type-helper-text-size); font-weight:var(--type-helper-text-weight); color:var(--text-muted); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); text-align:center; transition:color var(--motion-base) var(--ease-out), background-color var(--motion-base) var(--ease-out), border-color var(--motion-base) var(--ease-out); }
   .status-msg--warning { color:var(--amber); }
+  .train-focus-strip {
+    width:100%;
+    border:1px solid color-mix(in srgb, var(--border) 84%, white);
+    border-radius:16px;
+    background:linear-gradient(180deg, color-mix(in srgb, var(--surface-muted) 94%, white), color-mix(in srgb, var(--surf) 96%, var(--surface-muted)));
+    color:inherit;
+    padding:12px 14px;
+    display:grid;
+    grid-template-columns:auto 1fr auto;
+    align-items:center;
+    gap:10px;
+    text-align:left;
+  }
+  .train-focus-strip:disabled { cursor:default; opacity:1; }
+  .train-focus-strip__label { font-size:var(--type-helper-text-size); color:var(--text-muted); text-transform:uppercase; letter-spacing:var(--type-helper-text-track); }
+  .train-focus-strip__value { font-weight:600; color:var(--brown); }
+  .train-focus-strip__meta { font-size:var(--type-helper-text-size); color:var(--text-muted); }
+  .train-focus-strip--recovery {
+    border-color:color-mix(in srgb, var(--warning) 30%, var(--border));
+    box-shadow:0 0 0 1px color-mix(in srgb, var(--warning) 15%, transparent);
+  }
   .ring-sub-btn {
     margin-top:var(--space-card-row-gap);
     font-size:var(--type-metric-label-size);
@@ -666,6 +687,20 @@
   .section { padding:var(--space-3); overflow-x:hidden; }
   .section > .section-title:first-child { margin-bottom:var(--space-section-gap); }
   .history-section-head { display:flex; justify-content:space-between; align-items:baseline; margin-bottom:var(--space-3); }
+  .history-story-summary {
+    display:flex;
+    flex-wrap:wrap;
+    gap:8px;
+    margin:-6px 0 var(--space-card-row-gap);
+  }
+  .history-story-summary span {
+    font-size:var(--type-helper-text-size);
+    color:var(--text-muted);
+    background:var(--surface-muted);
+    border:1px solid var(--border);
+    border-radius:999px;
+    padding:4px 10px;
+  }
   .section-title { font-size:var(--type-section-heading-size); font-weight:var(--type-section-heading-weight); color:var(--text); line-height:var(--type-section-heading-line); letter-spacing:var(--type-section-heading-track); margin:0; min-height:calc(var(--type-section-heading-line) * 1em); display:flex; align-items:baseline; }
   .section-title--flush { margin-bottom:0; }
   .empty-state { text-align:center; padding:var(--space-5) 28px; color:var(--text-muted); }


### PR DESCRIPTION
### Motivation
- Align the app navigation and information architecture with the redesigned product model where Train = focus/action, History = story/timeline, Progress = emotional progress, and Settings = calm control.
- Remove duplication (notably dashboard-style metrics in Train) and ensure logs and hints do not dominate the Train experience while keeping the app dog-specific and emotionally clear.

### Description
- Added an IA deliverable file `IA_REFACTOR_PLAN_2026-04-16.md` containing the audit, IA plan, responsibility map, and duplication removal recommendations.
- Updated `src/features/home/HomeScreen.jsx` to remove the dashboard-style rings and introduce a compact `train-focus-strip` (action-first), and retitled the utility area to "Support routines" to keep quick logs lightweight.
- Updated `src/features/history/HistoryFeature.jsx` to reframe the view as a "Story timeline", added top-level helper copy and summary chips while preserving existing edit/delete controls.
- Retoned `src/features/stats/StatsScreen.jsx` labels to be emotionally legible (e.g. `Today’s feeling`, `Confidence signals`, `Journey curve`, `Daily rhythm`).
- Retoned `src/features/settings/SettingsScreen.jsx` heading and section labels to a premium, product-native tone (now "Calm control") and adjusted onboarding copy in `src/features/setup/SetupScreens.jsx` to match the same language.
- Added supporting styles for the new `train-focus-strip` and history summary chips in `src/styles/app.css`.

### Testing
- Ran the unit test suite with `npm test`, and all tests passed (`17 test files, 230 tests` passed).
- Built the production bundle with `npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0baaff5788332a83e7331abc34ab6)