### PR TITLE
Redesign Train screen into focused calm-session experience

### DIFF
--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -1,4 +1,4 @@
-import { SessionControl, SessionRatingPanel, TrainProgressBar } from "../train/TrainComponents";
+import { SessionControl, SessionRatingPanel } from "../train/TrainComponents";
 import { DISTRESS_TYPES, PATTERN_TYPES, WALK_TYPE_OPTIONS, fmt, fmtClock, isToday, walkTypeLabel } from "../app/helpers";
 import { Img, ModalCloseButton } from "../app/ui";
 import { useState } from "react";
@@ -8,7 +8,6 @@ export default function HomeScreen(props) {
     name,
     sessions,
     recommendation,
-    goalPct,
     goalSec,
     phase,
     elapsed,
@@ -66,6 +65,7 @@ export default function HomeScreen(props) {
     || recommendation?.explanation
     || "We temporarily adjusted session targets to rebuild calm confidence before progression resumes.";
   const [showRecoveryInfo, setShowRecoveryInfo] = useState(false);
+  const [todayOpen, setTodayOpen] = useState(false);
   const sessionBlockedMessage = daily.blockReason === "cap"
     ? `Daily alone-time cap reached (${fmtClock(daily.capSec)}). Log more sessions tomorrow.`
     : daily.blockReason === "max_sessions"
@@ -75,7 +75,16 @@ export default function HomeScreen(props) {
   return (
     <div className="tab-content train-screen">
       <div className="train-main">
-        <TrainProgressBar goalPct={goalPct} target={target} goalSec={goalSec} fmt={fmt} />
+        <header className="train-identity-header surface-card">
+          <div className="train-identity-header__badge" aria-hidden="true">
+            <Img src="hero-dog.png" size={36} alt="" />
+          </div>
+          <div className="train-identity-header__copy">
+            <div className="train-identity-header__eyebrow">Training with</div>
+            <h2 className="train-identity-header__name">{name}</h2>
+            <p className="train-identity-header__mood">Build calm confidence, one short separation at a time.</p>
+          </div>
+        </header>
 
         <SessionControl
           phase={phase}
@@ -88,7 +97,26 @@ export default function HomeScreen(props) {
           fmt={fmt}
           canStart={daily.canAdd}
           startBlockedMessage={sessionBlockedMessage}
+          allowIdlePress={false}
         />
+        {phase === "idle" && (
+          <button
+            type="button"
+            className="train-primary-cta button-base button-primary button--lg button--pill"
+            onClick={startSession}
+            disabled={!daily.canAdd}
+          >
+            Start calm session
+          </button>
+        )}
+
+        <section className="train-context-block surface-card">
+          <p className="train-context-block__title">Today’s calm target</p>
+          <p className="train-context-block__value">{fmtClock(target)}</p>
+          <p className="train-context-block__meta">
+            Logged today: <strong>{daily.count}</strong> · Goal pace: <strong>{fmt(goalSec)}</strong>
+          </p>
+        </section>
 
         <SessionRatingPanel
           phase={phase}
@@ -107,23 +135,20 @@ export default function HomeScreen(props) {
           distressTypes={DISTRESS_TYPES}
         />
 
-        {phase === "idle" && (
-          <button
-            type="button"
-            className={`train-focus-strip ${recoveryMode?.active ? "train-focus-strip--recovery" : ""}`.trim()}
-            onClick={recoveryMode?.active ? () => setShowRecoveryInfo(true) : undefined}
-            disabled={!recoveryMode?.active}
-          >
-            <span className="train-focus-strip__label">Focus now</span>
-            <span className="train-focus-strip__value">{fmtClock(target)} calm session</span>
-            <span className="train-focus-strip__meta">{daily.count} logged today</span>
-          </button>
-        )}
         {phase === "idle" && showTrainFirstRunHint && (
           <div className="train-inline-guidance" role="note" aria-live="polite">
             <span className="train-inline-guidance__label">Target adapts</span>
             <span className="train-inline-guidance__copy">Calm runs nudge up. Stress signs can step time down.</span>
           </div>
+        )}
+        {phase === "idle" && recoveryMode?.active && (
+          <button
+            type="button"
+            className="train-recovery-link"
+            onClick={() => setShowRecoveryInfo(true)}
+          >
+            Recovery plan active · view steps
+          </button>
         )}
         {showRecoveryInfo && recoveryMode?.active && (
           <div className="quick-modal-overlay" role="dialog" aria-modal="true" onClick={() => setShowRecoveryInfo(false)}>
@@ -186,24 +211,38 @@ export default function HomeScreen(props) {
           </p>
         )}
 
-        <div className="tool-group-card surface-card surface-card--tool-group">
-          <div className="section-title">Support routines</div>
-          <div className="t-helper">Quick log items that support training, without leaving Train.</div>
-          <div className="quick-actions-row">
-            <button className="quick-action-btn" type="button" onClick={walkPhase === "idle" ? startWalk : undefined}>
-              <span className="quick-action-label">Walk</span>
-              <span className="quick-action-meta">{walkPhase === "timing" ? `${fmt(walkElapsed)} live` : `Today: ${pattern.todayWalks}`}</span>
-            </button>
-            <button className={`quick-action-btn ${pattern.behind ? "warn" : ""}`} type="button" onClick={() => setPatOpen(true)}>
-              <span className="quick-action-label">Pattern break</span>
-              <span className="quick-action-meta">Today: {pattern.todayPat}</span>
-            </button>
-            <button className="quick-action-btn" type="button" onClick={openFeedingForm}>
-              <span className="quick-action-label">Feeding</span>
-              <span className="quick-action-meta">Today: {feedings.filter((f) => isToday(f.date)).length}</span>
-            </button>
+        <section className="train-today surface-card settings-collapsible-card settings-collapsible-card--quiet">
+          <button
+            type="button"
+            className="settings-collapsible-toggle secondary-control--toggle"
+            aria-expanded={todayOpen}
+            onClick={() => setTodayOpen((prev) => !prev)}
+          >
+            <div>
+              <div className="section-title section-title--flush">Today</div>
+              <div className="t-helper">{daily.count} session logs · support routines</div>
+            </div>
+            <span className="settings-collapsible-arrow" aria-hidden="true">{todayOpen ? "−" : "+"}</span>
+          </button>
+          <div className={`collapsible-body ${todayOpen ? "open" : "closed"}`}>
+            <div className="settings-collapsible-inner">
+              <div className="quick-actions-row">
+                <button className="quick-action-btn" type="button" onClick={walkPhase === "idle" ? startWalk : undefined}>
+                  <span className="quick-action-label">Walk</span>
+                  <span className="quick-action-meta">{walkPhase === "timing" ? `${fmt(walkElapsed)} live` : `Today: ${pattern.todayWalks}`}</span>
+                </button>
+                <button className={`quick-action-btn ${pattern.behind ? "warn" : ""}`} type="button" onClick={() => setPatOpen(true)}>
+                  <span className="quick-action-label">Pattern break</span>
+                  <span className="quick-action-meta">Today: {pattern.todayPat}</span>
+                </button>
+                <button className="quick-action-btn" type="button" onClick={openFeedingForm}>
+                  <span className="quick-action-label">Feeding</span>
+                  <span className="quick-action-meta">Today: {feedings.filter((f) => isToday(f.date)).length}</span>
+                </button>
+              </div>
+            </div>
           </div>
-        </div>
+        </section>
 
         {(walkPhase !== "idle" || patOpen) && (
           <div className="quick-modal-overlay" role="dialog" aria-modal="true" onClick={() => { if (walkPhase !== "idle") cancelWalk(); if (patOpen) setPatOpen(false); }}>

--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -20,6 +20,7 @@ export function SessionControl({
   fmt,
   canStart = true,
   startBlockedMessage = "Session limit reached for today.",
+  allowIdlePress = true,
 }) {
   const [pressing, setPressing] = useState(false);
   const remaining = Math.max(target - elapsed, 0);
@@ -42,20 +43,22 @@ export function SessionControl({
     }, 120);
   };
 
+  const idleCanPress = allowIdlePress && canStart && Boolean(onStart);
+
   return (
     <>
       {phase !== "rating" && (<div className="session-control-wrap">
         <button
           className={`session-control ${isRunning ? "is-running" : ""} ${pressing ? "is-pressing" : ""} ${completed ? "is-complete" : ""} ${isPastTarget ? "is-over-target" : ""}`}
-          onClick={isIdle && canStart ? startWithFeedback : undefined}
-          disabled={isIdle && !canStart}
+          onClick={isIdle && idleCanPress ? startWithFeedback : undefined}
+          disabled={isIdle && !idleCanPress}
           aria-label={isRunning
             ? (isPastTarget
               ? `${fmt(overTargetSeconds)} over target in current session`
               : `${fmt(remainingSeconds)} remaining in current session`)
-            : canStart
+            : idleCanPress
               ? `Start ${fmt(target)} session`
-              : startBlockedMessage}
+              : canStart ? `Ready for ${fmt(target)} session` : startBlockedMessage}
           aria-live={isRunning ? "polite" : undefined}
         >
           <svg className="sc-ring-svg" viewBox="0 0 226 226" aria-hidden="true">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -503,6 +503,88 @@
     margin-top:var(--space-card-row-gap);
     width:100%;
   }
+  .train-identity-header {
+    display:flex;
+    align-items:center;
+    gap:14px;
+    padding:18px;
+    border-radius:20px;
+    background:linear-gradient(180deg, color-mix(in srgb, var(--surf) 96%, white), color-mix(in srgb, var(--surface-muted) 90%, white));
+    border:1px solid color-mix(in srgb, var(--border) 82%, white);
+  }
+  .train-identity-header__badge {
+    width:52px;
+    height:52px;
+    border-radius:50%;
+    display:grid;
+    place-items:center;
+    background:color-mix(in srgb, var(--green) 18%, var(--surface-muted));
+    box-shadow:0 6px 16px color-mix(in srgb, var(--surface-overlay-soft) 18%, transparent);
+    flex:0 0 auto;
+  }
+  .train-identity-header__copy { min-width:0; }
+  .train-identity-header__eyebrow {
+    font-size:var(--type-helper-text-size);
+    color:var(--text-muted);
+    text-transform:uppercase;
+    letter-spacing:var(--type-helper-text-track);
+    margin-bottom:2px;
+  }
+  .train-identity-header__name {
+    margin:0;
+    color:var(--brown);
+    font-size:var(--type-card-heading-size);
+    line-height:var(--type-card-heading-line);
+  }
+  .train-identity-header__mood {
+    margin:4px 0 0;
+    color:var(--text-muted);
+    font-size:var(--type-helper-text-size);
+    line-height:var(--type-helper-text-line);
+  }
+  .train-primary-cta {
+    width:min(100%, 280px);
+    margin:2px auto 0;
+    transition:transform 180ms ease, box-shadow 220ms ease, opacity 180ms ease;
+  }
+  .train-primary-cta:not(:disabled):hover { transform:translateY(-1px); }
+  .train-context-block {
+    text-align:center;
+    padding:18px 16px;
+    border-radius:18px;
+    border:1px solid color-mix(in srgb, var(--border) 80%, white);
+    background:color-mix(in srgb, var(--surf) 94%, white);
+  }
+  .train-context-block__title {
+    margin:0;
+    text-transform:uppercase;
+    letter-spacing:var(--type-helper-text-track);
+    color:var(--text-muted);
+    font-size:var(--type-helper-text-size);
+  }
+  .train-context-block__value {
+    margin:6px 0 2px;
+    color:var(--brown);
+    font-size:var(--type-metric-xl-size);
+    line-height:var(--type-metric-xl-line);
+    font-weight:var(--type-metric-xl-weight);
+    letter-spacing:var(--type-metric-xl-track);
+  }
+  .train-context-block__meta {
+    margin:0;
+    color:var(--text-muted);
+    font-size:var(--type-helper-text-size);
+  }
+  .train-recovery-link {
+    border:none;
+    background:transparent;
+    color:var(--amber);
+    font-size:var(--type-helper-text-size);
+    margin:0 auto;
+    text-decoration:underline;
+    text-underline-offset:2px;
+  }
+  .train-today { padding:12px 14px; border-radius:18px; }
   .ring-sub-btn {
     margin-top:var(--space-card-row-gap);
     font-size:var(--type-metric-label-size);


### PR DESCRIPTION
### Motivation
- Rework the Train tab to be a focused action screen centered on a single primary hero control and a separate CTA so training feels like guiding a dog’s calmness rather than viewing a dashboard. 
- Reduce visual clutter (threshold bar, secondary rings, tool-heavy dashboard elements and dominant logs) to create strong minimalism, generous spacing, and smooth transitions. 
- Skills used: none — changes are direct UI/layout and style updates to existing components.

### Description
- Replace the top progress/dashboard emphasis with a dog identity header and a single central hero circle by changing `HomeScreen` layout and removing the immediate `TrainProgressBar` from the default Train view. 
- Add a distinct primary call-to-action `Start calm session` and a compact context block showing Today’s calm target and simple pacing info, implemented in `src/features/home/HomeScreen.jsx`. 
- Move support logging quick-actions into a collapsible Today section to hide secondary tools by default, and keep session rating and other overlays unchanged but user-triggered. 
- Add `allowIdlePress` to `SessionControl` and pass `allowIdlePress={false}` from `HomeScreen` so the hero circle can be visual-first while the separate CTA is the primary action, and add new minimalist styles in `src/styles/app.css` to support the redesign (files changed: `src/features/home/HomeScreen.jsx`, `src/features/train/TrainComponents.jsx`, `src/styles/app.css`).

### Testing
- Built the production bundle with `npm run build`, which completed successfully. 
- No additional automated test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d03fb1a88332973506074bd074f4)