### PR TITLE
Improve Train screen understanding with contextual inline hints

### DIFF
--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -1,7 +1,7 @@
 import { SessionControl, SessionRatingPanel } from "../train/TrainComponents";
 import { DISTRESS_TYPES, PATTERN_TYPES, WALK_TYPE_OPTIONS, fmt, fmtClock, isToday, walkTypeLabel } from "../app/helpers";
 import { Img, ModalCloseButton } from "../app/ui";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function HomeScreen(props) {
   const {
@@ -65,11 +65,24 @@ export default function HomeScreen(props) {
     || recommendation?.explanation
     || "We temporarily adjusted session targets to rebuild calm confidence before progression resumes.";
   const [todayOpen, setTodayOpen] = useState(false);
+  const [trainExplainOpen, setTrainExplainOpen] = useState(false);
   const sessionBlockedMessage = daily.blockReason === "cap"
     ? `Daily alone-time cap reached (${fmtClock(daily.capSec)}). Log more sessions tomorrow.`
     : daily.blockReason === "max_sessions"
       ? `Daily session max reached (${daily.maxCount}). Log more sessions tomorrow.`
       : "";
+  const toggleTrainExplain = () => {
+    setTrainExplainOpen((prev) => !prev);
+    if (showTrainFirstRunHint) dismissTrainFirstRunHint();
+  };
+
+  useEffect(() => {
+    if (phase !== "idle") {
+      setTrainExplainOpen(false);
+      return;
+    }
+    if (showTrainFirstRunHint) setTrainExplainOpen(true);
+  }, [phase, showTrainFirstRunHint]);
 
   return (
     <div className="tab-content train-screen">
@@ -98,7 +111,27 @@ export default function HomeScreen(props) {
           canStart={daily.canAdd}
           startBlockedMessage={sessionBlockedMessage}
           allowIdlePress={false}
+          onIdlePress={toggleTrainExplain}
         />
+        {phase === "idle" && (
+          <div className="train-contextual-help">
+            <button
+              type="button"
+              className={`train-inline-guidance ${showTrainFirstRunHint ? "is-first-run" : ""}`}
+              onClick={toggleTrainExplain}
+              aria-expanded={trainExplainOpen}
+            >
+              <span className="train-inline-guidance__label">Tap to explain</span>
+              <span className="train-inline-guidance__copy">What this circle and target mean</span>
+            </button>
+            {trainExplainOpen && (
+              <div className="train-inline-explain" role="note" aria-live="polite">
+                <p><strong>Big circle:</strong> this rep's timer. During a session, the number counts down and the ring fills as calm time is completed.</p>
+                <p><strong>Target time ({fmtClock(target)}):</strong> your current safe goal for one calm rep. End while {name} is still settled.</p>
+              </div>
+            )}
+          </div>
+        )}
         {phase === "idle" && (
           <button
             type="button"
@@ -111,8 +144,8 @@ export default function HomeScreen(props) {
         )}
 
         <section className="train-context-block surface-card">
-          <p className="train-context-block__title">Current calm threshold</p>
-          <p className="train-context-block__value">{fmtClock(target)} with {name}</p>
+          <p className="train-context-block__title">Today's target time</p>
+          <p className="train-context-block__value">{fmtClock(target)} calm for {name}</p>
           <p className="train-context-block__meta">
             Sessions today: <strong>{daily.count}</strong> · Daily pace target: <strong>{fmt(goalSec)}</strong>
           </p>
@@ -127,8 +160,8 @@ export default function HomeScreen(props) {
               className="train-inline-guidance"
               onClick={dismissTrainFirstRunHint}
             >
-              <span className="train-inline-guidance__label">Target adapts</span>
-              <span className="train-inline-guidance__copy">Calm sessions can rise. Stress signs step time down.</span>
+              <span className="train-inline-guidance__label">Target adapts gently</span>
+              <span className="train-inline-guidance__copy">Calm reps step up over time. Stress signs lower the next goal.</span>
             </button>
           )}
           {phase === "idle" && recoveryMode?.active && (

--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -22,6 +22,7 @@ export function SessionControl({
   canStart = true,
   startBlockedMessage = "Session limit reached for today.",
   allowIdlePress = true,
+  onIdlePress,
 }) {
   const [pressing, setPressing] = useState(false);
   const remaining = Math.max(target - elapsed, 0);
@@ -65,22 +66,33 @@ export function SessionControl({
     }, 120);
   };
 
-  const idleCanPress = allowIdlePress && canStart && Boolean(onStart);
+  const idleCanStart = allowIdlePress && canStart && Boolean(onStart);
+  const idleCanExplain = !idleCanStart && Boolean(onIdlePress);
+  const idleCanPress = idleCanStart || idleCanExplain;
+  const handleIdlePress = () => {
+    if (idleCanStart) {
+      startWithFeedback();
+      return;
+    }
+    if (idleCanExplain) onIdlePress();
+  };
 
   return (
     <>
       {phase !== "rating" && (<div className="session-control-wrap">
         <button
           className={`session-control state-${displayState} ${isRunning ? "is-running" : ""} ${pressing ? "is-pressing" : ""} ${completed ? "is-complete" : ""} ${isPastTarget ? "is-over-target" : ""}`}
-          onClick={isIdle && idleCanPress ? startWithFeedback : undefined}
+          onClick={isIdle && idleCanPress ? handleIdlePress : undefined}
           disabled={isIdle && !idleCanPress}
           aria-label={isRunning
             ? (isPastTarget
               ? `${fmt(overTargetSeconds)} over target in current session`
               : `${fmt(remainingSeconds)} remaining in current session`)
-            : idleCanPress
+            : idleCanStart
               ? `Start ${fmt(target)} session`
-              : canStart ? `Ready for ${fmt(target)} session` : startBlockedMessage}
+              : idleCanExplain
+                ? `Explain ${fmt(target)} session target`
+                : canStart ? `Ready for ${fmt(target)} session` : startBlockedMessage}
           aria-live={isRunning ? "polite" : undefined}
         >
           <svg className="sc-ring-svg" viewBox="0 0 226 226" aria-hidden="true">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -497,6 +497,17 @@
     border-style:solid;
     transition:border-color 220ms ease, transform 180ms ease, box-shadow 220ms ease;
   }
+  .train-contextual-help {
+    width:min(100%, 360px);
+    margin:6px auto 0;
+  }
+  .train-contextual-help .train-inline-guidance {
+    margin-top:0;
+  }
+  .train-inline-guidance.is-first-run {
+    border-color:color-mix(in srgb, var(--primaryBlue) 44%, var(--border));
+    box-shadow:0 0 0 1px color-mix(in srgb, var(--primaryBlue) 24%, transparent);
+  }
   .train-inline-guidance:hover {
     border-color:color-mix(in srgb, var(--primaryBlue) 36%, var(--border));
     transform:translateY(-1px);
@@ -515,6 +526,21 @@
     color:var(--text-muted);
     text-align:right;
   }
+  .train-inline-explain {
+    margin-top:8px;
+    border-radius:14px;
+    border:1px solid color-mix(in srgb, var(--border) 82%, white);
+    background:color-mix(in srgb, var(--surf) 96%, white);
+    padding:10px 12px;
+    display:grid;
+    gap:6px;
+    color:var(--text-muted);
+    text-align:left;
+    font-size:var(--type-helper-text-size);
+    line-height:var(--type-helper-text-line);
+  }
+  .train-inline-explain p { margin:0; }
+  .train-inline-explain strong { color:var(--brown); }
   .train-focus-strip--recovery {
     border-color:color-mix(in srgb, var(--warning) 30%, var(--border));
     box-shadow:0 0 0 1px color-mix(in srgb, var(--warning) 15%, transparent);


### PR DESCRIPTION
### Motivation
- Clarify what the large circular control represents so users immediately understand the timer/progress affordance.
- Make the meaning of the target time explicit without adding permanent instructional clutter or harsh modals.
- Provide a gentle, first-time inline hint and on-demand tap-to-explain behavior that preserves a calm, minimal UI.

### Description
- Added a collapsible, inline “Tap to explain” helper under the Train circle that auto-opens for first-time users and can be toggled thereafter (`HomeScreen.jsx` updates). 
- Refined microcopy in the context card to read `"Today's target time"` and `"{fmtClock(target)} calm for {name}"`, and softened the first-run hint copy to `"Target adapts gently"` (`HomeScreen.jsx`).
- Extended `SessionControl` to accept `onIdlePress` and changed idle-click behavior so the big circle can trigger the contextual explanation when start-on-circle is disabled, with updated aria-labels (`TrainComponents.jsx`).
- Added lightweight styling for the contextual helper and explanation panel (`app.css`) to keep the interaction subtle and visually calm.

### Testing
- Ran the unit test suite with `npm run test` and all tests passed (`230 tests` passed).
- Built the production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d5a0c12883329715b649758f1a83)