### PR TITLE
Add premium dog-focused Welcome screen and setup landing flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import { buildPartialCapabilitySyncMessage, partitionPendingOutboundByCapability
 import { computeSyncSummary } from "./features/app/syncSummary";
 import { fmt, fmtClock, getOutcomeTone, normalizeWalkType, walkTypeLabel } from "./features/app/helpers";
 import { CameraIcon, ChartIcon, HistoryIcon, HomeIcon, PawIcon, SettingsIcon } from "./features/app/ui.jsx";
-import { DogSelect, Onboarding } from "./features/setup/SetupScreens";
+import { DogSelect, Onboarding, WelcomeScreen } from "./features/setup/SetupScreens";
 import HomeScreen from "./features/home/HomeScreen";
 import StatsScreen from "./features/stats/StatsScreen";
 import SettingsScreen from "./features/settings/SettingsScreen";
@@ -74,6 +74,7 @@ export default function PawTimer() {
   const [feedingOpen, setFeedingOpen] = useState(false);
   const [feedingDraft, setFeedingDraft] = useState(() => ({ time: toDateTimeLocalValue(new Date()), foodType: "meal", amount: "small" }));
   const [historyModal, setHistoryModal] = useState(null);
+  const getSetupLandingScreen = useCallback((nextDogs = dogs) => (ensureArray(nextDogs).length > 0 ? "select" : "welcome"), [dogs]);
 
   const {
     needRefresh: [needRefresh],
@@ -433,10 +434,10 @@ export default function PawTimer() {
   }, [commitFeedings, commitPatterns, commitSessions, commitWalks, recomputeTarget, setEntrySyncState]);
 
   useEffect(() => {
-    if (!activeDogId) { setScreen("select"); return; }
+    if (!activeDogId) { setScreen(getSetupLandingScreen(dogs)); return; }
     const normalizedId = canonicalDogId(activeDogId);
     const dog = dogs.find((d) => canonicalDogId(d.id) === normalizedId) ?? ensureArray(load(DOGS_KEY, [])).find((d) => canonicalDogId(d.id) === normalizedId);
-    if (!dog) { setScreen("select"); return; }
+    if (!dog) { setScreen(getSetupLandingScreen(dogs)); return; }
     const local = hydrateDogFromLocal(normalizedId);
     const hydratedTombstones = normalizeTombstones(local.tombstones).map(withHydratedSyncState);
     const hydratedSessions = sortByDateAsc(normalizeSessions(local.sessions).map(withHydratedSyncState));
@@ -476,14 +477,14 @@ export default function PawTimer() {
       dog,
     );
     setScreen("app");
-  }, [activeDogId, dogs, recomputeTarget, withHydratedSyncState]);
+  }, [activeDogId, dogs, getSetupLandingScreen, recomputeTarget, withHydratedSyncState]);
 
   useEffect(() => {
     const savedId = load(ACTIVE_DOG_KEY, null);
     const savedDogs = ensureArray(load(DOGS_KEY, []));
     if (savedId && (SYNC_ENABLED || savedDogs.find((d) => canonicalDogId(d.id) === canonicalDogId(savedId)))) setActiveDogId(canonicalDogId(savedId));
-    else setScreen("select");
-  }, []);
+    else setScreen(getSetupLandingScreen(savedDogs));
+  }, [getSetupLandingScreen]);
 
   useEffect(() => {
     if (!activeDogId || !SYNC_ENABLED) { setSyncStatus("idle"); setSyncError(""); return; }
@@ -1079,8 +1080,19 @@ export default function PawTimer() {
     return <circle cx={cx} cy={cy} r={5} fill={c} stroke="white" strokeWidth={2} />;
   };
 
+  if (screen === "welcome") {
+    return (
+      <>
+        {toast && <div className="toast">{toast}</div>}
+        <WelcomeScreen
+          onStart={() => { setOnboardingState({ mode: "new", dogId: null }); setScreen("onboard"); }}
+          onManageDogs={() => setScreen("select")}
+        />
+      </>
+    );
+  }
   if (screen === "select") return <>{toast && <div className="toast">{toast}</div>}<DogSelect dogs={dogs} onSelect={handleDogSelect} onCreateNew={() => { setOnboardingState({ mode: "new", dogId: null }); setScreen("onboard"); }} /></>;
-  if (screen === "onboard") return <Onboarding onComplete={handleOnboardComplete} onBack={() => { setOnboardingState(null); setScreen("select"); }} />;
+  if (screen === "onboard") return <Onboarding onComplete={handleOnboardComplete} onBack={() => { setOnboardingState(null); setScreen(getSetupLandingScreen(dogs)); }} />;
 
   return (
     <>

--- a/src/features/setup/SetupScreens.jsx
+++ b/src/features/setup/SetupScreens.jsx
@@ -2,6 +2,38 @@ import { useState } from "react";
 import { CALM_DURATIONS, GOAL_DURATIONS, LEAVE_OPTIONS } from "../app/helpers";
 import { PawIcon } from "../app/ui";
 
+export function WelcomeScreen({ onStart, onManageDogs }) {
+  return (
+    <div className="welcome-screen">
+      <div className="ws-hero">
+        <div className="ws-halo ws-halo--one" aria-hidden="true" />
+        <div className="ws-halo ws-halo--two" aria-hidden="true" />
+        <div className="ws-paw">
+          <PawIcon size={66} />
+        </div>
+        <div className="ws-eyebrow">Calm dog training</div>
+        <h1 className="ws-title">PawTimer</h1>
+        <p className="ws-copy">
+          Gentle, science-led sessions that help your dog feel safer when home alone.
+        </p>
+      </div>
+
+      <div className="ws-footer">
+        <button
+          className="ws-cta button-base button-primary button--lg button-size-primary-cta button--block"
+          type="button"
+          onClick={onStart}
+        >
+          Start setup
+        </button>
+        <button className="ws-secondary" type="button" onClick={onManageDogs}>
+          I already have a dog profile
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function Onboarding({ onComplete, onBack }) {
   const [step, setStep] = useState(0);
   const [name, setName] = useState("");

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -82,6 +82,97 @@
 
   /* ── Dog Select ── */
   .dog-select { max-width:480px; margin:0 auto; min-height:100vh; display:flex; flex-direction:column; background:var(--bg); overflow-x:hidden; }
+  .welcome-screen {
+    max-width: 480px;
+    margin: 0 auto;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 56px 24px 36px;
+    background:
+      radial-gradient(circle at 12% 10%, rgba(210, 172, 131, 0.14), transparent 44%),
+      radial-gradient(circle at 90% 16%, rgba(184, 224, 199, 0.22), transparent 40%),
+      linear-gradient(180deg, var(--surface-hero-top) 0%, var(--bg) 72%);
+    overflow: hidden;
+  }
+  .ws-hero { position: relative; text-align: left; animation: ws-fade-up .7s var(--ease-out-soft, ease-out) both; }
+  .ws-halo {
+    position: absolute;
+    border-radius: 999px;
+    pointer-events: none;
+    filter: blur(1px);
+    animation: ws-breathe 7s ease-in-out infinite;
+  }
+  .ws-halo--one {
+    top: -20px;
+    right: -78px;
+    width: 210px;
+    height: 210px;
+    background: radial-gradient(circle, rgba(184,224,199,0.26) 0%, rgba(184,224,199,0) 72%);
+  }
+  .ws-halo--two {
+    top: 86px;
+    left: -96px;
+    width: 180px;
+    height: 180px;
+    background: radial-gradient(circle, rgba(210,172,131,0.16) 0%, rgba(210,172,131,0) 72%);
+    animation-delay: 1.6s;
+  }
+  .ws-paw { margin-bottom: 24px; display: inline-flex; transform: translateY(0); animation: ws-float 5.8s ease-in-out infinite; }
+  .ws-eyebrow {
+    font-size: var(--type-overline-size);
+    line-height: var(--type-overline-line);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    font-weight: var(--type-overline-weight);
+    margin-bottom: 10px;
+  }
+  .ws-title {
+    margin: 0;
+    font-size: clamp(2rem, 8.5vw, 2.65rem);
+    line-height: 1.08;
+    letter-spacing: -0.015em;
+    color: var(--brown);
+  }
+  .ws-copy {
+    margin: 14px 0 0;
+    max-width: 29ch;
+    color: var(--text-muted);
+    font-size: var(--type-body-lg-size);
+    line-height: 1.56;
+    letter-spacing: var(--type-body-track);
+    font-weight: var(--type-body-lg-weight);
+  }
+  .ws-footer { display: flex; flex-direction: column; gap: 12px; animation: ws-fade-up .9s .08s var(--ease-out-soft, ease-out) both; }
+  .ws-cta { box-shadow: 0 12px 34px rgba(70, 90, 72, 0.2); }
+  .ws-secondary {
+    align-self: center;
+    border: 0;
+    background: transparent;
+    color: var(--text-muted);
+    font-size: var(--type-secondary-size);
+    line-height: var(--type-secondary-line);
+    font-weight: var(--type-secondary-weight);
+    letter-spacing: var(--type-secondary-track);
+    padding: 8px 10px;
+    cursor: pointer;
+  }
+  .ws-secondary:hover { color: var(--brown); }
+  @keyframes ws-fade-up {
+    from { opacity: 0; transform: translateY(12px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  @keyframes ws-float {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-5px); }
+  }
+  @keyframes ws-breathe {
+    0%, 100% { transform: scale(1); opacity: 0.9; }
+    50% { transform: scale(1.08); opacity: 1; }
+  }
+
   .ds-hero { background:linear-gradient(180deg,var(--surface-hero-top) 0%,var(--bg) 72%); padding:60px 28px 32px; position:relative; overflow:hidden; text-align:center; }
   .ds-hero::before { content:''; position:absolute; top:-40px; right:-40px; width:200px; height:200px; background:radial-gradient(circle,rgba(184,224,199,0.24) 0%,transparent 72%); border-radius:50%; }
   .ds-logo { margin-bottom:14px; position:relative; z-index:1; display:flex; justify-content:center; }


### PR DESCRIPTION
### Motivation
- Provide a calm, premium entry that immediately communicates PawTimer is a dog-focused separation‑training app and gently leads first-time users into onboarding. 
- Keep the screen minimal and warm with a single primary CTA, subtle dog identity, and premium motion while preserving existing select/onboarding flows.

### Description
- Added a new `WelcomeScreen` component in `src/features/setup/SetupScreens.jsx` that shows short, clear copy, a paw identity mark, one primary CTA (`Start setup`) and a secondary path for returning users. 
- Updated `src/App.jsx` to determine the setup landing (`welcome` vs `select`) based on whether any dog profiles exist and wired the `welcome` render branch and onboarding back-navigation to use this landing logic via `getSetupLandingScreen`. 
- Implemented visual styles and subtle motion in `src/styles/app.css` (soft gradients, halo accents, floating paw, fade-up animations) consistent with existing design tokens and preserved minimal hierarchy. 
- Reused existing `PawIcon` and existing button classes so the Welcome screen integrates with the global visual system.

### Testing
- Built the production bundle with `npm run build` and the build completed successfully. 
- Ran the test suite with `npm run test` and all automated tests passed (`Test Files 17 passed`, `Tests 230 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0bf2040a483328476913a6eae3b7e)