### PR TITLE
Join-by-ID flow: soft validation, lookup preview, and confirmation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -814,13 +814,46 @@ export default function PawTimer() {
 
   const openDog = (dog) => { logSyncDebug("openDog", { dogId: canonicalDogId(dog?.id) }); setOnboardingState(null); setActiveDogId(canonicalDogId(dog.id)); setScreen("app"); };
 
-  const handleDogSelect = async (id, isJoin = false) => {
+  const handleDogSelect = async (id, isJoin = false, options = {}) => {
     const normalizedId = canonicalDogId(id);
+    const mode = options?.mode || "join";
+    const isPreview = mode === "preview";
+    if (isPreview && isJoin) {
+      const localDog = dogs.find((dog) => canonicalDogId(dog.id) === normalizedId)
+        ?? ensureArray(load(DOGS_KEY, [])).find((dog) => canonicalDogId(dog.id) === normalizedId);
+      if (localDog) {
+        return {
+          ok: true,
+          normalizedId,
+          dogName: localDog?.dogName || "Shared dog profile",
+          source: "Already on this device",
+        };
+      }
+      if (!SYNC_ENABLED) {
+        return { ok: false, message: "Sync is currently unavailable on this device." };
+      }
+      const { result: remote, error } = await syncFetch(normalizedId);
+      setSyncDegradation(getSyncDegradationState());
+      if (!remote?.dog) {
+        return { ok: false, message: error || `No shared profile found for ${normalizedId} yet.` };
+      }
+      return {
+        ok: true,
+        normalizedId,
+        dogName: remote?.dog?.dogName || "Shared dog profile",
+        source: remote?.syncCapability?.mode === "partial" ? "Shared profile (partial sync)" : "Shared profile",
+      };
+    }
     if (isJoin && SYNC_ENABLED) {
       setSyncStatus("syncing");
       const { result: remote, error } = await syncFetch(normalizedId);
       setSyncDegradation(getSyncDegradationState());
-      if (!remote?.dog) { setSyncStatus("err"); setSyncError(error || `No shared dog account found for ${normalizedId}`); showToast(`No shared profile found for ${normalizedId} yet.`); return; }
+      if (!remote?.dog) {
+        setSyncStatus("err");
+        setSyncError(error || `No shared dog account found for ${normalizedId}`);
+        showToast(`No shared profile found for ${normalizedId} yet.`);
+        return { ok: false, message: `No shared profile found for ${normalizedId} yet.` };
+      }
       const sharedDog = normalizeDogSyncMetadata({ ...remote.dog, id: normalizedId });
       setDogs((prev) => {
         const existing = prev.find((d) => canonicalDogId(d.id) === normalizedId) ?? null;
@@ -889,12 +922,19 @@ export default function PawTimer() {
         showToast(`Joined shared profile ${normalizedId}.`);
       }
       openDog(sharedDog);
-      return;
+      return { ok: true, normalizedId, dogName: sharedDog?.dogName || "Shared dog profile" };
     }
     const existing = dogs.find((d) => canonicalDogId(d.id) === normalizedId) ?? ensureArray(load(DOGS_KEY, [])).find((d) => canonicalDogId(d.id) === normalizedId);
-    if (existing) { openDog(existing); return; }
-    if (isJoin) { setSyncStatus("err"); setSyncError(`No shared dog account found for ${normalizedId}`); showToast(`No shared profile found for ${normalizedId}. Check the ID and try again.`); }
-    else { setOnboardingState({ mode: "claim", dogId: normalizedId }); setActiveDogId(normalizedId); setScreen("onboard"); }
+    if (existing) { openDog(existing); return { ok: true, normalizedId, dogName: existing?.dogName || "Shared dog profile" }; }
+    if (isJoin) {
+      setSyncStatus("err");
+      setSyncError(`No shared dog account found for ${normalizedId}`);
+      showToast(`No shared profile found for ${normalizedId}. Check the ID and try again.`);
+      return { ok: false, message: `No shared profile found for ${normalizedId}.` };
+    } else {
+      setOnboardingState({ mode: "claim", dogId: normalizedId }); setActiveDogId(normalizedId); setScreen("onboard");
+      return { ok: true, normalizedId };
+    }
   };
 
   const handleOnboardComplete = (data) => {

--- a/src/features/setup/SetupScreens.jsx
+++ b/src/features/setup/SetupScreens.jsx
@@ -127,17 +127,50 @@ export function Onboarding({ onComplete, onBack }) {
 
 export function DogSelect({ dogs, onSelect, onCreateNew }) {
   const [joinId, setJoinId] = useState("");
-  const [joinError, setJoinError] = useState("");
+  const [joinState, setJoinState] = useState({ status: "idle", message: "", preview: null });
   const [activePath, setActivePath] = useState(null);
+  const [isLookingUp, setIsLookingUp] = useState(false);
 
-  const handleJoin = () => {
-    const id = joinId.trim().toUpperCase();
-    if (id.length < 3 || !id.includes("-")) {
-      setJoinError("Enter a valid dog ID — e.g. LUNA-4829");
+  const normalizeJoinId = (value) => value.replace(/[^a-zA-Z0-9-]/g, "").replace(/\s+/g, "").toUpperCase();
+  const hasValidShape = (value) => value.length >= 4 && /[A-Z]/.test(value) && /\d/.test(value) && value.includes("-");
+
+  const validateJoinId = (value) => {
+    if (!value) return "Enter the shared ID to continue.";
+    if (!value.includes("-")) return "Include the dash in the shared ID (example: LUNA-4829).";
+    if (value.length < 4) return "That ID looks short — please check and try again.";
+    if (!/[A-Z]/.test(value) || !/\d/.test(value)) return "Use letters and numbers from the shared ID.";
+    return "";
+  };
+
+  const handleLookup = async () => {
+    const normalized = normalizeJoinId(joinId);
+    const softValidation = validateJoinId(normalized);
+    if (softValidation) {
+      setJoinState({ status: "invalid", message: softValidation, preview: null });
       return;
     }
-    setJoinError("");
-    onSelect(id, true);
+    if (typeof onSelect !== "function") return;
+    setIsLookingUp(true);
+    const result = await onSelect(normalized, true, { mode: "preview" });
+    if (result?.ok) {
+      setJoinState({
+        status: "ready",
+        message: "Looks good. Review and confirm to join this profile.",
+        preview: result,
+      });
+    } else {
+      setJoinState({
+        status: "not-found",
+        message: result?.message || "We couldn't find that shared ID yet. Please check and retry.",
+        preview: null,
+      });
+    }
+    setIsLookingUp(false);
+  };
+
+  const handleJoinConfirm = async () => {
+    if (!joinState.preview?.normalizedId) return;
+    await onSelect(joinState.preview.normalizedId, true, { mode: "join", preview: joinState.preview });
   };
 
   return (
@@ -172,20 +205,46 @@ export function DogSelect({ dogs, onSelect, onCreateNew }) {
 
         <div className={`ds-join-panel ${activePath === "join" ? "is-open" : ""}`}>
           <div className="ds-section-label">Join with a dog ID</div>
-          <div className="ds-note">IDs are unique and matched securely, case-insensitive.</div>
+          <div className="ds-note">
+            This shared ID connects one household's dog profile across devices.
+            You'll usually receive it from your partner, trainer, or whoever created the profile in Settings.
+          </div>
           <div className="ds-join-row">
             <input
               className="ds-join-input"
               placeholder="e.g. LUNA-4829"
               value={joinId}
-              onChange={(e) => { setJoinId(e.target.value); setJoinError(""); }}
-              onKeyDown={(e) => e.key === "Enter" && joinId.trim() && handleJoin()}
+              onChange={(e) => {
+                setJoinId(e.target.value);
+                if (joinState.status !== "idle") setJoinState({ status: "idle", message: "", preview: null });
+              }}
+              onBlur={() => {
+                const normalized = normalizeJoinId(joinId);
+                const softValidation = validateJoinId(normalized);
+                if (joinId && softValidation) setJoinState({ status: "invalid", message: softValidation, preview: null });
+              }}
+              onKeyDown={(e) => e.key === "Enter" && joinId.trim() && handleLookup()}
               maxLength={14}
             />
-            <button className="ds-join-btn" onClick={handleJoin}>Join →</button>
+            <button className="ds-join-btn" onClick={handleLookup} disabled={isLookingUp || !hasValidShape(normalizeJoinId(joinId))}>
+              {isLookingUp ? "Checking…" : "Check ID"}
+            </button>
           </div>
-          {joinError && <div className="ds-join-error">{joinError}</div>}
-          <div className="ds-join-hint">Find this ID in PawTimer → Settings.</div>
+          {joinState.message && <div className={`ds-join-feedback ds-join-feedback--${joinState.status}`}>{joinState.message}</div>}
+          {joinState.status === "ready" && joinState.preview && (
+            <div className="ds-join-confirm-card">
+              <div className="ds-join-confirm-eyebrow">Ready to join</div>
+              <div className="ds-join-confirm-title">{joinState.preview.dogName || "Shared dog profile"}</div>
+              <div className="ds-join-confirm-copy">
+                ID: {joinState.preview.normalizedId}
+                {joinState.preview.source ? ` • ${joinState.preview.source}` : ""}
+              </div>
+              <button className="ds-join-btn ds-join-confirm-btn" type="button" onClick={handleJoinConfirm}>
+                Confirm and join
+              </button>
+            </div>
+          )}
+          <div className="ds-join-hint">Find this ID in PawTimer → Settings → Sync devices.</div>
         </div>
 
         {dogs.length > 0 && <>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -205,7 +205,7 @@
     transform:translateY(-4px);
     transition:max-height 280ms var(--ease-out), opacity 220ms var(--ease-out), transform 280ms var(--ease-out), padding 280ms var(--ease-out);
   }
-  .ds-join-panel.is-open { max-height:260px; opacity:1; transform:translateY(0); padding:var(--space-card-padding); }
+  .ds-join-panel.is-open { max-height:540px; opacity:1; transform:translateY(0); padding:var(--space-card-padding); }
   .ds-section-label { font-size:var(--type-section-eyebrow-size); letter-spacing:var(--type-section-eyebrow-track); color:var(--text-muted); font-weight:var(--type-section-eyebrow-weight); line-height:var(--type-section-eyebrow-line); margin-bottom:var(--space-card-row-gap); text-transform:uppercase; }
   .ds-dog-card { margin-bottom:var(--space-card-row-gap); }
   .ds-dog-name { font-size:var(--type-list-row-title-size); color:var(--brown); font-weight:var(--type-list-row-title-weight); line-height:var(--type-list-row-title-line); letter-spacing:var(--type-list-row-title-track); }
@@ -224,6 +224,27 @@
   .ds-join-btn { padding:var(--space-inline-control-padding); white-space:nowrap; }
   .ds-join-hint { font-size:var(--type-helper-text-size); color:var(--text-muted); margin-top:var(--space-card-row-gap); line-height:var(--type-helper-text-line); font-weight:var(--type-helper-text-weight); letter-spacing:var(--type-helper-text-track); }
   .ds-join-error { font-size:var(--type-helper-text-size); line-height:var(--type-helper-text-line); font-weight:var(--type-helper-text-weight); letter-spacing:var(--type-helper-text-track); color:var(--red); margin-top:var(--space-card-row-gap); }
+  .ds-join-feedback { margin-top:var(--space-card-row-gap); font-size:var(--type-helper-text-size); line-height:var(--type-helper-text-line); font-weight:var(--type-helper-text-weight); letter-spacing:var(--type-helper-text-track); }
+  .ds-join-feedback--invalid, .ds-join-feedback--not-found { color:var(--red); }
+  .ds-join-feedback--ready { color:var(--green-dark); }
+  .ds-join-confirm-card {
+    margin-top:var(--space-card-row-gap);
+    padding:var(--space-inline-control-padding);
+    border-radius:var(--radius-md);
+    border:1px solid color-mix(in srgb, var(--green-dark) 26%, var(--border));
+    background:color-mix(in srgb, var(--surface-muted) 74%, var(--green-soft));
+  }
+  .ds-join-confirm-eyebrow {
+    font-size:var(--type-overline-size);
+    line-height:var(--type-overline-line);
+    font-weight:var(--type-overline-weight);
+    letter-spacing:var(--type-overline-track);
+    color:var(--text-muted);
+    text-transform:uppercase;
+  }
+  .ds-join-confirm-title { margin-top:4px; font-size:var(--type-body-lg-size); font-weight:var(--type-body-lg-weight); line-height:var(--type-body-lg-line); color:var(--brown); }
+  .ds-join-confirm-copy { margin-top:4px; font-size:var(--type-helper-text-size); color:var(--text-muted); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); font-weight:var(--type-helper-text-weight); }
+  .ds-join-confirm-btn { margin-top:var(--space-card-row-gap); width:100%; }
 
   /* ── Onboarding ── */
   .onboarding { max-width:480px; margin:0 auto; min-height:100vh; padding-bottom:40px; display:flex; flex-direction:column; background:var(--bg); overflow-x:hidden; }


### PR DESCRIPTION
### Motivation
- Provide a calm, clear two-step flow for joining an existing dog by ID so users can validate what they are joining before committing.
- Avoid harsh error popups by using soft inline validation and gentle recovery states that match the app design system.
- Surface contextual help about what the shared ID is and where it comes from to reduce confusion during setup.

### Description
- Add a lookup-and-confirm UX in `DogSelect` including `normalizeJoinId`, `validateJoinId`, `handleLookup`, and `handleJoinConfirm`, plus `joinState` and `isLookingUp` state to drive inline feedback and a confirmation card (`src/features/setup/SetupScreens.jsx`).
- Extend `handleDogSelect` to accept an `options` object and support a preview mode (`mode: "preview"`) that returns a structured result for UI preview while preserving the existing join behavior (`mode: "join"`) (`src/App.jsx`).
- Update styles to expand the join panel and add feedback / confirmation visuals (`.ds-join-feedback`, `.ds-join-confirm-card`, etc.) so the flow remains consistent with the design system (`src/styles/app.css`).

### Testing
- Built the app with `npm run build` and the build completed successfully.
- Ran the test suite with `npm run test` and all automated tests passed (`17` test files, `230` tests total, all passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ca1c94b88332a9485a55a177c671)