### PR TITLE
Implement History session detail bottom sheet interaction

### DIFF
--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import EmptyState from "../../components/EmptyState";
 import { buildEditedActivityIso, sortByDateAsc, toDateInputValue, toTimeInputValue } from "../../lib/activityDateTime";
 import { normalizeDistressLevel } from "../../lib/protocol";
@@ -334,6 +334,7 @@ const renderSyncBadge = (entry) => {
 
 export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, historyModal, setHistoryModal, actions }) {
   const [expandedItemKey, setExpandedItemKey] = useState(null);
+  const [sessionDetail, setSessionDetail] = useState(null);
   const parsedDuration = historyModal?.mode === "duration" ? parseDurationInput(historyModal.value) : null;
   const requiresPositiveDuration = historyModal?.kind === "session";
   const durationHasInput = historyModal?.mode === "duration" && String(historyModal.value ?? "").trim().length > 0;
@@ -388,23 +389,43 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
     setExpandedItemKey((prev) => (prev === itemKey ? null : itemKey));
   };
 
-  const renderHistoryCard = ({ itemKey, title, date, value, badge, syncBadge, expandedContent, kindLabel }) => {
+  useEffect(() => {
+    if (!sessionDetail) return;
+    const closeOnEscape = (event) => {
+      if (event.key === "Escape") setSessionDetail(null);
+    };
+    window.addEventListener("keydown", closeOnEscape);
+    return () => window.removeEventListener("keydown", closeOnEscape);
+  }, [sessionDetail]);
+
+  const renderHistoryCard = ({ itemKey, title, date, value, badge, syncBadge, expandedContent, kindLabel, onActivate }) => {
     const isExpanded = expandedItemKey === itemKey;
     const detailsId = `history-details-${itemKey}`;
+    const isInteractiveCard = typeof onActivate === "function" || Boolean(expandedContent);
+    const cardClassName = `h-item ${isExpanded ? "is-expanded" : ""} ${typeof onActivate === "function" ? "is-tap-card" : ""}`.trim();
+
+    const handleActivate = () => {
+      if (typeof onActivate === "function") {
+        onActivate();
+        return;
+      }
+      if (expandedContent) toggleExpandedItem(itemKey);
+    };
 
     return (
       <div
-        className={`h-item ${isExpanded ? "is-expanded" : ""}`.trim()}
+        className={cardClassName}
         key={itemKey}
-        role="button"
-        tabIndex={0}
-        aria-expanded={isExpanded}
-        aria-controls={detailsId}
-        onClick={() => toggleExpandedItem(itemKey)}
+        role={isInteractiveCard ? "button" : undefined}
+        tabIndex={isInteractiveCard ? 0 : undefined}
+        aria-expanded={expandedContent ? isExpanded : undefined}
+        aria-controls={expandedContent ? detailsId : undefined}
+        onClick={isInteractiveCard ? handleActivate : undefined}
         onKeyDown={(event) => {
+          if (!isInteractiveCard) return;
           if (event.key !== "Enter" && event.key !== " ") return;
           event.preventDefault();
-          toggleExpandedItem(itemKey);
+          handleActivate();
         }}
       >
         <div className="h-body">
@@ -494,33 +515,15 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                 s.distressLevel
                 ?? (s.result === "success" ? "none" : (s.result === "distress" ? "strong" : null)),
               );
-              const detailBadges = sessionDetailBadges(s);
               return renderHistoryCard({
                 itemKey: `s-${s.id}`,
                 title: "Training session",
                 date: fmtDate(s.date),
                 value: fmt(s.actualDuration),
                 kindLabel: "Training",
+                onActivate: () => setSessionDetail(s),
                 badge: <span className={`h-badge badge-${lv}`}>{lv === "none" ? "No distress" : lv === "subtle" ? "Subtle stress" : lv === "active" ? "Active distress" : "Severe distress"}</span>,
                 syncBadge: renderSyncBadge(s),
-                expandedContent: <>
-                  <div className="h-expand-grid">
-                    <HistoryDetailGroup label="Session details">
-                      <HistoryChipList items={detailBadges} />
-                    </HistoryDetailGroup>
-                  </div>
-                  <div className="h-expand-footer">
-                    <HistoryDetailGroup label="Actions">
-                      <HistoryActionGroup
-                        actions={[
-                          { key: "time", className: "h-edit", label: "Edit session time", icon: <ClockIcon />, onClick: () => actions.editSessionTime(s.id, setHistoryModal) },
-                          { key: "duration", className: "h-edit", label: "Edit session duration", icon: <EditIcon />, onClick: () => actions.editSessionDuration(s.id, setHistoryModal) },
-                          { key: "delete", className: "h-del", label: "Delete session", icon: <DeleteIcon />, onClick: () => actions.requestHistoryDelete("session", s, setHistoryModal) },
-                        ]}
-                      />
-                    </HistoryDetailGroup>
-                  </div>
-                </>,
               });
             }
             if (item.kind === "walk") {
@@ -668,6 +671,67 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                 <button className="history-delete-confirm button-base button-danger button--md button--pill" type="button" onClick={() => actions.confirmHistoryDelete(historyModal, setHistoryModal)}>Delete</button>
               </div>
             </>}
+          </div>
+        </div>
+      )}
+
+      {sessionDetail && (
+        <div
+          className="history-session-sheet-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="history-session-sheet-title"
+          onClick={() => setSessionDetail(null)}
+        >
+          <div className="history-session-sheet modal-card modal-card--dialog-md" onClick={(event) => event.stopPropagation()}>
+            <div className="history-session-sheet-grabber" aria-hidden="true" />
+            <div className="quick-modal-head">
+              <div className="section-title section-title--flush" id="history-session-sheet-title">Session details</div>
+              <ModalCloseButton onClick={() => setSessionDetail(null)} />
+            </div>
+            <div className="history-session-sheet-meta">
+              <div className="history-session-sheet-value">{fmt(sessionDetail.actualDuration)}</div>
+              <div className="history-session-sheet-date">{fmtDate(sessionDetail.date)}</div>
+            </div>
+            <HistoryDetailGroup label="Details">
+              <HistoryChipList items={sessionDetailBadges(sessionDetail)} />
+            </HistoryDetailGroup>
+            <HistoryDetailGroup label="Actions">
+              <HistoryActionGroup
+                actions={[
+                  {
+                    key: "time",
+                    className: "h-edit",
+                    label: "Edit session time",
+                    icon: <ClockIcon />,
+                    onClick: () => {
+                      actions.editSessionTime(sessionDetail.id, setHistoryModal);
+                      setSessionDetail(null);
+                    },
+                  },
+                  {
+                    key: "duration",
+                    className: "h-edit",
+                    label: "Edit session duration",
+                    icon: <EditIcon />,
+                    onClick: () => {
+                      actions.editSessionDuration(sessionDetail.id, setHistoryModal);
+                      setSessionDetail(null);
+                    },
+                  },
+                  {
+                    key: "delete",
+                    className: "h-del",
+                    label: "Delete session",
+                    icon: <DeleteIcon />,
+                    onClick: () => {
+                      actions.requestHistoryDelete("session", sessionDetail, setHistoryModal);
+                      setSessionDetail(null);
+                    },
+                  },
+                ]}
+              />
+            </HistoryDetailGroup>
           </div>
         </div>
       )}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1365,6 +1365,7 @@
   .pat-edit-btn:hover { color:var(--blue-darker); }
   .h-item { position:relative; margin:0; align-items:flex-start; animation:surfaceEnter var(--motion-enter) var(--ease-out); border:1px solid transparent; border-radius:var(--radius-sm); padding:10px 10px 10px 0; transition:background var(--motion-base) var(--ease-out), border-color var(--motion-base) var(--ease-out); }
   .h-item:hover { background:color-mix(in srgb, var(--surface-muted) 64%, white); }
+  .h-item.is-tap-card { cursor:pointer; }
   .h-item:focus-visible { outline:none; border-color:color-mix(in srgb, var(--mutedBlue) 40%, var(--border)); background:color-mix(in srgb, var(--surface-muted) 70%, white); }
   .h-item.is-expanded { border-color:color-mix(in srgb, var(--mutedBlue) 24%, var(--border)); background:color-mix(in srgb, var(--surface-muted) 70%, white); }
   .h-body { flex:1; min-width:0; display:flex; flex-direction:column; gap:var(--space-control-gap); }
@@ -1395,6 +1396,12 @@
   .h-chip-list { display:flex; flex-wrap:wrap; gap:var(--row-gap-default); }
   .h-chip { display:inline-flex; align-items:center; min-height:30px; padding:var(--space-density-compact-control-gap) 10px; border-radius:999px; background:color-mix(in srgb, var(--surface-muted) 90%, var(--warm-accent-soft)); color:var(--brown-muted); font-size:var(--type-secondary-size); font-weight:var(--type-secondary-weight); line-height:var(--type-secondary-line); letter-spacing:var(--type-secondary-track); border:1px solid color-mix(in srgb, var(--warm-accent-border) 24%, transparent); }
   .h-detail-empty { font-size:var(--type-secondary-size); font-weight:var(--type-secondary-weight); line-height:var(--type-secondary-line); letter-spacing:var(--type-secondary-track); color:var(--text-muted); }
+  .history-session-sheet-overlay { position:fixed; inset:0; z-index:225; display:flex; align-items:flex-end; justify-content:center; padding:var(--space-2); background:color-mix(in srgb, var(--surface-overlay) 86%, transparent); animation:fadeIn var(--motion-base) var(--ease-out); }
+  .history-session-sheet { --modal-card-max-width:540px; width:100%; margin:0; border-radius:24px 24px 18px 18px; background:var(--surface-gradient-raised); border-color:color-mix(in srgb, var(--border) 92%, var(--surf)); padding-top:var(--space-2); display:grid; gap:var(--space-control-gap); animation:ratingSheetIn var(--motion-slow, 260ms) var(--ease-out); }
+  .history-session-sheet-grabber { width:44px; height:5px; border-radius:999px; background:color-mix(in srgb, var(--text-subtle) 30%, transparent); margin:0 auto; }
+  .history-session-sheet-meta { display:grid; gap:3px; }
+  .history-session-sheet-value { font-size:var(--type-metric-lg-size); line-height:var(--type-metric-lg-line); letter-spacing:var(--type-metric-lg-track); font-weight:var(--type-metric-lg-weight); color:var(--brown); font-variant-numeric:tabular-nums; }
+  .history-session-sheet-date { font-size:var(--type-secondary-size); line-height:var(--type-secondary-line); letter-spacing:var(--type-secondary-track); font-weight:var(--type-secondary-weight); color:var(--text-muted); }
   .badge-none   { background:color-mix(in srgb, var(--status-success-bg) 74%, transparent);  color:var(--green-dark); }
   .badge-subtle { background:color-mix(in srgb, var(--warning) 14%, transparent); color:var(--orange); }
   .badge-active { background:color-mix(in srgb, var(--status-attention-bg) 90%, transparent); color:var(--status-attention-fg); }


### PR DESCRIPTION
### Motivation
- Replace the cramped inline expansion for training sessions with a focused, minimal detail surface to keep the timeline calm and avoid abrupt modal explosions.
- Preserve existing edit/delete flows so users can still perform `Edit session time`, `Edit session duration`, and `Delete session` from the new sheet.

### Description
- Added a tap-to-open bottom sheet by introducing `sessionDetail` state and wiring session cards to call `setSessionDetail(...)` to open the sheet in `src/features/history/HistoryFeature.jsx`.
- Implemented a compact session sheet UI with grabber, headline, duration/date, compact chips, Escape-to-close, and action buttons that reuse existing handlers, also closing the sheet before invoking edits or delete.
- Kept non-session timeline items (walks, pattern breaks, feedings) using the existing inline expand behavior so scope is limited to sessions.
- Added related styling for the sheet and a small interactive card affordance in `src/styles/app.css`.

### Testing
- Ran the related unit/runtime suites: `npm test -- tests/historyProgressEditRuntime.test.js tests/historyDurationEditing.test.js tests/historyDeleteMutations.test.js tests/historyDeleteReloadHydration.test.js` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e070c5f48332b3d0e1b860cc7c96)