### PR TITLE
Redesign Train active session state and controls

### DIFF
--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -137,17 +137,6 @@ export default function HomeScreen(props) {
             )}
           </div>
         )}
-        {phase === "idle" && (
-          <button
-            type="button"
-            className="train-primary-cta button-base button-primary button--lg button--pill"
-            onClick={startSession}
-            disabled={!daily.canAdd}
-          >
-            Start calm session
-          </button>
-        )}
-
         <section className="train-context-block surface-card">
           <p className="train-context-block__title">Today's target time</p>
           <p className="train-context-block__value">{fmtClock(target)} calm for {name}</p>

--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -1,10 +1,48 @@
 import { useState } from "react";
 
-function SessionActionRow({ onEnd, onCancel }) {
+function SessionActionRow({
+  isRunning,
+  canStart,
+  onStart,
+  onEnd,
+  onCancel,
+  onIdlePress,
+  startBlockedMessage,
+}) {
+  const canRunStart = canStart && Boolean(onStart);
+  const canExplain = !canRunStart && Boolean(onIdlePress);
+  const handlePrimary = () => {
+    if (isRunning) {
+      onEnd?.();
+      return;
+    }
+    if (canRunStart) {
+      onStart?.();
+      return;
+    }
+    if (canExplain) onIdlePress?.();
+  };
+
   return (
-    <div className="session-actions">
-      <button className="session-end-btn button-base button-primary button--md button--pill" onClick={onEnd}>End Session</button>
-      <button className="session-cancel-btn button-base button-ghost button--md button--pill" onClick={onCancel}>Cancel (don't save)</button>
+    <div className={`session-actions ${isRunning ? "is-running" : "is-idle"}`}>
+      <button
+        className="session-primary-btn button-base button-primary button--md button--pill"
+        onClick={handlePrimary}
+        disabled={!isRunning && !canRunStart && !canExplain}
+      >
+        {isRunning ? "End and save session" : "Start calm session"}
+      </button>
+      <button
+        className="session-cancel-btn button-base button-ghost button--md button--pill"
+        onClick={onCancel}
+        aria-hidden={!isRunning}
+        tabIndex={isRunning ? 0 : -1}
+      >
+        Cancel session (don&apos;t save)
+      </button>
+      {!isRunning && !canStart && (
+        <p className="session-action-meta" role="status">{startBlockedMessage}</p>
+      )}
     </div>
   );
 }
@@ -112,12 +150,25 @@ export function SessionControl({
               <div className="sc-time-value">{fmt(timerValue)}</div>
               <div className="sc-caption">{innerCaption}</div>
               <div className="sc-support">{helperCaption}</div>
+              <div className={`sc-state-chip ${isRunning ? "is-running" : ""}`}>
+                {isRunning ? `Session live · ${fmt(elapsed)} elapsed` : "Ready when you are"}
+              </div>
             </div>
           </div>
         </button>
       </div>)}
 
-      {isRunning && <SessionActionRow onEnd={onEnd} onCancel={onCancel} />}
+      {phase !== "rating" && (
+        <SessionActionRow
+          isRunning={isRunning}
+          canStart={canStart}
+          onStart={startWithFeedback}
+          onEnd={onEnd}
+          onCancel={onCancel}
+          onIdlePress={onIdlePress}
+          startBlockedMessage={startBlockedMessage}
+        />
+      )}
     </>
   );
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -444,13 +444,57 @@
     color:var(--text-muted);
     text-wrap:balance;
   }
+  .sc-state-chip {
+    margin-top:6px;
+    padding:5px 10px;
+    border-radius:999px;
+    font-size:11px;
+    letter-spacing:0.02em;
+    font-weight:600;
+    color:color-mix(in srgb, var(--brown) 82%, var(--text-muted));
+    background:color-mix(in srgb, var(--surface-muted) 86%, white);
+    border:1px solid color-mix(in srgb, var(--border) 82%, white);
+    transition:background-color 240ms ease, color 240ms ease, border-color 240ms ease;
+  }
+  .sc-state-chip.is-running {
+    color:color-mix(in srgb, var(--green-dark) 80%, var(--brown));
+    background:color-mix(in srgb, var(--green-light) 34%, white);
+    border-color:color-mix(in srgb, var(--green) 36%, var(--border));
+  }
   .sc-progress.is-dim { opacity:0.18; }
   @keyframes heroBreath {
     0%, 100% { transform:scale(1); box-shadow:0 18px 46px color-mix(in srgb, var(--green-dark) 20%, transparent), inset 0 1px 0 rgba(255,255,255,0.72); }
     50% { transform:scale(1.014); box-shadow:0 20px 50px color-mix(in srgb, var(--green-dark) 25%, transparent), inset 0 1px 0 rgba(255,255,255,0.75); }
   }
-  .session-actions { margin-top:var(--space-card-row-gap); display:flex; flex-direction:column; gap:10px; align-items:center; }
-  .session-end-btn, .session-cancel-btn { width:min(100%, 260px); padding:var(--space-inline-control-padding); }
+  .session-actions {
+    margin-top:var(--space-card-row-gap);
+    display:flex;
+    flex-direction:column;
+    gap:8px;
+    align-items:center;
+    width:min(100%, 320px);
+    margin-inline:auto;
+  }
+  .session-primary-btn, .session-cancel-btn { width:min(100%, 280px); padding:var(--space-inline-control-padding); }
+  .session-cancel-btn {
+    opacity:0;
+    max-height:0;
+    overflow:hidden;
+    transform:translateY(-4px);
+    transition:opacity 220ms ease, max-height 280ms ease, transform 220ms ease;
+  }
+  .session-actions.is-running .session-cancel-btn {
+    opacity:0.8;
+    max-height:44px;
+    transform:translateY(0);
+  }
+  .session-actions.is-running .session-cancel-btn:hover { opacity:1; }
+  .session-action-meta {
+    margin:0;
+    text-align:center;
+    font-size:var(--type-helper-text-size);
+    color:var(--text-muted);
+  }
 
   .readiness-hint { margin:var(--space-card-row-gap) auto 0; width:min(100%, 320px); padding:var(--space-inline-control-padding); border-radius:12px; border:1px solid var(--border); background:var(--surface-muted); display:flex; align-items:center; justify-content:space-between; gap:var(--space-control-gap); }
   .readiness-label { font-size:var(--type-field-label-size); line-height:var(--type-field-label-line); letter-spacing:var(--type-field-label-track); color:var(--text-muted); font-weight:var(--type-field-label-weight); }


### PR DESCRIPTION
### Motivation

- Provide a calm, focused, and premium-feeling active session state where the hero circle remains the primary progress display and the user clearly understands the session is running. 
- Make the end action distinct from a subtle secondary cancel, avoid abrupt CTA swaps, and keep transitions smooth between idle and running states.

### Description

- Reworked the session action row into a single adaptive `SessionActionRow` that accepts `isRunning`, `canStart`, `onStart`, `onEnd`, `onCancel`, `onIdlePress`, and `startBlockedMessage` and exposes a single primary CTA plus a subtle secondary cancel path. (See `src/features/train/TrainComponents.jsx`.)
- Kept the hero circle as the progress/timer and added a live status chip inside the control (`sc-state-chip`) that shows `Session live · … elapsed` when running. (See `SessionControl` in `src/features/train/TrainComponents.jsx`.)
- Removed the duplicate idle-only CTA from `HomeScreen` so the primary action no longer jumps between different parts of the view and the control stays stable during state changes. (`src/features/home/HomeScreen.jsx`)
- Added CSS for the state chip and smooth reveal/hide transitions for the action row and cancel button to create a calm, premium visual treatment and avoid abrupt view swaps. (`src/styles/app.css`)

### Testing

- Ran the unit test suite with `npm test` (Vitest) and all tests passed: `230` tests succeeded.
- Verified production build with `npm run build` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d89d098c83329b1f61f101cd2d11)