### PR TITLE
Redesign History screen into calm timeline progress story

### DIFF
--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -343,18 +343,58 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
   const recentCount = timeline.slice(0, 7).length;
   const sessionCount = timeline.filter((item) => item.kind === "session").length;
   const careCount = timeline.filter((item) => item.kind !== "session").length;
+  const lastSession = timeline.find((item) => item.kind === "session");
+  const timelineByDay = timeline.reduce((acc, item) => {
+    const isoDate = item?.date;
+    if (!isoDate) return acc;
+    const dayKey = isoDate.slice(0, 10);
+    if (!acc[dayKey]) acc[dayKey] = [];
+    acc[dayKey].push(item);
+    return acc;
+  }, {});
+  const dayGroups = Object.entries(timelineByDay).sort(([a], [b]) => (a < b ? 1 : -1));
+  const recentTrend = (() => {
+    const trendDays = 7;
+    const today = new Date();
+    const buckets = [];
+    for (let offset = trendDays - 1; offset >= 0; offset -= 1) {
+      const bucketDate = new Date(today);
+      bucketDate.setHours(0, 0, 0, 0);
+      bucketDate.setDate(bucketDate.getDate() - offset);
+      const dayKey = bucketDate.toISOString().slice(0, 10);
+      const daySessions = timelineByDay[dayKey]?.filter((item) => item.kind === "session") ?? [];
+      const calmSessions = daySessions.filter((item) => normalizeDistressLevel(item?.data?.distressLevel) === "none").length;
+      buckets.push({
+        dayKey,
+        count: daySessions.length,
+        calmCount: calmSessions,
+        label: bucketDate.toLocaleDateString(undefined, { weekday: "short" }),
+      });
+    }
+    return buckets;
+  })();
+  const trendMax = Math.max(1, ...recentTrend.map((day) => day.count));
+  const trendLevel = (count) => {
+    if (count <= 0) return 0;
+    const ratio = count / trendMax;
+    if (ratio >= 0.8) return 4;
+    if (ratio >= 0.6) return 3;
+    if (ratio >= 0.35) return 2;
+    if (ratio >= 0.15) return 1;
+    return 0;
+  };
 
   const toggleExpandedItem = (itemKey) => {
     setExpandedItemKey((prev) => (prev === itemKey ? null : itemKey));
   };
 
-  const renderHistoryCard = ({ itemKey, title, date, value, badge, syncBadge, expandedContent }) => {
+  const renderHistoryCard = ({ itemKey, title, date, value, badge, syncBadge, expandedContent, kindLabel }) => {
     const isExpanded = expandedItemKey === itemKey;
     const detailsId = `history-details-${itemKey}`;
 
     return (
       <div
-        className={`h-item surface-row--interactive interactive-row-card ${isExpanded ? "is-expanded" : ""}`.trim()}
+        className={`h-item ${isExpanded ? "is-expanded" : ""}`.trim()}
         key={itemKey}
         role="button"
         tabIndex={0}
@@ -369,7 +409,9 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
       >
         <div className="h-body">
           <div className="h-content">
+            <div className="h-marker" aria-hidden="true" />
             <div className="h-info">
+              <div className="h-kind">{kindLabel}</div>
               <div className="h-main">{title}</div>
               <div className="h-meta-line">
                 <span className="h-date">{date}</span>
@@ -397,22 +439,55 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
         <div className="section">
           <div className="history-section-head">
             <div>
-              <div className="section-title">Story timeline</div>
-              <div className="t-helper">A narrative of {name}'s training and support routines over time.</div>
+              <div className="section-title">History</div>
+              <div className="t-helper">A calm view of {name}&rsquo;s training progress.</div>
             </div>
             {sessions.length > 0 && <button className="clear-btn surface-text-button secondary-control secondary-control--inline-text" onClick={actions.clearSessions}>Clear sessions</button>}
           </div>
           {timeline.length > 0 && (
-            <div className="history-story-summary">
-              <span>{recentCount} recent moments</span>
-              <span>{sessionCount} training sessions</span>
-              <span>{careCount} support routine logs</span>
+            <div className="history-summary-surface">
+              <div className="history-summary-grid">
+                <div className="history-summary-item">
+                  <div className="history-summary-value">{sessionCount}</div>
+                  <div className="history-summary-label">Training sessions</div>
+                </div>
+                <div className="history-summary-item">
+                  <div className="history-summary-value">{careCount}</div>
+                  <div className="history-summary-label">Care routine logs</div>
+                </div>
+                <div className="history-summary-item">
+                  <div className="history-summary-value">{recentCount}</div>
+                  <div className="history-summary-label">Recent moments</div>
+                </div>
+              </div>
+              <div className="history-mini-trend" aria-label="Last seven days of training sessions">
+                <div className="history-mini-trend-head">
+                  <span>7-day training rhythm</span>
+                  <span>{recentTrend.reduce((sum, day) => sum + day.count, 0)} sessions</span>
+                </div>
+                <div className="history-mini-trend-bars" role="img" aria-label="Each bar shows number of sessions completed each day">
+                  {recentTrend.map((day) => (
+                    <div className="history-mini-trend-day" key={day.dayKey}>
+                      <div
+                        className={`history-mini-trend-bar history-mini-trend-bar--level-${trendLevel(day.count)}`}
+                        title={`${day.dayKey}: ${day.count} session${day.count === 1 ? "" : "s"}, ${day.calmCount} calm`}
+                      />
+                      <span>{day.label.slice(0, 1)}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              {lastSession ? <div className="history-summary-note">Latest training session: {fmtDate(lastSession.date)}.</div> : null}
             </div>
           )}
 
           {timeline.length === 0 ? (
             <EmptyState media={<TrendIcon />} title="No activity yet" body={`Start ${name}'s first session and your training history will appear here.`} ctaLabel="Go to Train →" onCta={() => setTab("home")} />
-          ) : timeline.map((item) => {
+          ) : dayGroups.map(([dayKey, items]) => (
+            <div className="history-day-group" key={dayKey}>
+              <div className="history-day-label">{new Date(`${dayKey}T00:00:00`).toLocaleDateString(undefined, { weekday: "long", month: "short", day: "numeric" })}</div>
+              <div className="history-day-track">
+                {items.map((item) => {
             if (item.kind === "session") {
               const s = item.data;
               const lv = normalizeDistressLevel(
@@ -425,6 +500,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                 title: "Training session",
                 date: fmtDate(s.date),
                 value: fmt(s.actualDuration),
+                kindLabel: "Training",
                 badge: <span className={`h-badge badge-${lv}`}>{lv === "none" ? "No distress" : lv === "subtle" ? "Subtle stress" : lv === "active" ? "Active distress" : "Severe distress"}</span>,
                 syncBadge: renderSyncBadge(s),
                 expandedContent: <>
@@ -454,6 +530,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                 title: `${walkTypeLabel(w.type)} with ${name}`,
                 date: fmtDate(w.date),
                 value: w.duration ? fmt(w.duration) : "—",
+                kindLabel: "Support",
                 badge: <span className="h-side-label">Duration</span>,
                 syncBadge: renderSyncBadge(w),
                 expandedContent: <>
@@ -483,6 +560,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                 itemKey: `p-${p.id}`,
                 title: patLabels[pt.type] || pt.label,
                 date: fmtDate(p.date),
+                kindLabel: "Support",
                 badge: <span className="h-badge badge-pat">Pattern break</span>,
                 syncBadge: renderSyncBadge(p),
                 expandedContent: <>
@@ -510,6 +588,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                 title: <span className="history-food-type">{f.foodType}</span>,
                 date: fmtDate(f.date),
                 value: f.amount,
+                kindLabel: "Support",
                 badge: <span className="h-badge badge-feed">Feeding</span>,
                 syncBadge: renderSyncBadge(f),
                 expandedContent: <>
@@ -531,7 +610,8 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
               });
             }
             return null;
-          })}
+          })}</div></div>
+          ))}
         </div>
       </div>
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1214,20 +1214,27 @@
   .section { padding:var(--space-3); overflow-x:hidden; }
   .section > .section-title:first-child { margin-bottom:var(--space-section-gap); }
   .history-section-head { display:flex; justify-content:space-between; align-items:baseline; margin-bottom:var(--space-3); }
-  .history-story-summary {
-    display:flex;
-    flex-wrap:wrap;
-    gap:8px;
-    margin:-6px 0 var(--space-card-row-gap);
-  }
-  .history-story-summary span {
-    font-size:var(--type-helper-text-size);
-    color:var(--text-muted);
-    background:var(--surface-muted);
-    border:1px solid var(--border);
-    border-radius:999px;
-    padding:4px 10px;
-  }
+  .history-summary-surface { margin:0 0 var(--space-section-gap); padding:var(--space-card-padding); border-radius:var(--radius-sm); border:1px solid color-mix(in srgb, var(--mutedBlue) 16%, var(--border)); background:color-mix(in srgb, var(--surface-muted) 80%, white); display:grid; gap:var(--space-control-gap); }
+  .history-summary-grid { display:grid; grid-template-columns:repeat(3, minmax(0, 1fr)); gap:var(--space-control-gap); }
+  .history-summary-item { display:grid; gap:2px; min-width:0; }
+  .history-summary-value { font-size:var(--type-field-value-size); font-weight:var(--type-field-value-weight); line-height:var(--type-field-value-line); letter-spacing:var(--type-field-value-track); color:var(--brown); font-variant-numeric:tabular-nums; }
+  .history-summary-label { font-size:var(--type-helper-text-size); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); color:var(--text-muted); }
+  .history-summary-note { font-size:var(--type-helper-text-size); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); color:var(--brown-muted); }
+  .history-mini-trend { display:grid; gap:var(--space-density-compact-control-gap); }
+  .history-mini-trend-head { display:flex; justify-content:space-between; align-items:center; gap:var(--space-control-gap); font-size:var(--type-helper-text-size); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); color:var(--text-muted); }
+  .history-mini-trend-bars { height:56px; display:grid; grid-template-columns:repeat(7, minmax(0, 1fr)); gap:8px; align-items:end; }
+  .history-mini-trend-day { height:100%; display:grid; grid-template-rows:1fr auto; gap:4px; justify-items:center; align-items:end; min-width:0; }
+  .history-mini-trend-bar { width:100%; border-radius:999px; background:linear-gradient(180deg, color-mix(in srgb, var(--primaryBlue) 58%, white), color-mix(in srgb, var(--mutedBlue) 72%, var(--surface-muted))); min-height:12px; }
+  .history-mini-trend-bar--level-0 { height:12%; }
+  .history-mini-trend-bar--level-1 { height:30%; }
+  .history-mini-trend-bar--level-2 { height:50%; }
+  .history-mini-trend-bar--level-3 { height:74%; }
+  .history-mini-trend-bar--level-4 { height:100%; }
+  .history-mini-trend-day span { font-size:var(--type-micro-text-size); line-height:var(--type-micro-text-line); letter-spacing:var(--type-micro-text-track); color:var(--text-muted); text-transform:uppercase; }
+  .history-day-group { display:grid; gap:var(--space-control-gap); margin-bottom:var(--space-section-gap); }
+  .history-day-label { font-size:var(--type-overline-size); line-height:var(--type-overline-line); letter-spacing:var(--type-overline-track); font-weight:var(--type-overline-weight); text-transform:uppercase; color:var(--text-muted); }
+  .history-day-track { position:relative; display:grid; gap:var(--space-density-compact-control-gap); }
+  .history-day-track::before { content:""; position:absolute; left:11px; top:2px; bottom:2px; width:2px; border-radius:999px; background:color-mix(in srgb, var(--border) 88%, transparent); }
   .section-title { font-size:var(--type-section-heading-size); font-weight:var(--type-section-heading-weight); color:var(--text); line-height:var(--type-section-heading-line); letter-spacing:var(--type-section-heading-track); margin:0; min-height:calc(var(--type-section-heading-line) * 1em); display:flex; align-items:baseline; }
   .section-title--flush { margin-bottom:0; }
   .empty-state { text-align:center; padding:var(--space-5) 28px; color:var(--text-muted); }
@@ -1356,11 +1363,15 @@
   .pat-edit-actions { display:flex; align-items:center; gap:var(--space-control-gap); flex-shrink:0; }
   .pat-edit-btn { border:none; background:none; cursor:pointer; color:var(--primaryBlue); text-decoration:underline; }
   .pat-edit-btn:hover { color:var(--blue-darker); }
-  .h-item { margin-bottom:var(--space-card-row-gap); align-items:flex-start; animation:surfaceEnter var(--motion-enter) var(--ease-out); }
-  .h-item.is-expanded { box-shadow:var(--shadow-lg); }
+  .h-item { position:relative; margin:0; align-items:flex-start; animation:surfaceEnter var(--motion-enter) var(--ease-out); border:1px solid transparent; border-radius:var(--radius-sm); padding:10px 10px 10px 0; transition:background var(--motion-base) var(--ease-out), border-color var(--motion-base) var(--ease-out); }
+  .h-item:hover { background:color-mix(in srgb, var(--surface-muted) 64%, white); }
+  .h-item:focus-visible { outline:none; border-color:color-mix(in srgb, var(--mutedBlue) 40%, var(--border)); background:color-mix(in srgb, var(--surface-muted) 70%, white); }
+  .h-item.is-expanded { border-color:color-mix(in srgb, var(--mutedBlue) 24%, var(--border)); background:color-mix(in srgb, var(--surface-muted) 70%, white); }
   .h-body { flex:1; min-width:0; display:flex; flex-direction:column; gap:var(--space-control-gap); }
   .h-content { display:flex; align-items:flex-start; justify-content:space-between; gap:var(--space-control-gap); min-width:0; }
+  .h-marker { width:10px; height:10px; margin:8px 0 0 7px; border-radius:50%; background:color-mix(in srgb, var(--mutedBlue) 65%, white); box-shadow:0 0 0 3px color-mix(in srgb, var(--surface-muted) 86%, white); flex:0 0 auto; }
   .h-info { flex:1; min-width:0; display:flex; flex-direction:column; gap:var(--row-gap-dense); padding-top:1px; }
+  .h-kind { font-size:var(--type-micro-text-size); font-weight:var(--type-overline-weight); line-height:var(--type-micro-text-line); letter-spacing:var(--type-overline-track); color:var(--text-muted); text-transform:uppercase; }
   .h-main { font-size:var(--type-list-row-title-size); font-weight:var(--type-list-row-title-weight); line-height:var(--type-list-row-title-line); letter-spacing:var(--type-list-row-title-track); color:var(--brown); }
   .h-meta-line { display:flex; flex-wrap:wrap; align-items:center; gap:8px; min-width:0; }
   .h-date { font-size:var(--type-helper-text-size); font-weight:var(--type-helper-text-weight); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); color:var(--text-muted); min-width:0; }
@@ -1375,7 +1386,7 @@
   .h-secondary { font-size:var(--type-helper-text-size); font-weight:var(--type-helper-text-weight); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); color:var(--text-muted); }
   .h-secondary { min-width:0; }
   .h-badge { font-size:var(--type-status-text-size); font-weight:var(--type-status-text-weight); line-height:var(--type-status-text-line); padding:var(--space-pill-padding-small); border-radius:99px; letter-spacing:var(--type-status-text-track); white-space:nowrap; flex-shrink:0; text-transform:uppercase; }
-  .h-expand { display:grid; gap:var(--space-control-gap); margin-top:var(--space-card-row-gap); padding-top:var(--space-control-gap); border-top:1px solid var(--border); }
+  .h-expand { display:grid; gap:var(--space-control-gap); margin-top:var(--space-density-compact-control-gap); margin-left:24px; padding-top:var(--space-control-gap); border-top:1px solid var(--border); }
   .h-expand-grid { display:grid; gap:var(--space-control-gap); }
   .h-expand-footer { padding-top:2px; }
   .h-detail-group { display:grid; gap:var(--row-gap-default); }
@@ -1391,7 +1402,9 @@
   .badge-feed   { background:var(--status-warning-bg); color:color-mix(in srgb, var(--warning) 72%, var(--brown)); }
   .badge-pat    { background:var(--status-neutral-bg); color:var(--brown-mid); }
   @media (max-width: 560px) {
+    .history-summary-grid { grid-template-columns:1fr; gap:var(--space-density-compact-control-gap); }
     .h-content { flex-direction:column; align-items:flex-start; }
+    .h-marker { margin-left:8px; }
     .h-side { align-items:flex-start; text-align:left; }
     .h-actions { justify-content:flex-start; }
   }


### PR DESCRIPTION
### Motivation
- Convert the History view from a raw log dump of heavy cards into a calm, readable progress story showing meaningful progression and context. 
- Surface a compact, informative summary and trend so users quickly understand recent training rhythm without dashboard clutter. 
- Preserve existing edit/delete flows and dog-training semantics while reducing visual noise.

### Description
- Reorganized history rendering to group entries by day (YYYY‑MM‑DD) and render day headers with a vertical timeline rail, replacing the previous flat list. (`src/features/history/HistoryFeature.jsx`)
- Added a top summary surface with key counts (training sessions, care logs, recent moments), a compact 7‑day mini trend (bucketed bars), and latest-session note to provide immediate, low‑noise context. (`src/features/history/HistoryFeature.jsx`, `src/styles/app.css`)
- Reworked item rows to be lighter and timeline‑oriented: introduced a small timeline marker, a concise kind label (`Training` / `Support`), and kept tap‑to‑expand details and existing action buttons (edit time/duration, delete). (`src/features/history/HistoryFeature.jsx`, `src/styles/app.css`)
- Replaced inline visual sizing for the mini trend with a discrete bucket model (`trendLevel`) and CSS classes to satisfy inline-style hygiene. (`src/features/history/HistoryFeature.jsx`, `src/styles/app.css`)
- Kept all existing modal editors, action handlers, and sync badges unchanged so behavior and data flows remain intact. (`src/features/history/HistoryFeature.jsx`)

### Testing
- Ran a production build with `npm run build` which completed successfully. 
- Ran unit tests with `vitest` for history-related suites using `npm run test -- tests/historyDurationEditing.test.js tests/historyDeleteReloadHydration.test.js` and all tests passed (2 files, 12 tests total). 
- Ran the inline-style hygiene check (`npm run check:inline-styles`); the new code removed inline sizing for the mini trend, but the checker still flags an unrelated pre-existing inline style in `src/features/train/TrainComponents.jsx` (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0debbbc188332ac47216da9a3660b)