### PR TITLE
Add first-run Train guidance overlay and inline hint

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,6 +68,7 @@ export default function PawTimer() {
   const [protoOverride, setProtoOverride] = useState(() => ensureObject(load("pawtimer_proto_override", {})));
   const [settingsDisclosure, setSettingsDisclosure] = useState(null);
   const [trainingSettingsOpen, setTrainingSettingsOpen] = useState(false);
+  const [trainFirstRunHintVisible, setTrainFirstRunHintVisible] = useState(false);
   const [walkPhase, setWalkPhase] = useState("idle");
   const [walkElapsed, setWalkElapsed] = useState(0);
   const [walkPendingDuration, setWalkPendingDuration] = useState(0);
@@ -213,6 +214,10 @@ export default function PawTimer() {
     () => dogs.find((d) => canonicalDogId(d.id) === canonicalDogId(activeDogId)) ?? null,
     [activeDogId, dogs],
   );
+  const trainFirstRunHintKey = useMemo(
+    () => (activeDogId ? `pawtimer_train_intro_seen_v1_${canonicalDogId(activeDogId)}` : null),
+    [activeDogId],
+  );
   const canonicalSessions = useMemo(() => sortValidDateAsc(sessions), [sessions]);
   const deriveRecommendation = useCallback((nextSessions, nextWalks = walks, nextPatterns = patterns, nextDog = activeDog || {}) => {
     const logicalSessions = sortValidDateAsc(nextSessions);
@@ -251,6 +256,22 @@ export default function PawTimer() {
   useEffect(() => {
     setTarget((prev) => (prev === recommendation.duration ? prev : recommendation.duration));
   }, [recommendation.duration]);
+
+  useEffect(() => {
+    if (!activeDogId || !trainFirstRunHintKey) {
+      setTrainFirstRunHintVisible(false);
+      return;
+    }
+    const hasSessions = canonicalSessions.length > 0;
+    const hasSeenHint = load(trainFirstRunHintKey, false) === true;
+    setTrainFirstRunHintVisible(!hasSeenHint && !hasSessions);
+  }, [activeDogId, canonicalSessions.length, trainFirstRunHintKey]);
+
+  const completeTrainFirstRunHint = useCallback(() => {
+    if (!trainFirstRunHintKey) return;
+    save(trainFirstRunHintKey, true);
+    setTrainFirstRunHintVisible(false);
+  }, [trainFirstRunHintKey]);
 
   const reportLocalWriteFailure = useCallback((errorMessage) => {
     setSyncStatus("err");
@@ -962,6 +983,7 @@ export default function PawTimer() {
       else if (appData.daily.blockReason === "max_sessions") showToast(`Daily session max reached (${appData.daily.maxCount}).`);
       return;
     }
+    completeTrainFirstRunHint();
     setElapsed(0); setSessionCompleted(false); setSessionOutcome(null); setLatencyDraft(""); setDistressTypeDraft(""); setPhase("running");
   };
   const endSession = () => { clearInterval(timerRef.current); setFinalElapsed(elapsed); setPhase("rating"); };
@@ -1162,7 +1184,7 @@ export default function PawTimer() {
           </div>
         </div>
 
-        {tab === "home" && <HomeScreen name={appData.name} sessions={canonicalSessions} recommendation={appData.recommendation} goalPct={appData.goalPct} goalSec={appData.goalSec} phase={phase} elapsed={elapsed} finalElapsed={finalElapsed} sessionCompleted={sessionCompleted} sessionOutcome={sessionOutcome} setSessionOutcome={setSessionOutcome} recordResult={recordResult} latencyDraft={latencyDraft} setLatencyDraft={setLatencyDraft} distressTypeDraft={distressTypeDraft} setDistressTypeDraft={setDistressTypeDraft} setPhase={setPhase} setElapsed={setElapsed} setFinalElapsed={setFinalElapsed} startSession={startSession} endSession={endSession} cancelSession={cancelSession} activeProto={appData.activeProto} daily={appData.daily} pattern={appData.pattern} walkPhase={walkPhase} startWalk={startWalk} cancelWalk={cancelWalk} walkElapsed={walkElapsed} endWalk={endWalk} walkPendingDuration={walkPendingDuration} saveWalkWithType={saveWalkWithType} patOpen={patOpen} setPatOpen={setPatOpen} patReminderText={appData.patReminderText} logPattern={logPattern} patLabels={patLabels} patterns={patterns} feedings={feedings} feedingOpen={feedingOpen} openFeedingForm={openFeedingForm} feedingDraft={feedingDraft} setFeedingDraft={setFeedingDraft} cancelFeedingForm={cancelFeedingForm} saveFeeding={saveFeeding} />}
+        {tab === "home" && <HomeScreen name={appData.name} sessions={canonicalSessions} recommendation={appData.recommendation} goalPct={appData.goalPct} goalSec={appData.goalSec} phase={phase} elapsed={elapsed} finalElapsed={finalElapsed} sessionCompleted={sessionCompleted} sessionOutcome={sessionOutcome} setSessionOutcome={setSessionOutcome} recordResult={recordResult} latencyDraft={latencyDraft} setLatencyDraft={setLatencyDraft} distressTypeDraft={distressTypeDraft} setDistressTypeDraft={setDistressTypeDraft} setPhase={setPhase} setElapsed={setElapsed} setFinalElapsed={setFinalElapsed} startSession={startSession} endSession={endSession} cancelSession={cancelSession} activeProto={appData.activeProto} daily={appData.daily} pattern={appData.pattern} walkPhase={walkPhase} startWalk={startWalk} cancelWalk={cancelWalk} walkElapsed={walkElapsed} endWalk={endWalk} walkPendingDuration={walkPendingDuration} saveWalkWithType={saveWalkWithType} patOpen={patOpen} setPatOpen={setPatOpen} patReminderText={appData.patReminderText} logPattern={logPattern} patLabels={patLabels} patterns={patterns} feedings={feedings} feedingOpen={feedingOpen} openFeedingForm={openFeedingForm} feedingDraft={feedingDraft} setFeedingDraft={setFeedingDraft} cancelFeedingForm={cancelFeedingForm} saveFeeding={saveFeeding} showTrainFirstRunHint={trainFirstRunHintVisible} dismissTrainFirstRunHint={completeTrainFirstRunHint} />}
         {tab === "history" && <HistoryScreen timeline={appData.timeline} sessions={canonicalSessions} name={appData.name} setTab={setTab} patLabels={patLabels} historyModal={historyModal} setHistoryModal={setHistoryModal} actions={historyActions} />}
         {tab === "progress" && <StatsScreen name={appData.name} totalCount={appData.totalCount} setTab={setTab} bestCalm={appData.bestCalm} recommendation={appData.recommendation} relapseTone={appData.relapseTone} chartData={appData.chartData} goalSec={appData.goalSec} CustomDot={CustomDot} distressLabel={appData.distressLabel} chartTrendLabel={appData.chartTrendLabel} aloneLastWeek={appData.aloneLastWeek} avgWalkDuration={appData.avgWalkDuration} avgSessionsPerDay={appData.avgSessionsPerDay} avgWalksPerDay={appData.avgWalksPerDay} headlineStatus={appData.headlineStatus} headlineStatusTone={appData.headlineStatusTone} />}
         {tab === "settings" && <SettingsScreen name={appData.name} activeDogId={activeDogId} copyDogId={copyDogId} notifEnabled={notifEnabled} handleToggleNotif={handleToggleNotif} notifTime={notifTime} setNotifTime={setNotifTime} scheduleNotif={scheduleNotif} dogs={dogs} activeProto={appData.activeProto} pattern={appData.pattern} recommendation={appData.recommendation} setTrainingSettingsOpen={setTrainingSettingsOpen} patLabels={patLabels} editingPat={editingPat} setEditingPat={setEditingPat} setPatLabels={setPatLabels} settingsDisclosure={settingsDisclosure} setSettingsDisclosure={setSettingsDisclosure} syncDiagRunning={syncDiagRunning} runSyncDiagnostics={runSyncDiagnostics} SYNC_ENABLED={SYNC_ENABLED} SB_URL={SB_URL} SB_KEY={SB_KEY} SB_BASE_URL={SB_BASE_URL} syncDiagResult={syncDiagResult} syncSummary={syncSummary} syncDegradation={syncDegradation} trainingSettingsOpen={trainingSettingsOpen} setProtoWarnAck={setProtoWarnAck} protoWarnAck={protoWarnAck} protoOverride={protoOverride} setProtoOverride={setProtoOverride} setScreen={setScreen} setOnboardingState={setOnboardingState} dogsState={dogs} setDogs={setDogs} save={save} ACTIVE_DOG_KEY={ACTIVE_DOG_KEY} setActiveDogId={setActiveDogId} clearDogActivityState={clearDogActivityState} />}

--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -50,6 +50,8 @@ export default function HomeScreen(props) {
     setFeedingDraft,
     cancelFeedingForm,
     saveFeeding,
+    showTrainFirstRunHint,
+    dismissTrainFirstRunHint,
   } = props;
   const target = recommendation?.duration ?? 0;
   const recoveryMode = recommendation?.details?.recoveryMode;
@@ -117,6 +119,12 @@ export default function HomeScreen(props) {
             <span className="train-focus-strip__meta">{daily.count} logged today</span>
           </button>
         )}
+        {phase === "idle" && showTrainFirstRunHint && (
+          <div className="train-inline-guidance" role="note" aria-live="polite">
+            <span className="train-inline-guidance__label">Target adapts</span>
+            <span className="train-inline-guidance__copy">Calm runs nudge up. Stress signs can step time down.</span>
+          </div>
+        )}
         {showRecoveryInfo && recoveryMode?.active && (
           <div className="quick-modal-overlay" role="dialog" aria-modal="true" onClick={() => setShowRecoveryInfo(false)}>
             <div className="quick-modal-card modal-card modal-card--dialog-md recovery-explain-modal" onClick={(e) => e.stopPropagation()}>
@@ -141,6 +149,27 @@ export default function HomeScreen(props) {
                 <span>{recoveryMode.currentStepLabel || `Step ${Math.max(1, recoveryMode.step)} of ${recoveryMode.totalSessions || 2}`}</span>
                 <span>{recoveryMode.remainingSessions} remaining</span>
               </div>
+            </div>
+          </div>
+        )}
+        {phase === "idle" && showTrainFirstRunHint && (
+          <div className="quick-modal-overlay train-first-run-overlay" role="dialog" aria-modal="true" aria-labelledby="train-first-run-title" onClick={dismissTrainFirstRunHint}>
+            <div className="quick-modal-card modal-card modal-card--dialog-md train-first-run-card" onClick={(e) => e.stopPropagation()}>
+              <div className="train-first-run-card__eyebrow">First training session</div>
+              <div className="quick-modal-title" id="train-first-run-title">How today's target works</div>
+              <p className="train-first-run-card__copy">
+                <strong>{fmtClock(target)}</strong> is your current calm threshold. End while {name} is still calm.
+              </p>
+              <p className="train-first-run-card__copy">
+                Progress is gradual: calm sessions can increase time, stress signs can decrease it to protect confidence.
+              </p>
+              <button
+                type="button"
+                className="button-base button-primary button--md button--pill train-first-run-card__cta"
+                onClick={dismissTrainFirstRunHint}
+              >
+                Got it
+              </button>
             </div>
           </div>
         )}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -451,9 +451,57 @@
   .train-focus-strip__label { font-size:var(--type-helper-text-size); color:var(--text-muted); text-transform:uppercase; letter-spacing:var(--type-helper-text-track); }
   .train-focus-strip__value { font-weight:600; color:var(--brown); }
   .train-focus-strip__meta { font-size:var(--type-helper-text-size); color:var(--text-muted); }
+  .train-inline-guidance {
+    margin-top:10px;
+    padding:10px 12px;
+    border:1px solid color-mix(in srgb, var(--primaryBlue) 24%, var(--border));
+    border-radius:14px;
+    background:linear-gradient(180deg, color-mix(in srgb, var(--surface-muted) 94%, white), color-mix(in srgb, var(--surf) 97%, var(--surface-muted)));
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+    gap:10px;
+  }
+  .train-inline-guidance__label {
+    font-size:var(--type-helper-text-size);
+    font-weight:600;
+    color:var(--primaryBlue);
+    letter-spacing:var(--type-helper-text-track);
+    text-transform:uppercase;
+    white-space:nowrap;
+  }
+  .train-inline-guidance__copy {
+    font-size:var(--type-helper-text-size);
+    color:var(--text-muted);
+    text-align:right;
+  }
   .train-focus-strip--recovery {
     border-color:color-mix(in srgb, var(--warning) 30%, var(--border));
     box-shadow:0 0 0 1px color-mix(in srgb, var(--warning) 15%, transparent);
+  }
+  .train-first-run-overlay { z-index:205; }
+  .train-first-run-card {
+    border:1px solid color-mix(in srgb, var(--primaryBlue) 20%, var(--border));
+    background:linear-gradient(180deg, color-mix(in srgb, var(--surf) 95%, white), color-mix(in srgb, var(--surface-muted) 94%, var(--primaryBlue-weak)));
+    box-shadow:0 18px 38px color-mix(in srgb, var(--surface-overlay-strong) 36%, transparent);
+  }
+  .train-first-run-card__eyebrow {
+    margin-bottom:4px;
+    font-size:var(--type-helper-text-size);
+    color:var(--text-muted);
+    text-transform:uppercase;
+    letter-spacing:var(--type-helper-text-track);
+  }
+  .train-first-run-card__copy {
+    margin:var(--space-card-row-gap) 0 0;
+    color:color-mix(in srgb, var(--brown) 88%, var(--text));
+    font-size:var(--type-list-row-secondary-size);
+    line-height:var(--type-list-row-secondary-line);
+  }
+  .train-first-run-card__copy strong { color:var(--brown); }
+  .train-first-run-card__cta {
+    margin-top:var(--space-card-row-gap);
+    width:100%;
   }
   .ring-sub-btn {
     margin-top:var(--space-card-row-gap);


### PR DESCRIPTION
### Motivation
- Provide a minimal, contextual first-run explanation that appears when a new dog profile first enters Train so users understand what the training target means, that progression is gradual, and that targets can adjust up or down when stress is observed.
- Keep the guidance lightweight and premium: one concise overlay plus a small inline hint rather than a long tutorial wall.

### Description
- Add app-level state and per-dog persistence: `trainFirstRunHintVisible` state and a per-dog localStorage key `pawtimer_train_intro_seen_v1_<DOGID>` to show the guidance exactly once for fresh profiles (`src/App.jsx`).
- Compute hint visibility from `canonicalSessions.length` and stored seen-flag, and expose `completeTrainFirstRunHint` to mark the hint seen and hide it (the hint is also auto-completed when `startSession` is invoked) (`src/App.jsx`).
- Wire the hint into the Train entry by passing `showTrainFirstRunHint` and `dismissTrainFirstRunHint` props into `HomeScreen` (`src/App.jsx`).
- Implement UI: an elegant inline contextual hint near the focus strip and a soft modal overlay card that explains the target, gradual progression, and stress-driven adjustments; the overlay is dismissible and uses the app’s modal styling (`src/features/home/HomeScreen.jsx`).
- Add matching styles for the inline hint and first-run overlay/card to align with the app’s visual language (`src/styles/app.css`).

### Testing
- Built production bundle with `npm run build` and the build completed successfully (noting a chunk-size advisory warning). 
- Ran unit tests with `npm run test` and all test suites passed (`17` test files, `230` tests total).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ce63373083329b094ac16e2caaed)