### PR TITLE
Onboarding decision screen: create or join dog

### DIFF
--- a/src/features/setup/SetupScreens.jsx
+++ b/src/features/setup/SetupScreens.jsx
@@ -116,6 +116,7 @@ export function Onboarding({ onComplete, onBack }) {
 export function DogSelect({ dogs, onSelect, onCreateNew }) {
   const [joinId, setJoinId] = useState("");
   const [joinError, setJoinError] = useState("");
+  const [activePath, setActivePath] = useState(null);
 
   const handleJoin = () => {
     const id = joinId.trim().toUpperCase();
@@ -132,11 +133,51 @@ export function DogSelect({ dogs, onSelect, onCreateNew }) {
       <div className="ds-hero">
         <div className="ds-logo"><PawIcon size={68} /></div>
         <div className="ds-title">PawTimer</div>
-        <div className="ds-sub">Separation anxiety training tracker</div>
+        <div className="ds-sub">Choose how you want to get started.</div>
       </div>
       <div className="ds-body">
+        <div className="ds-path-grid">
+          <button
+            className={`ds-path-card ${activePath === "create" ? "selected" : ""}`}
+            type="button"
+            onClick={() => {
+              setActivePath("create");
+              onCreateNew();
+            }}
+          >
+            <div className="ds-path-title">Create new dog</div>
+            <div className="ds-path-copy">Set up your dog's calm plan in under a minute.</div>
+          </button>
+          <button
+            className={`ds-path-card ${activePath === "join" ? "selected" : ""}`}
+            type="button"
+            onClick={() => setActivePath("join")}
+          >
+            <div className="ds-path-title">Join existing dog by ID</div>
+            <div className="ds-path-copy">Use a shared ID to track the same dog together.</div>
+          </button>
+        </div>
+
+        <div className={`ds-join-panel ${activePath === "join" ? "is-open" : ""}`}>
+          <div className="ds-section-label">Join with a dog ID</div>
+          <div className="ds-note">IDs are unique and matched securely, case-insensitive.</div>
+          <div className="ds-join-row">
+            <input
+              className="ds-join-input"
+              placeholder="e.g. LUNA-4829"
+              value={joinId}
+              onChange={(e) => { setJoinId(e.target.value); setJoinError(""); }}
+              onKeyDown={(e) => e.key === "Enter" && joinId.trim() && handleJoin()}
+              maxLength={14}
+            />
+            <button className="ds-join-btn" onClick={handleJoin}>Join →</button>
+          </div>
+          {joinError && <div className="ds-join-error">{joinError}</div>}
+          <div className="ds-join-hint">Find this ID in PawTimer → Settings.</div>
+        </div>
+
         {dogs.length > 0 && <>
-          <div className="ds-section-label">Your dogs</div>
+          <div className="ds-section-label u-mt-section-tight">Your dogs</div>
           {dogs.map((d) => (
             <button key={d.id} className="ds-dog-card surface-row--interactive interactive-row-card" type="button" onClick={() => onSelect(d.id)}>
               <span className="interactive-row-card__icon"><PawIcon size={30} /></span>
@@ -147,33 +188,7 @@ export function DogSelect({ dogs, onSelect, onCreateNew }) {
               <div className="ds-dog-arrow interactive-row-card__trailing">›</div>
             </button>
           ))}
-          <div className="ds-divider">
-            <div className="ds-divider-line" /><div className="ds-divider-text">or</div><div className="ds-divider-line" />
-          </div>
         </>}
-
-        <button className="ds-btn button-base button-primary button--lg button-size-primary-cta button--block" onClick={onCreateNew}>
-          <PawIcon size={20} color="rgba(255,255,255,0.85)" /> Add a new dog
-        </button>
-
-        <div className="ds-section-label u-mt-section-tight">Join with a dog ID</div>
-        <div className="ds-note">Dog IDs are case-insensitive — matched automatically regardless of case.</div>
-        <div className="t-helper u-mb-card-row">
-          Use the same ID from your partner's phone to track the same dog together.
-        </div>
-        <div className="ds-join-row">
-          <input
-            className="ds-join-input"
-            placeholder="e.g. LUNA-4829"
-            value={joinId}
-            onChange={(e) => { setJoinId(e.target.value); setJoinError(""); }}
-            onKeyDown={(e) => e.key === "Enter" && joinId.trim() && handleJoin()}
-            maxLength={14}
-          />
-          <button className="ds-join-btn" onClick={handleJoin}>Join →</button>
-        </div>
-        {joinError && <div className="ds-join-error">{joinError}</div>}
-        <div className="ds-join-hint">Find the ID in PawTimer → Settings tab.</div>
       </div>
     </div>
   );

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -179,6 +179,33 @@
   .ds-title { font-size:var(--type-hero-title-size); font-weight:var(--type-hero-title-weight); color:var(--brown); line-height:var(--type-hero-title-line); letter-spacing:var(--type-hero-title-track); position:relative; z-index:1; }
   .ds-sub { font-size:var(--type-hero-subtitle-size); font-weight:var(--type-hero-subtitle-weight); color:var(--text-muted); margin-top:8px; position:relative; z-index:1; line-height:var(--type-hero-subtitle-line); letter-spacing:var(--type-hero-subtitle-track); }
   .ds-body { padding:var(--space-3); flex:1; overflow-x:hidden; }
+  .ds-path-grid { display:grid; grid-template-columns:1fr; gap:var(--space-control-gap); margin-bottom:var(--space-section-gap); }
+  .ds-path-card {
+    border:1px solid color-mix(in srgb, var(--border) 86%, var(--warm-accent-border));
+    border-radius:16px;
+    padding:var(--space-card-padding);
+    background:linear-gradient(180deg, var(--surf) 0%, color-mix(in srgb, var(--surface-muted) 20%, var(--warm-accent-soft)) 100%);
+    text-align:left;
+    color:var(--text);
+    cursor:pointer;
+    transition:transform var(--motion-press) var(--ease-out), border-color var(--motion-base) var(--ease-out), box-shadow var(--motion-base) var(--ease-out), background var(--motion-base) var(--ease-out);
+  }
+  .ds-path-card:hover { border-color:color-mix(in srgb, var(--mutedBlue) 46%, var(--border)); box-shadow:var(--shadow); }
+  .ds-path-card.selected { border-color:var(--mutedBlue); box-shadow:var(--surface-focus-shadow-soft); }
+  .ds-path-title { font-size:var(--type-list-row-title-size); line-height:var(--type-list-row-title-line); font-weight:var(--type-list-row-title-weight); letter-spacing:var(--type-list-row-title-track); color:var(--brown); }
+  .ds-path-copy { margin-top:6px; color:var(--text-muted); font-size:var(--type-secondary-size); line-height:var(--type-secondary-line); font-weight:var(--type-secondary-weight); }
+  .ds-join-panel {
+    border:1px solid color-mix(in srgb, var(--border) 88%, var(--mutedBlue));
+    border-radius:16px;
+    padding:0 var(--space-card-padding);
+    margin-bottom:var(--space-section-gap);
+    max-height:0;
+    opacity:0;
+    overflow:hidden;
+    transform:translateY(-4px);
+    transition:max-height 280ms var(--ease-out), opacity 220ms var(--ease-out), transform 280ms var(--ease-out), padding 280ms var(--ease-out);
+  }
+  .ds-join-panel.is-open { max-height:260px; opacity:1; transform:translateY(0); padding:var(--space-card-padding); }
   .ds-section-label { font-size:var(--type-section-eyebrow-size); letter-spacing:var(--type-section-eyebrow-track); color:var(--text-muted); font-weight:var(--type-section-eyebrow-weight); line-height:var(--type-section-eyebrow-line); margin-bottom:var(--space-card-row-gap); text-transform:uppercase; }
   .ds-dog-card { margin-bottom:var(--space-card-row-gap); }
   .ds-dog-name { font-size:var(--type-list-row-title-size); color:var(--brown); font-weight:var(--type-list-row-title-weight); line-height:var(--type-list-row-title-line); letter-spacing:var(--type-list-row-title-track); }


### PR DESCRIPTION
### Motivation
- Provide a clean, low-cognitive-load entry that makes the two primary onboarding flows explicit: creating a new dog or joining an existing dog by ID.
- Make the join-by-ID path feel trustworthy and deliberate while keeping the same dog-focused tone and design language used across the app.

### Description
- Reworked the `DogSelect` UI to include two prominent action cards: `Create new dog` (immediately invokes the onboarding flow) and `Join existing dog by ID` (reveals a dedicated join panel). (src/features/setup/SetupScreens.jsx)
- Kept existing quick-select dog cards for returning users and reused the existing join validation and wiring (`onSelect(id, true)`) so both flows are fully connected. (src/features/setup/SetupScreens.jsx)
- Added styles and interaction states for the decision surface and join panel, including hover/selected states and a smooth expand/collapse transition for the join panel (`.ds-path-card`, `.ds-join-panel`). (src/styles/app.css)
- Minimal copy adjustments to reduce cognitive load and reinforce a dog-specific, reassuring tone without changing data or sync behavior. (src/features/setup/SetupScreens.jsx)

### Testing
- Ran unit tests with `npm run test` and all tests passed: 17 test files, 230 tests (230 passed).
- Built the production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c3f5c7b883329d2f97a76e9e1528)