### PR TITLE
Implement dog-first create-dog onboarding flow

### DIFF
--- a/src/features/setup/SetupScreens.jsx
+++ b/src/features/setup/SetupScreens.jsx
@@ -2,6 +2,13 @@ import { useState } from "react";
 import { CALM_DURATIONS, GOAL_DURATIONS, LEAVE_OPTIONS } from "../app/helpers";
 import { PawIcon } from "../app/ui";
 
+const CREATE_DOG_STEPS = [
+  { key: "name", progressLabel: "Step 1 of 4" },
+  { key: "leaving", progressLabel: "Step 2 of 4" },
+  { key: "calm", progressLabel: "Step 3 of 4" },
+  { key: "goal", progressLabel: "Step 4 of 4" },
+];
+
 export function WelcomeScreen({ onStart, onManageDogs }) {
   return (
     <div className="welcome-screen">
@@ -42,8 +49,9 @@ export function Onboarding({ onComplete, onBack }) {
   const [goal, setGoal] = useState(null);
 
   const cleanName = name.replace(/\s+/g, " ").trim();
-  const canNext = [cleanName.length >= 1, leaves !== null, calm !== null, goal !== null][step];
+  const canNext = [cleanName.length >= 1, leaves !== null, calm !== null, true][step];
   const displayName = cleanName || "your dog";
+  const activeStep = CREATE_DOG_STEPS[step];
 
   const handleNext = () => {
     if (step < 3) setStep((s) => s + 1);
@@ -54,56 +62,60 @@ export function Onboarding({ onComplete, onBack }) {
     <div className="onboarding">
       <div className="ob-hero">
         <div className="ob-hero-icon"><PawIcon size={48} /></div>
-        <div className="ob-title">PawTimer</div>
-        <div className="ob-subtitle">Set up {displayName}'s calm plan in 4 quick steps.</div>
+        <div className="ob-eyebrow">Create dog</div>
+        <div className="ob-title">{displayName === "your dog" ? "Start a calm journey" : `${displayName}'s calm journey`}</div>
+        <div className="ob-subtitle">{activeStep.progressLabel} • One focused choice at a time.</div>
         <div className="ob-step-indicator">
           {[0, 1, 2, 3].map((i) => <div key={i} className={`ob-step-dot ${i < step ? "done" : i === step ? "active" : ""}`} />)}
         </div>
       </div>
       <div className="ob-body">
-        {step === 0 && <>
-          <div className="ob-question">What's your dog's name?</div>
-          <div className="ob-note prose">Names are case-insensitive, and we'll keep your dog's natural spelling.</div>
-          <div className="ob-hint">Used across Train, History, Progress, and Settings.</div>
-          <input className="ob-input" placeholder="e.g. Luna, Maximilian…" value={name} onChange={(e) => setName(e.target.value)} onKeyDown={(e) => e.key === "Enter" && canNext && handleNext()} autoFocus />
-        </>}
-        {step === 1 && <>
-          <div className="ob-question">How often do you leave the house per day?</div>
-          <div className="ob-hint">Shapes daily support routine suggestions.</div>
-          <div className="ob-options">
-            {LEAVE_OPTIONS.map((o) => (
-              <button key={o.value} className={`ob-option ${leaves === o.value ? "selected" : ""}`} onClick={() => setLeaves(o.value)}>
-                <div><div className="ob-option-label">{o.label}</div><div className="ob-option-sub">{o.sub}</div></div>
-              </button>
-            ))}
-          </div>
-        </>}
-        {step === 2 && <>
-          <div className="ob-question">How long can {displayName} stay calm alone now?</div>
-          <div className="ob-hint">Train starts near 80% and adapts to calm streaks and stress signs.</div>
-          <div className="ob-duration-grid">
-            {CALM_DURATIONS.map((d) => (
-              <button key={d.value} className={`ob-dur-btn ${calm === d.value ? "selected" : ""}`} onClick={() => setCalm(d.value)}>
-                <div className="ob-dur-val">{d.label}</div><div className="ob-dur-lbl">{d.sub}</div>
-              </button>
-            ))}
-          </div>
-        </>}
-        {step === 3 && <>
-          <div className="ob-question">What's the goal for {displayName}?</div>
-          <div className="ob-hint">Training is gradual. You can change this any time.</div>
-          <div className="ob-duration-grid">
-            {GOAL_DURATIONS.map((d) => (
-              <button key={d.value} className={`ob-dur-btn ${goal === d.value ? "selected" : ""}`} onClick={() => setGoal(d.value)}>
-                <div className="ob-dur-val">{d.label}</div><div className="ob-dur-lbl">{d.sub}</div>
-              </button>
-            ))}
-          </div>
-        </>}
+        <div key={step} className="ob-step-panel">
+          {step === 0 && <>
+            <div className="ob-question">Who are we training with today?</div>
+            <div className="ob-note prose">Your dog's name personalizes every cue and progress view.</div>
+            <div className="ob-hint">You can update this later in settings if needed.</div>
+            <input className="ob-input" placeholder="e.g. Luna, Mochi, Rocco…" value={name} onChange={(e) => setName(e.target.value)} onKeyDown={(e) => e.key === "Enter" && canNext && handleNext()} autoFocus />
+          </>}
+          {step === 1 && <>
+            <div className="ob-question">How often is {displayName} home alone?</div>
+            <div className="ob-hint">This helps shape your weekly rhythm and guidance intensity.</div>
+            <div className="ob-options">
+              {LEAVE_OPTIONS.map((o) => (
+                <button key={o.value} className={`ob-option ${leaves === o.value ? "selected" : ""}`} onClick={() => setLeaves(o.value)}>
+                  <div><div className="ob-option-label">{o.label}</div><div className="ob-option-sub">{o.sub}</div></div>
+                </button>
+              ))}
+            </div>
+          </>}
+          {step === 2 && <>
+            <div className="ob-question">How long does {displayName} stay calm right now?</div>
+            <div className="ob-hint">We'll start gently from this baseline and build calm confidence over time.</div>
+            <div className="ob-duration-grid">
+              {CALM_DURATIONS.map((d) => (
+                <button key={d.value} className={`ob-dur-btn ${calm === d.value ? "selected" : ""}`} onClick={() => setCalm(d.value)}>
+                  <div className="ob-dur-val">{d.label}</div><div className="ob-dur-lbl">{d.sub}</div>
+                </button>
+              ))}
+            </div>
+          </>}
+          {step === 3 && <>
+            <div className="ob-question">Choose a future calm goal for {displayName}</div>
+            <div className="ob-note prose">Optional: skip for now and set this after a few sessions.</div>
+            <div className="ob-hint">Goals keep motivation high — training still works even without one.</div>
+            <div className="ob-duration-grid">
+              {GOAL_DURATIONS.map((d) => (
+                <button key={d.value} className={`ob-dur-btn ${goal === d.value ? "selected" : ""}`} onClick={() => setGoal(d.value)}>
+                  <div className="ob-dur-val">{d.label}</div><div className="ob-dur-lbl">{d.sub}</div>
+                </button>
+              ))}
+            </div>
+          </>}
+        </div>
       </div>
       <div className="ob-footer">
         <button className="ob-btn-next button-base button-primary button--lg button-size-primary-cta button--block" onClick={handleNext} disabled={!canNext}>
-          {step < 3 ? "Continue →" : `Start training with ${displayName}`}
+          {step < 3 ? "Continue →" : `Begin ${displayName}'s plan`}
         </button>
         <button className="ob-back-btn" onClick={() => step === 0 ? onBack?.() : setStep((s) => s - 1)}>
           ← {step === 0 ? "Back to dogs" : "Back"}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -230,6 +230,17 @@
   .ob-hero { background:linear-gradient(180deg,var(--surface-hero-top) 0%,var(--bg) 72%); padding:44px 24px 22px; position:relative; overflow:hidden; }
   .ob-hero::before { content:''; position:absolute; top:-60px; right:-60px; width:240px; height:240px; background:radial-gradient(circle,rgba(184,224,199,0.24) 0%,transparent 72%); border-radius:50%; }
   .ob-hero-icon { position:relative; z-index:1; margin-bottom:12px; }
+  .ob-eyebrow {
+    font-size:var(--type-section-eyebrow-size);
+    color:var(--text-muted);
+    text-transform:uppercase;
+    letter-spacing:var(--type-section-eyebrow-track);
+    font-weight:var(--type-section-eyebrow-weight);
+    line-height:var(--type-section-eyebrow-line);
+    position:relative;
+    z-index:1;
+    margin-bottom:8px;
+  }
   .ob-title { font-size:var(--type-hero-title-size); font-weight:var(--type-hero-title-weight); color:var(--brown); line-height:var(--type-hero-title-line); letter-spacing:var(--type-hero-title-track); position:relative; z-index:1; }
   .ob-subtitle { font-size:var(--type-hero-subtitle-size); color:var(--text-muted); margin-top:10px; line-height:var(--type-hero-subtitle-line); letter-spacing:var(--type-hero-subtitle-track); font-weight:var(--type-hero-subtitle-weight); position:relative; z-index:1; }
   .ob-step-indicator { display:flex; gap:6px; margin-top:20px; position:relative; z-index:1; }
@@ -237,6 +248,10 @@
   .ob-step-dot.active { background:var(--brown); }
   .ob-step-dot.done   { background:var(--green-dark); }
   .ob-body { padding:var(--space-card-padding-lg); flex:1; }
+  .ob-step-panel {
+    animation: ob-step-enter 280ms var(--ease-out-soft, ease-out) both;
+    will-change: transform, opacity;
+  }
   .ob-question { font-size:var(--type-section-heading-size); font-weight:var(--type-section-heading-weight); color:var(--brown); margin-bottom:var(--space-card-row-gap); line-height:var(--type-section-heading-line); letter-spacing:var(--type-section-heading-track); }
   .ob-hint { font-size:var(--type-body-size); color:var(--text-muted); margin-bottom:var(--space-section-gap); line-height:var(--type-body-line); letter-spacing:var(--type-body-track); font-weight:var(--type-body-weight); }
   .ob-note { font-size:var(--type-overline-size); color:var(--primaryBlue); background:var(--softBlue); border:1px solid var(--softBlueBorder); border-left:3px solid var(--mutedBlue); border-radius:0 var(--radius-sm) var(--radius-sm) 0; padding:var(--space-inline-control-padding); margin-bottom:var(--space-card-row-gap); line-height:var(--type-overline-line); letter-spacing:var(--type-overline-track); font-weight:var(--type-overline-weight); text-transform:uppercase; }
@@ -257,6 +272,10 @@
   .ob-btn-next { transition:opacity 0.2s; }
 
   .ob-btn-next:disabled { opacity:0.22; cursor:default; }
+  @keyframes ob-step-enter {
+    from { opacity:0; transform:translateY(8px); }
+    to { opacity:1; transform:translateY(0); }
+  }
   .ob-back-btn {
     --small-tertiary-size:44px;
     border-radius:999px;


### PR DESCRIPTION
### Motivation
- Convert the generic setup into a dog-first, journey-oriented create-dog onboarding that feels like a calm training path rather than a long form. 
- Use progressive disclosure so each screen requests one focused choice (name, leaving frequency, current calm, optional future goal) to avoid a giant-form feeling. 
- Make the future goal explicitly optional and provide contextual hints to keep the flow friendly and motivating. 
- Add subtle transitions and minimal visual polish to keep the UI calm, premium, and smooth between steps.

### Description
- Added `CREATE_DOG_STEPS` metadata and `activeStep` handling to centralize step labels and progress text. (modified `src/features/setup/SetupScreens.jsx`).
- Rewrote onboarding copy to use dog-first language and progressive-disclosure phrasing across the four focused steps. (modified `src/features/setup/SetupScreens.jsx`).
- Made the final step (goal) optional by changing `canNext` to allow completion without a selected goal, and kept the complete payload (`dogName`, `leavesPerDay`, `currentMaxCalm`, `goalSeconds`). (modified `src/features/setup/SetupScreens.jsx`).
- Wrapped step content in a keyed `ob-step-panel` and added `ob-eyebrow` copy, an enter animation (`ob-step-enter`) and related CSS for a smooth step transition and subtle visual polish. (modified `src/styles/app.css`).
- Updated the final CTA copy to read `Begin <dog>'s plan` for clearer journey-first language. (modified `src/features/setup/SetupScreens.jsx`).

### Testing
- Ran the test suite with `npm run test` and all automated tests passed. 
- Test summary: `17 files` collected and `230 tests` passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c82a1a9883329b20928e7c6b22b4)