### PR TITLE
Implement dog-focused Train hero circle with stateful visuals

### DIFF
--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -89,6 +89,7 @@ export default function HomeScreen(props) {
           phase={phase}
           elapsed={elapsed}
           target={target}
+          name={name}
           onStart={startSession}
           onEnd={endSession}
           onCancel={cancelSession}

--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -13,6 +13,7 @@ export function SessionControl({
   phase,
   elapsed,
   target,
+  name = "your dog",
   onStart,
   onEnd,
   onCancel,
@@ -32,7 +33,28 @@ export function SessionControl({
   const isRunning = phase === "running";
   const isIdle = phase === "idle";
   const isPastTarget = elapsed > target;
-  const timerValue = isRunning ? elapsed : remainingSeconds;
+  const timerValue = isRunning ? remainingSeconds : target;
+  const displayState = !canStart && isIdle
+    ? "warning"
+    : completed
+      ? "success"
+      : isRunning
+        ? "active"
+        : "idle";
+  const innerCaption = displayState === "warning"
+    ? "Calm practice is paused for today"
+    : displayState === "success"
+      ? `${name} hit this calm target`
+      : displayState === "active"
+        ? isPastTarget
+          ? `Past target — end while ${name} is still settled`
+          : `${name}'s calm hold for this rep`
+        : `Next calm session target for ${name}`;
+  const helperCaption = displayState === "active"
+    ? (isPastTarget ? `+${fmt(overTargetSeconds)} calm hold` : `${fmt(elapsed)} completed this rep`)
+    : displayState === "warning"
+      ? "Come back tomorrow for the next rep"
+      : "Builds comfort with short solo reps";
 
   const startWithFeedback = () => {
     if (!onStart || !canStart) return;
@@ -49,7 +71,7 @@ export function SessionControl({
     <>
       {phase !== "rating" && (<div className="session-control-wrap">
         <button
-          className={`session-control ${isRunning ? "is-running" : ""} ${pressing ? "is-pressing" : ""} ${completed ? "is-complete" : ""} ${isPastTarget ? "is-over-target" : ""}`}
+          className={`session-control state-${displayState} ${isRunning ? "is-running" : ""} ${pressing ? "is-pressing" : ""} ${completed ? "is-complete" : ""} ${isPastTarget ? "is-over-target" : ""}`}
           onClick={isIdle && idleCanPress ? startWithFeedback : undefined}
           disabled={isIdle && !idleCanPress}
           aria-label={isRunning
@@ -74,16 +96,10 @@ export function SessionControl({
           </svg>
 
           <div className="sc-content">
-            <div className="sc-idle" aria-hidden={isRunning}>
-              <div className="sc-idle-label">
-                <span>Start</span>
-                <span>{canStart ? "Session" : "Blocked"}</span>
-              </div>
-            </div>
-
             <div className="sc-time">
               <div className="sc-time-value">{fmt(timerValue)}</div>
-              {isPastTarget && <div className="sc-over-target">+{fmt(overTargetSeconds)} over target</div>}
+              <div className="sc-caption">{innerCaption}</div>
+              <div className="sc-support">{helperCaption}</div>
             </div>
           </div>
         </button>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -378,8 +378,8 @@
   .session-control {
     position:relative; width:clamp(248px, 74vw, 312px); aspect-ratio:1/1;
     border:none; border-radius:50%; cursor:pointer;
-    background:var(--session-control-idle-bg);
-    box-shadow:var(--session-control-idle-shadow);
+    background:radial-gradient(circle at 32% 24%, color-mix(in srgb, var(--green-light) 52%, white), color-mix(in srgb, var(--surface-muted) 72%, var(--surf)) 48%, color-mix(in srgb, var(--surf) 88%, var(--surface-muted)));
+    box-shadow:0 18px 46px color-mix(in srgb, var(--green-dark) 20%, transparent), inset 0 1px 0 rgba(255,255,255,0.72);
     display:flex; align-items:center; justify-content:center;
     transition:transform 160ms ease, box-shadow 360ms ease, filter 360ms ease, background-color 260ms ease;
     touch-action:manipulation;
@@ -388,16 +388,32 @@
     content:""; position:absolute; inset:-10px; border-radius:50%; pointer-events:none;
     border:10px solid var(--session-control-ring-border);
   }
-  .session-control.is-running {
-    background:var(--surf);
-    box-shadow:var(--session-control-running-shadow);
-    filter:saturate(1.08);
+  .session-control.state-idle { animation:heroBreath 4.6s ease-in-out infinite; }
+  .session-control.state-idle .sc-progress { stroke:color-mix(in srgb, var(--green-dark) 60%, var(--brown)); }
+  .session-control.state-active {
+    background:radial-gradient(circle at 35% 26%, color-mix(in srgb, var(--green-light) 38%, white), color-mix(in srgb, var(--surf) 96%, var(--green-light)));
+    box-shadow:0 14px 38px color-mix(in srgb, var(--green-dark) 25%, transparent), inset 0 1px 0 rgba(255,255,255,0.68);
+    filter:saturate(1.02);
+    animation:none;
+  }
+  .session-control.state-success {
+    background:radial-gradient(circle at 35% 26%, color-mix(in srgb, var(--green-light) 46%, white), color-mix(in srgb, var(--surface-muted) 64%, var(--surf)));
+    box-shadow:0 16px 40px color-mix(in srgb, var(--green) 24%, transparent), inset 0 1px 0 rgba(255,255,255,0.7);
+    animation:none;
+  }
+  .session-control.state-warning {
+    background:radial-gradient(circle at 35% 26%, color-mix(in srgb, var(--amber-light) 34%, white), color-mix(in srgb, var(--surface-muted) 74%, var(--surf)));
+    box-shadow:0 16px 40px color-mix(in srgb, var(--amber) 18%, transparent), inset 0 1px 0 rgba(255,255,255,0.66);
+    animation:none;
   }
   .session-control.is-pressing { transform:scale(0.975); }
   .session-control:focus-visible { outline:3px solid color-mix(in srgb, var(--primaryBlue) 28%, transparent); outline-offset:4px; }
   .sc-ring-svg { position:absolute; inset:-10px; width:calc(100% + 20px); height:calc(100% + 20px); transform:rotate(-90deg); }
   .sc-track { fill:none; stroke:var(--session-control-track-stroke); stroke-width:10; }
-  .sc-progress { fill:none; stroke:var(--green-dark); stroke-width:10; stroke-linecap:round; transition:stroke-dashoffset 1000ms linear, opacity 320ms ease; }
+  .sc-progress { fill:none; stroke:var(--green-dark); stroke-width:10; stroke-linecap:round; transition:stroke-dashoffset 1000ms linear, opacity 320ms ease, stroke 320ms ease; }
+  .session-control.state-active .sc-progress { stroke:var(--green-dark); }
+  .session-control.state-success .sc-progress { stroke:var(--green); }
+  .session-control.state-warning .sc-progress { stroke:var(--amber); }
   .session-control.is-over-target .sc-progress { stroke:var(--green); }
   .sc-content { position:relative; z-index:1; display:grid; place-items:center; text-align:center; width:100%; height:100%; padding:var(--space-card-padding); }
     .sc-content::before {
@@ -405,23 +421,34 @@
     position:absolute;
     inset:18%;
     border-radius:50%;
-    background:var(--session-control-content-shade);
+    background:radial-gradient(circle at 50% 40%, rgba(255,255,255,0.88), rgba(255,255,255,0.76) 44%, rgba(255,255,255,0.12) 74%);
     pointer-events:none;
     z-index:0;
   }
-  .session-control.is-running .sc-content::before,
-  .session-control.is-complete .sc-content::before { background:var(--session-control-content-active-bg); }
-  .sc-idle { position:relative; z-index:1; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:0; transition:opacity 260ms ease, transform 300ms ease; }
-  .sc-idle-label { display:flex; flex-direction:column; align-items:center; justify-content:center; gap:4px; text-transform:uppercase; font-size:var(--type-metric-xl-size); font-weight:var(--type-metric-xl-weight); letter-spacing:var(--type-metric-xl-track); line-height:var(--type-metric-xl-line); color:var(--session-control-idle-fg); text-shadow:var(--session-control-idle-text-shadow); }
-  .sc-idle-label span { display:block; }
-  .sc-time { position:absolute; opacity:0; transform:scale(0.95); transition:opacity 320ms ease-in-out, transform 320ms ease-in-out; display:flex; flex-direction:column; align-items:center; gap:4px; }
-  .sc-time-value { font-size:var(--type-metric-xl-size); line-height:var(--type-metric-xl-line); font-weight:var(--type-metric-xl-weight); color:var(--green-dark); letter-spacing:var(--type-metric-xl-track); font-variant-numeric:tabular-nums; }
+  .sc-time { position:relative; z-index:1; opacity:1; transform:scale(1); transition:opacity 320ms ease-in-out, transform 320ms ease-in-out; display:flex; flex-direction:column; align-items:center; gap:4px; max-width:188px; }
+  .sc-time-value { font-size:clamp(2rem, 8.6vw, 2.8rem); line-height:1.03; font-weight:var(--type-metric-xl-weight); color:var(--green-dark); letter-spacing:var(--type-metric-xl-track); font-variant-numeric:tabular-nums; }
+  .session-control.state-warning .sc-time-value { color:var(--brown); }
   .session-control.is-over-target .sc-time-value { color:var(--green); }
-  .sc-over-target { font-size:var(--type-status-text-size); font-weight:var(--type-status-text-weight); line-height:var(--type-status-text-line); letter-spacing:var(--type-status-text-track); color:var(--green-dark); text-transform:uppercase; }
+  .sc-caption {
+    font-size:var(--type-helper-text-size);
+    line-height:var(--type-helper-text-line);
+    letter-spacing:var(--type-helper-text-track);
+    color:var(--brown);
+    font-weight:var(--font-semibold);
+    text-wrap:balance;
+  }
+  .sc-support {
+    font-size:var(--type-micro-text-size);
+    line-height:var(--type-micro-text-line);
+    letter-spacing:var(--type-micro-text-track);
+    color:var(--text-muted);
+    text-wrap:balance;
+  }
   .sc-progress.is-dim { opacity:0.18; }
-  .session-control.is-running .sc-idle { opacity:0; transform:translateY(-4px); }
-  .session-control.is-running .sc-time,
-  .session-control.is-complete .sc-time { opacity:1; transform:scale(1); }
+  @keyframes heroBreath {
+    0%, 100% { transform:scale(1); box-shadow:0 18px 46px color-mix(in srgb, var(--green-dark) 20%, transparent), inset 0 1px 0 rgba(255,255,255,0.72); }
+    50% { transform:scale(1.014); box-shadow:0 20px 50px color-mix(in srgb, var(--green-dark) 25%, transparent), inset 0 1px 0 rgba(255,255,255,0.75); }
+  }
   .session-actions { margin-top:var(--space-card-row-gap); display:flex; flex-direction:column; gap:10px; align-items:center; }
   .session-end-btn, .session-cancel-btn { width:min(100%, 260px); padding:var(--space-inline-control-padding); }
 


### PR DESCRIPTION
### Motivation
- Make the Train hero circle feel like a calmness target for a specific dog rather than a generic timer by surfacing dog-focused captions, subtle breathing animation, and soft visual states.
- Provide clearer in-circle context so the numeric duration is immediately understandable as a calm-session target for training, not a productivity timer.

### Description
- Extended `SessionControl` with a `name` prop and updated `HomeScreen` to pass `name` into the hero so captions read like training guidance rather than a generic timer (`src/features/train/TrainComponents.jsx`, `src/features/home/HomeScreen.jsx`).
- Reworked center content logic to compute `displayState` (`idle`/`active`/`success`/`warning`), choose a `timerValue`, and render contextual captions `innerCaption` and `helperCaption` derived from `phase`, `completed`, `canStart`, and elapsed vs target (`src/features/train/TrainComponents.jsx`).
- Kept the existing SVG progress ring and action controls but wired state classes into the button (`state-...`) so visuals map to state while preserving stroke/offset logic and existing accessibility labels (`src/features/train/TrainComponents.jsx`).
- Updated styles for a premium, minimal look: soft gradients, restrained glow, idle "breathing" animation `heroBreath`, and state-specific color treatments for `state-idle`, `state-active`, `state-success`, and `state-warning` (`src/styles/app.css`).

### Testing
- Built the production bundle with `npm run build`, which completed successfully.
- Ran the test suite with `npm test` (Vitest), and all automated tests passed (`230 tests, 17 files`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d405ee708332bd26f443ce56a26a)