### PR TITLE
Redesign end-of-session feedback into a calm bottom sheet

### DIFF
--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -199,81 +199,38 @@ export function SessionRatingPanel({
   phase,
   finalElapsed,
   name,
-  sessionOutcome,
-  setSessionOutcome,
   recordResult,
-  latencyDraft,
-  setLatencyDraft,
-  distressTypeDraft,
-  setDistressTypeDraft,
   onCancel,
   fmt,
   Img,
-  distressTypes,
 }) {
   if (phase !== "rating") return null;
 
   return (
     <div className="rating-overlay" role="presentation">
-      <div className="rating-screen session-feedback modal-card modal-card--dialog-md" role="dialog" aria-modal="true" aria-labelledby="session-rating-title">
+      <div className="rating-screen session-feedback modal-card modal-card--dialog-md rating-sheet" role="dialog" aria-modal="true" aria-labelledby="session-rating-title" aria-describedby="session-rating-sub">
+        <div className="rating-sheet-grabber" aria-hidden="true" />
         <div className="rating-title" id="session-rating-title">Was there any stress?</div>
-        <div className="rating-sub">
-          {fmt(finalElapsed)} session — how did {name} handle it?
+        <div className="rating-sub" id="session-rating-sub">
+          {fmt(finalElapsed)} session with {name}. Your choice updates the next training target.
         </div>
         <div className="result-grid">
-          <button className="btn-result btn-none" onClick={() => { setSessionOutcome("none"); recordResult("none"); }}>
-            <Img src="result-calm.png" size={36} alt="No distress"/>
-            <div><div>No distress</div><div className="result-desc">{name} was completely calm</div></div>
+          <button className="btn-result btn-none" onClick={() => recordResult("none")}>
+            <Img src="result-calm.png" size={36} alt="No stress"/>
+            <div><div>No stress</div><div className="result-desc">Fully calm throughout the session</div></div>
           </button>
-          <button className="btn-result btn-mild" onClick={() => setSessionOutcome("subtle")}>
-            <Img src="result-mild.png" size={36} alt="Subtle stress"/>
-            <div><div>Subtle stress</div><div className="result-desc">Mild/passive signs (restless, lip licking, etc.)</div></div>
+          <button className="btn-result btn-mild" onClick={() => recordResult("subtle")}>
+            <Img src="result-mild.png" size={36} alt="Slight stress"/>
+            <div><div>Slight stress</div><div className="result-desc">Small signs, but able to settle</div></div>
           </button>
-          <button className="btn-result btn-strong" onClick={() => setSessionOutcome("active")}>
-            <Img src="result-strong.png" size={36} alt="Active distress"/>
-            <div><div>Active distress</div><div className="result-desc">Barking, pacing, unable to settle</div></div>
-          </button>
-          <button className="btn-result btn-severe" onClick={() => setSessionOutcome("severe")}>
-            <Img src="result-strong.png" size={36} alt="Severe distress"/>
-            <div><div>Severe distress</div><div className="result-desc">Panic, escape attempt, major breakdown</div></div>
+          <button className="btn-result btn-strong" onClick={() => recordResult("active")}>
+            <Img src="result-strong.png" size={36} alt="Strong stress"/>
+            <div><div>Strong stress</div><div className="result-desc">Clear stress; next step should be easier</div></div>
           </button>
         </div>
-        {sessionOutcome && sessionOutcome !== "none" && (
-          <div className="outcome-details">
-            <label className="field-label" htmlFor="latency-input">Latency to first stress (seconds)</label>
-            <input
-              id="latency-input"
-              className="text-input"
-              type="number"
-              min="0"
-              step="1"
-              placeholder="Optional"
-              value={latencyDraft}
-              onChange={(e) => setLatencyDraft(e.target.value)}
-            />
-            <label className="field-label" htmlFor="distress-type">Distress type (optional)</label>
-            <select
-              id="distress-type"
-              className="text-input"
-              value={distressTypeDraft}
-              onChange={(e) => setDistressTypeDraft(e.target.value)}
-            >
-              <option value="">Select distress type</option>
-              {distressTypes.map((type) => (
-                <option key={type} value={type}>{type}</option>
-              ))}
-            </select>
-            <button
-              className="btn-save-outcome button-base button-primary button--md button--block"
-              onClick={() => recordResult(sessionOutcome, {
-                latencyToFirstDistress: latencyDraft,
-                distressType: distressTypeDraft || null,
-              })}
-            >
-              Save session
-            </button>
-          </div>
-        )}
+        <p className="rating-adapt-note" role="status">
+          We use this feedback to adjust pace automatically and keep training in the calm zone.
+        </p>
         <button className="session-cancel-btn button-base button-ghost button--md button--block" onClick={onCancel}>
           Discard this session
         </button>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1088,15 +1088,29 @@
     inset:0;
     z-index:210;
     display:flex;
-    align-items:center;
+    align-items:flex-end;
     justify-content:center;
     padding:var(--space-2);
-    background:var(--surface-overlay);
+    background:color-mix(in srgb, var(--surface-overlay) 86%, transparent);
     min-height:100vh;
     min-height:100dvh;
     box-sizing:border-box;
+    animation:fadeIn var(--motion-base) var(--ease-out);
   }
-  .rating-screen { --modal-card-max-width:420px; --modal-card-max-height:calc(100dvh - 32px); margin:0; background:var(--surface-gradient-raised); border-color:color-mix(in srgb, var(--border) 94%, var(--surf)); box-shadow:var(--shadow); }
+  .rating-screen { --modal-card-max-width:520px; --modal-card-max-height:min(80dvh, 560px); margin:0; background:var(--surface-gradient-raised); border-color:color-mix(in srgb, var(--border) 94%, var(--surf)); box-shadow:var(--shadow); }
+  .rating-sheet {
+    width:100%;
+    border-radius:24px 24px 18px 18px;
+    padding-top:var(--space-2);
+    animation:ratingSheetIn var(--motion-slow, 260ms) var(--ease-out);
+  }
+  .rating-sheet-grabber {
+    width:44px;
+    height:5px;
+    border-radius:999px;
+    background:color-mix(in srgb, var(--text-subtle) 30%, transparent);
+    margin:0 auto var(--space-control-gap);
+  }
   .rating-title { font-size:var(--type-section-heading-size); font-weight:var(--type-section-heading-weight); line-height:var(--type-section-heading-line); letter-spacing:var(--type-section-heading-track); color:var(--brown); text-align:center; margin-bottom:4px; }
   .rating-sub   { font-size:var(--type-body-size); color:var(--text-muted); text-align:center; margin-bottom:var(--space-2); line-height:var(--type-body-line); letter-spacing:var(--type-body-track); font-weight:var(--type-body-weight); }
   .result-grid { display:flex; flex-direction:column; gap:var(--space-control-gap); margin-bottom:var(--space-1); }
@@ -1107,11 +1121,24 @@
   .btn-strong { background:var(--status-attention-bg); color:var(--status-attention-fg); border-color:color-mix(in srgb, var(--status-attention-fg) 24%, var(--border)); }
   .btn-severe { background:var(--status-danger-bg); color:var(--status-danger-fg); border-color:color-mix(in srgb, var(--status-danger-fg) 24%, var(--border)); }
   .btn-result:hover { transform:translateY(-2px); }
+  .rating-adapt-note {
+    margin:var(--space-control-gap) 0 var(--space-1);
+    padding:var(--space-1) var(--space-2);
+    border-radius:var(--radius-sm);
+    border:1px solid color-mix(in srgb, var(--primaryBlue) 18%, var(--border));
+    background:color-mix(in srgb, var(--softBlue) 64%, var(--surf));
+    color:var(--brown-mid);
+    font-size:var(--type-secondary-size);
+    line-height:var(--type-secondary-line);
+    letter-spacing:var(--type-secondary-track);
+    font-weight:var(--type-secondary-weight);
+  }
   .outcome-details { margin-top:var(--space-2); padding:var(--space-2); border:1px solid var(--border); border-radius:var(--radius-sm); background:var(--surface-muted); display:flex; flex-direction:column; gap:var(--space-1); }
   .field-label { font-size:var(--type-secondary-size); color:var(--brown); font-weight:var(--type-secondary-weight); line-height:var(--type-secondary-line); }
   /* Form controls: default field */
   .text-input { width:100%; border:1.5px solid var(--border); border-radius:10px; padding:var(--space-field-padding-default); font-size:var(--type-body-size); line-height:var(--type-body-line); letter-spacing:var(--type-body-track); font-weight:var(--type-body-weight); color:var(--brown); background:var(--surf); }
   .btn-save-outcome { margin-top:var(--space-density-compact-control-gap); border-radius:10px; padding:var(--space-field-padding-default); }
+  @keyframes ratingSheetIn { from { opacity:0; transform:translateY(20px) scale(.995); } to { opacity:1; transform:translateY(0) scale(1); } }
 
   /* ── Contextual tips ── */
   .ctx { margin:0 var(--space-card-padding-lg) var(--space-card-row-gap); padding:var(--space-field-padding-default); background:var(--surf); border-radius:var(--radius-sm); border:1px solid color-mix(in srgb, var(--mutedBlue) 18%, var(--border)); border-left:3px solid var(--mutedBlue); font-size:var(--type-secondary-size); color:var(--text-muted); line-height:var(--type-secondary-line); letter-spacing:var(--type-secondary-track); font-weight:var(--type-secondary-weight); box-shadow:var(--shadow); }


### PR DESCRIPTION
### Motivation
- Replace the abrupt centered rating popup with a calm, premium bottom-sheet to make post-session feedback feel softer and less intrusive.
- Keep the decision fast and clear with the required stress options and remove slow follow-ups to reduce friction.
- Make it obvious to users that their choice adapts future training targets so the app’s behavior is transparent.

### Description
- Reworked the session rating UI in `SessionRatingPanel` to render as a bottom sheet with a grabber and slide-in animation instead of a centered modal (changes in `src/features/train/TrainComponents.jsx`).
- Simplified the options to the required single-tap choices and wired them to `recordResult(...)`: `No stress` → `none`, `Slight stress` → `subtle`, `Strong stress` → `active` (no intermediate state or extra save step).
- Removed the latency/distress-type follow-up fields and the multi-step outcome draft flow to keep the interaction quick and focused.
- Added an adaptive explanatory note and style updates in `src/styles/app.css` (backdrop, align to bottom, sheet radius, grabber, and entrance animation).

### Testing
- Built production assets with `npm run build` (succeeded).
- Ran the test suite with `npm test` (all tests passed: 17 files, 230 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0da0b6ba08332b6f156fb584bd069)