### PR TITLE
Refactor Train Today's logs into a calm collapsible panel

### DIFF
--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -66,6 +66,11 @@ export default function HomeScreen(props) {
     || "We temporarily adjusted session targets to rebuild calm confidence before progression resumes.";
   const [todayOpen, setTodayOpen] = useState(false);
   const [trainExplainOpen, setTrainExplainOpen] = useState(false);
+  const todaySessions = sessions.filter((s) => isToday(s.date));
+  const todayFeedingCount = feedings.filter((f) => isToday(f.date)).length;
+  const recentSessionLogs = [...todaySessions]
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .slice(0, 4);
   const sessionBlockedMessage = daily.blockReason === "cap"
     ? `Daily alone-time cap reached (${fmtClock(daily.capSec)}). Log more sessions tomorrow.`
     : daily.blockReason === "max_sessions"
@@ -203,27 +208,41 @@ export default function HomeScreen(props) {
             onClick={() => setTodayOpen((prev) => !prev)}
           >
             <div>
-              <div className="section-title section-title--flush">Today</div>
-              <div className="t-helper">{daily.count} session logs · support routines</div>
+              <div className="section-title section-title--flush">Today&apos;s logs</div>
+              <div className="t-helper">{todaySessions.length} calm sessions · support activity</div>
             </div>
             <span className="settings-collapsible-arrow" aria-hidden="true">{todayOpen ? "−" : "+"}</span>
           </button>
-          <div className={`collapsible-body ${todayOpen ? "open" : "closed"}`}>
+          <div className={`collapsible-body train-today-body ${todayOpen ? "open" : "closed"}`}>
             <div className="settings-collapsible-inner">
-              <div className="quick-actions-row">
-                <button className="quick-action-btn" type="button" onClick={walkPhase === "idle" ? startWalk : undefined}>
-                  <span className="quick-action-label">Walk</span>
-                  <span className="quick-action-meta">{walkPhase === "timing" ? `${fmt(walkElapsed)} live` : `Today: ${pattern.todayWalks}`}</span>
+              <div className="train-today-list" role="list" aria-label="Today's logged activity">
+                <div className="train-today-row" role="listitem">
+                  <span className="train-today-row__label">Calm sessions</span>
+                  <span className="train-today-row__meta">{todaySessions.length} logged</span>
+                </div>
+                <button className="train-today-row train-today-row--action" type="button" onClick={walkPhase === "idle" ? startWalk : undefined}>
+                  <span className="train-today-row__label">Walk</span>
+                  <span className="train-today-row__meta">{walkPhase === "timing" ? `${fmt(walkElapsed)} live` : `${pattern.todayWalks} today`}</span>
                 </button>
-                <button className={`quick-action-btn ${pattern.behind ? "warn" : ""}`} type="button" onClick={() => setPatOpen(true)}>
-                  <span className="quick-action-label">Pattern break</span>
-                  <span className="quick-action-meta">Today: {pattern.todayPat}</span>
+                <button className={`train-today-row train-today-row--action ${pattern.behind ? "warn" : ""}`} type="button" onClick={() => setPatOpen(true)}>
+                  <span className="train-today-row__label">Pattern break</span>
+                  <span className="train-today-row__meta">{pattern.todayPat} today</span>
                 </button>
-                <button className="quick-action-btn" type="button" onClick={openFeedingForm}>
-                  <span className="quick-action-label">Feeding</span>
-                  <span className="quick-action-meta">Today: {feedings.filter((f) => isToday(f.date)).length}</span>
+                <button className="train-today-row train-today-row--action" type="button" onClick={openFeedingForm}>
+                  <span className="train-today-row__label">Feeding</span>
+                  <span className="train-today-row__meta">{todayFeedingCount} today</span>
                 </button>
               </div>
+              {recentSessionLogs.length > 0 && (
+                <div className="train-today-mini-log" role="list" aria-label="Recent calm sessions">
+                  {recentSessionLogs.map((session) => (
+                    <div className="train-today-mini-log__row" role="listitem" key={session.id || `${session.date}-${session.actualDuration || 0}`}>
+                      <span>{new Date(session.date).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}</span>
+                      <span>{fmt(session.actualDuration || session.seconds || 0)}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         </section>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -660,6 +660,66 @@
     line-height:var(--type-helper-text-line);
   }
   .train-today { padding:12px 14px; border-radius:18px; }
+  .train-today-body {
+    transition:max-height 0.32s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.24s ease, transform 0.32s cubic-bezier(0.22, 1, 0.36, 1);
+    transform-origin:top center;
+  }
+  .train-today-body.open { transform:translateY(0); }
+  .train-today-body.closed { transform:translateY(-4px); }
+  .train-today-list {
+    display:grid;
+    gap:8px;
+  }
+  .train-today-row {
+    width:100%;
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+    gap:var(--space-control-gap);
+    border:1px solid color-mix(in srgb, var(--border) 88%, var(--surface-muted));
+    background:color-mix(in srgb, var(--surf) 96%, var(--surface-muted));
+    border-radius:12px;
+    padding:10px 12px;
+    color:var(--text);
+    font:inherit;
+    text-align:left;
+  }
+  .train-today-row--action {
+    cursor:pointer;
+    transition:border-color var(--motion-base) var(--ease-out), background var(--motion-base) var(--ease-out), transform var(--motion-press) var(--ease-out);
+  }
+  .train-today-row--action:hover {
+    border-color:color-mix(in srgb, var(--mutedBlue) 30%, var(--border));
+    background:color-mix(in srgb, var(--surface-muted) 86%, var(--warm-accent-soft));
+  }
+  .train-today-row--action:active { transform:scale(0.99); }
+  .train-today-row.warn { border-color:color-mix(in srgb, var(--amber) 40%, var(--border)); }
+  .train-today-row__label {
+    font-size:var(--type-body-size);
+    font-weight:var(--type-body-weight);
+    color:var(--brown);
+  }
+  .train-today-row__meta {
+    font-size:var(--type-helper-text-size);
+    color:var(--text-muted);
+    white-space:nowrap;
+  }
+  .train-today-mini-log {
+    border-top:1px solid color-mix(in srgb, var(--border) 74%, transparent);
+    margin-top:6px;
+    padding-top:8px;
+    display:grid;
+    gap:2px;
+  }
+  .train-today-mini-log__row {
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+    color:var(--text-muted);
+    font-size:var(--type-helper-text-size);
+    line-height:var(--type-helper-text-line);
+    padding:5px 2px;
+  }
   .ring-sub-btn {
     margin-top:var(--space-card-row-gap);
     font-size:var(--type-metric-label-size);


### PR DESCRIPTION
### Motivation
- Make the Train screen’s Today area quieter and secondary so logs don’t compete with the primary session timer by default.
- Present activity in a compact, low-visual-weight form that’s collapsed initially and expands with a smooth motion when needed.
- Surface just enough contextual detail (recent calm session times/durations and quick action rows) without heavy cards or clutter.

### Description
- Compute `todaySessions`, `todayFeedingCount`, and a trimmed `recentSessionLogs` in `src/features/home/HomeScreen.jsx` and wire the collapsible state for the Today panel.
- Replace the previous high-visual-weight quick-action grid with compact row-oriented controls and a minimal recent-session mini-log in `src/features/home/HomeScreen.jsx` while keeping existing walk/pattern/feed actions reachable.
- Add quiet, subtle styling and a smoother expand/collapse transition in `src/styles/app.css` including `.train-today-body`, `.train-today-row`, and `.train-today-mini-log` to enforce the calmer hierarchy and interactions.
- No data model or backend changes were made.

### Testing
- Ran `npm run test` and the test suite completed successfully (all tests passed).
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d71ed458833281c4a361b4e3f2d9)