### PR TITLE
Add contextual explanations when training target changes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import HomeScreen from "./features/home/HomeScreen";
 import StatsScreen from "./features/stats/StatsScreen";
 import SettingsScreen from "./features/settings/SettingsScreen";
 import { HistoryScreen, useHistoryEditing } from "./features/history/HistoryFeature";
+import { buildTrainTimeChangeInsight } from "./features/train/timeChangeInsight";
 import "./styles/theme.css";
 import "./styles/shared.css";
 import "./styles/primitives.css";
@@ -69,6 +70,7 @@ export default function PawTimer() {
   const [settingsDisclosure, setSettingsDisclosure] = useState(null);
   const [trainingSettingsOpen, setTrainingSettingsOpen] = useState(false);
   const [trainFirstRunHintVisible, setTrainFirstRunHintVisible] = useState(false);
+  const [trainTimeChangeInsight, setTrainTimeChangeInsight] = useState(null);
   const [walkPhase, setWalkPhase] = useState("idle");
   const [walkElapsed, setWalkElapsed] = useState(0);
   const [walkPendingDuration, setWalkPendingDuration] = useState(0);
@@ -984,6 +986,7 @@ export default function PawTimer() {
       return;
     }
     completeTrainFirstRunHint();
+    setTrainTimeChangeInsight(null);
     setElapsed(0); setSessionCompleted(false); setSessionOutcome(null); setLatencyDraft(""); setDistressTypeDraft(""); setPhase("running");
   };
   const endSession = () => { clearInterval(timerRef.current); setFinalElapsed(elapsed); setPhase("rating"); };
@@ -1058,6 +1061,14 @@ export default function PawTimer() {
     pushWithSyncStatus("session", session).then(({ ok, error }) => { if (!ok) showToast(`Sync failed: ${error}`); });
     const nextRecommendation = deriveRecommendation(updated, walks, patterns, dog);
     const next = nextRecommendation.duration;
+    const timeChangeInsight = buildTrainTimeChangeInsight({
+      previousDuration: target,
+      recommendedDuration: next,
+      recommendationType: nextRecommendation?.details?.recommendationType,
+      distressLevel,
+      dogName: dog?.dogName,
+    });
+    setTrainTimeChangeInsight(timeChangeInsight);
     cancelSession();
     const n = dog?.dogName ?? "your dog";
     if (distressLevel === "none") showToast(`${n} was calm. Next: ${fmt(next)}`);
@@ -1184,7 +1195,7 @@ export default function PawTimer() {
           </div>
         </div>
 
-        {tab === "home" && <HomeScreen name={appData.name} sessions={canonicalSessions} recommendation={appData.recommendation} goalPct={appData.goalPct} goalSec={appData.goalSec} phase={phase} elapsed={elapsed} finalElapsed={finalElapsed} sessionCompleted={sessionCompleted} sessionOutcome={sessionOutcome} setSessionOutcome={setSessionOutcome} recordResult={recordResult} latencyDraft={latencyDraft} setLatencyDraft={setLatencyDraft} distressTypeDraft={distressTypeDraft} setDistressTypeDraft={setDistressTypeDraft} setPhase={setPhase} setElapsed={setElapsed} setFinalElapsed={setFinalElapsed} startSession={startSession} endSession={endSession} cancelSession={cancelSession} activeProto={appData.activeProto} daily={appData.daily} pattern={appData.pattern} walkPhase={walkPhase} startWalk={startWalk} cancelWalk={cancelWalk} walkElapsed={walkElapsed} endWalk={endWalk} walkPendingDuration={walkPendingDuration} saveWalkWithType={saveWalkWithType} patOpen={patOpen} setPatOpen={setPatOpen} patReminderText={appData.patReminderText} logPattern={logPattern} patLabels={patLabels} patterns={patterns} feedings={feedings} feedingOpen={feedingOpen} openFeedingForm={openFeedingForm} feedingDraft={feedingDraft} setFeedingDraft={setFeedingDraft} cancelFeedingForm={cancelFeedingForm} saveFeeding={saveFeeding} showTrainFirstRunHint={trainFirstRunHintVisible} dismissTrainFirstRunHint={completeTrainFirstRunHint} />}
+        {tab === "home" && <HomeScreen name={appData.name} sessions={canonicalSessions} recommendation={appData.recommendation} goalPct={appData.goalPct} goalSec={appData.goalSec} phase={phase} elapsed={elapsed} finalElapsed={finalElapsed} sessionCompleted={sessionCompleted} sessionOutcome={sessionOutcome} setSessionOutcome={setSessionOutcome} recordResult={recordResult} latencyDraft={latencyDraft} setLatencyDraft={setLatencyDraft} distressTypeDraft={distressTypeDraft} setDistressTypeDraft={setDistressTypeDraft} setPhase={setPhase} setElapsed={setElapsed} setFinalElapsed={setFinalElapsed} startSession={startSession} endSession={endSession} cancelSession={cancelSession} activeProto={appData.activeProto} daily={appData.daily} pattern={appData.pattern} walkPhase={walkPhase} startWalk={startWalk} cancelWalk={cancelWalk} walkElapsed={walkElapsed} endWalk={endWalk} walkPendingDuration={walkPendingDuration} saveWalkWithType={saveWalkWithType} patOpen={patOpen} setPatOpen={setPatOpen} patReminderText={appData.patReminderText} logPattern={logPattern} patLabels={patLabels} patterns={patterns} feedings={feedings} feedingOpen={feedingOpen} openFeedingForm={openFeedingForm} feedingDraft={feedingDraft} setFeedingDraft={setFeedingDraft} cancelFeedingForm={cancelFeedingForm} saveFeeding={saveFeeding} showTrainFirstRunHint={trainFirstRunHintVisible} dismissTrainFirstRunHint={completeTrainFirstRunHint} trainTimeChangeInsight={trainTimeChangeInsight} />}
         {tab === "history" && <HistoryScreen timeline={appData.timeline} sessions={canonicalSessions} name={appData.name} setTab={setTab} patLabels={patLabels} historyModal={historyModal} setHistoryModal={setHistoryModal} actions={historyActions} />}
         {tab === "progress" && <StatsScreen name={appData.name} totalCount={appData.totalCount} setTab={setTab} bestCalm={appData.bestCalm} recommendation={appData.recommendation} relapseTone={appData.relapseTone} chartData={appData.chartData} goalSec={appData.goalSec} CustomDot={CustomDot} distressLabel={appData.distressLabel} chartTrendLabel={appData.chartTrendLabel} aloneLastWeek={appData.aloneLastWeek} avgWalkDuration={appData.avgWalkDuration} avgSessionsPerDay={appData.avgSessionsPerDay} avgWalksPerDay={appData.avgWalksPerDay} headlineStatus={appData.headlineStatus} headlineStatusTone={appData.headlineStatusTone} />}
         {tab === "settings" && <SettingsScreen name={appData.name} activeDogId={activeDogId} copyDogId={copyDogId} notifEnabled={notifEnabled} handleToggleNotif={handleToggleNotif} notifTime={notifTime} setNotifTime={setNotifTime} scheduleNotif={scheduleNotif} dogs={dogs} activeProto={appData.activeProto} pattern={appData.pattern} recommendation={appData.recommendation} setTrainingSettingsOpen={setTrainingSettingsOpen} patLabels={patLabels} editingPat={editingPat} setEditingPat={setEditingPat} setPatLabels={setPatLabels} settingsDisclosure={settingsDisclosure} setSettingsDisclosure={setSettingsDisclosure} syncDiagRunning={syncDiagRunning} runSyncDiagnostics={runSyncDiagnostics} SYNC_ENABLED={SYNC_ENABLED} SB_URL={SB_URL} SB_KEY={SB_KEY} SB_BASE_URL={SB_BASE_URL} syncDiagResult={syncDiagResult} syncSummary={syncSummary} syncDegradation={syncDegradation} trainingSettingsOpen={trainingSettingsOpen} setProtoWarnAck={setProtoWarnAck} protoWarnAck={protoWarnAck} protoOverride={protoOverride} setProtoOverride={setProtoOverride} setScreen={setScreen} setOnboardingState={setOnboardingState} dogsState={dogs} setDogs={setDogs} save={save} ACTIVE_DOG_KEY={ACTIVE_DOG_KEY} setActiveDogId={setActiveDogId} clearDogActivityState={clearDogActivityState} />}

--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -51,6 +51,7 @@ export default function HomeScreen(props) {
     saveFeeding,
     showTrainFirstRunHint,
     dismissTrainFirstRunHint,
+    trainTimeChangeInsight,
   } = props;
   const target = recommendation?.duration ?? 0;
   const recoveryMode = recommendation?.details?.recoveryMode;
@@ -162,6 +163,12 @@ export default function HomeScreen(props) {
             <div className="train-recovery-inline" role="note" aria-live="polite">
               <p className="train-recovery-inline__title">{recoveryModalTitle}</p>
               <p className="train-recovery-inline__copy">{recoveryModalCopy}</p>
+            </div>
+          )}
+          {phase === "idle" && trainTimeChangeInsight && (
+            <div className={`train-time-change-insight is-${trainTimeChangeInsight.tone || "neutral"}`} role="status" aria-live="polite">
+              <p className="train-time-change-insight__title">{trainTimeChangeInsight.title}</p>
+              <p className="train-time-change-insight__copy">{trainTimeChangeInsight.body}</p>
             </div>
           )}
         </section>

--- a/src/features/train/timeChangeInsight.js
+++ b/src/features/train/timeChangeInsight.js
@@ -1,0 +1,66 @@
+import { fmtClock } from "../app/helpers";
+
+function isNumber(value) {
+  return Number.isFinite(Number(value));
+}
+
+export function buildTrainTimeChangeInsight({
+  previousDuration,
+  recommendedDuration,
+  recommendationType,
+  distressLevel,
+  dogName,
+}) {
+  if (!isNumber(previousDuration) || !isNumber(recommendedDuration)) return null;
+
+  const previous = Number(previousDuration);
+  const next = Number(recommendedDuration);
+  const formattedNext = fmtClock(next);
+  const name = dogName || "your dog";
+  const dropped = next < previous;
+  const increased = next > previous;
+
+  if (!dropped && !increased && recommendationType !== "recovery_mode_active" && recommendationType !== "recovery_mode_resume") {
+    return null;
+  }
+
+  if (recommendationType === "recovery_mode_active") {
+    return {
+      tone: "caution",
+      title: `Recovery mode on · target is now ${formattedNext}`,
+      body: `${name} showed stress signs, so we switched to short reset sessions to rebuild calm confidence.`,
+    };
+  }
+
+  if (recommendationType === "recovery_mode_resume") {
+    return {
+      tone: "positive",
+      title: `Recovery complete · target is now ${formattedNext}`,
+      body: `Recent calm reset sessions went well, so we are gently stepping back up again.`,
+    };
+  }
+
+  if (dropped) {
+    return {
+      tone: "caution",
+      title: `Target eased to ${formattedNext}`,
+      body: distressLevel === "none"
+        ? `We lowered the next session slightly to keep training comfortable and steady.`
+        : `${name} showed stress signs, so the next session is shorter to protect confidence.`,
+    };
+  }
+
+  if (increased) {
+    return {
+      tone: "positive",
+      title: `Target increased to ${formattedNext}`,
+      body: `Recent calm sessions were successful, so the next step is a little longer.`,
+    };
+  }
+
+  return {
+    tone: "neutral",
+    title: `Target stays at ${formattedNext}`,
+    body: `We are holding this duration to keep progress steady and predictable.`,
+  };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -703,6 +703,39 @@
     color:var(--text-muted);
     line-height:var(--type-helper-text-line);
   }
+  .train-time-change-insight {
+    margin-top:10px;
+    border-radius:12px;
+    border:1px solid color-mix(in srgb, var(--border) 80%, white);
+    background:color-mix(in srgb, var(--surface-muted) 84%, var(--surf));
+    padding:10px 12px;
+    text-align:left;
+    animation:trainInsightFadeIn 220ms ease-out;
+  }
+  .train-time-change-insight.is-positive {
+    border-color:color-mix(in srgb, var(--green) 34%, var(--border));
+    background:color-mix(in srgb, var(--green) 14%, var(--surf));
+  }
+  .train-time-change-insight.is-caution {
+    border-color:color-mix(in srgb, var(--amber) 42%, var(--border));
+    background:color-mix(in srgb, var(--amber) 14%, var(--surf));
+  }
+  .train-time-change-insight__title {
+    margin:0;
+    font-size:var(--type-helper-text-size);
+    font-weight:600;
+    color:var(--brown);
+  }
+  .train-time-change-insight__copy {
+    margin:4px 0 0;
+    font-size:var(--type-helper-text-size);
+    color:var(--text-muted);
+    line-height:var(--type-helper-text-line);
+  }
+  @keyframes trainInsightFadeIn {
+    from { opacity:0; transform:translateY(4px); }
+    to { opacity:1; transform:translateY(0); }
+  }
   .train-today { padding:12px 14px; border-radius:18px; }
   .train-today-body {
     transition:max-height 0.32s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.24s ease, transform 0.32s cubic-bezier(0.22, 1, 0.36, 1);

--- a/tests/timeChangeInsight.test.js
+++ b/tests/timeChangeInsight.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { buildTrainTimeChangeInsight } from "../src/features/train/timeChangeInsight";
+
+describe("buildTrainTimeChangeInsight", () => {
+  it("explains decreases after stress with caution tone", () => {
+    const insight = buildTrainTimeChangeInsight({
+      previousDuration: 120,
+      recommendedDuration: 60,
+      recommendationType: "decrease_duration",
+      distressLevel: "active",
+      dogName: "Milo",
+    });
+
+    expect(insight?.tone).toBe("caution");
+    expect(insight?.title).toContain("Target eased");
+    expect(insight?.body).toContain("stress signs");
+  });
+
+  it("explains increases after calm sessions", () => {
+    const insight = buildTrainTimeChangeInsight({
+      previousDuration: 60,
+      recommendedDuration: 90,
+      recommendationType: "increase_duration",
+      distressLevel: "none",
+      dogName: "Milo",
+    });
+
+    expect(insight?.tone).toBe("positive");
+    expect(insight?.title).toContain("Target increased");
+  });
+
+  it("explains recovery mode activation", () => {
+    const insight = buildTrainTimeChangeInsight({
+      previousDuration: 90,
+      recommendedDuration: 60,
+      recommendationType: "recovery_mode_active",
+      distressLevel: "subtle",
+      dogName: "Milo",
+    });
+
+    expect(insight?.title).toContain("Recovery mode on");
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a calm, in-context explanation whenever the recommended training target changes so users understand why the target increased, decreased, or switched into/out of recovery mode.

### Description
- Add `buildTrainTimeChangeInsight` helper (`src/features/train/timeChangeInsight.js`) to generate simple tone/title/body explanations from previous vs recommended durations and recommendation type.
- Wire the helper into the train flow in `src/App.jsx` to clear insights on start and compute/set an insight after `recordResult`, then pass `trainTimeChangeInsight` into `HomeScreen`.
- Render a soft, non-modal inline insight banner in `src/features/home/HomeScreen.jsx` with polite `aria-live` semantics and add styles/animation in `src/styles/app.css` for positive/caution tones.
- Add unit tests for key scenarios in `tests/timeChangeInsight.test.js`.

### Testing
- Ran `npm test -- --run tests/timeChangeInsight.test.js` and the new tests passed.
- Ran the full test suite via `npm test` and all tests passed (233 tests total).
- Built the production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0dd2da00c833284aab795156e6174)