### PR TITLE
Add lightweight interpretation layer to History summary

### DIFF
--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -374,6 +374,85 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
     }
     return buckets;
   })();
+  const historyInsights = (() => {
+    const sessionItems = timeline
+      .filter((item) => item.kind === "session")
+      .map((item) => item.data)
+      .filter((session) => session?.date)
+      .sort((a, b) => (a.date > b.date ? 1 : -1));
+    if (sessionItems.length < 2) return [];
+
+    const scoreDistress = (session) => {
+      const level = normalizeDistressLevel(
+        session?.distressLevel
+        ?? (session?.result === "success" ? "none" : (session?.result === "distress" ? "strong" : null)),
+      );
+      if (level === "none") return 0;
+      if (level === "subtle") return 1;
+      if (level === "active") return 2;
+      return 3;
+    };
+
+    const average = (values) => values.reduce((sum, value) => sum + value, 0) / values.length;
+    const latestSessions = sessionItems.slice(-6);
+    const latestThree = latestSessions.slice(-3);
+    const previousThree = latestSessions.slice(0, 3);
+    const insightPool = [];
+
+    if (latestThree.length === 3 && previousThree.length === 3) {
+      const recentDistress = average(latestThree.map(scoreDistress));
+      const priorDistress = average(previousThree.map(scoreDistress));
+      if (recentDistress + 0.35 < priorDistress) {
+        insightPool.push("Improving over recent sessions.");
+      }
+    }
+
+    const todayKey = new Date().toISOString().slice(0, 10);
+    const todaySessions = sessionItems.filter((session) => session.date.slice(0, 10) === todayKey);
+    if (todaySessions.length >= 2) {
+      const todayDurations = todaySessions
+        .map((session) => (Number.isFinite(session.actualDuration) ? session.actualDuration : 0))
+        .filter((duration) => duration > 0);
+      const todayDistressAvg = average(todaySessions.map(scoreDistress));
+      if (todayDurations.length >= 2 && todayDistressAvg <= 1) {
+        const spread = Math.max(...todayDurations) - Math.min(...todayDurations);
+        if (spread <= 120) insightPool.push("More stable today.");
+      }
+    }
+
+    const distressScores = sessionItems.map(scoreDistress);
+    const mostRecentStressIndex = distressScores.reduce((latestIndex, score, index) => (score >= 2 ? index : latestIndex), -1);
+    if (mostRecentStressIndex >= 0 && mostRecentStressIndex + 2 < sessionItems.length) {
+      const preStressDuration = sessionItems
+        .slice(Math.max(0, mostRecentStressIndex - 2), mostRecentStressIndex)
+        .map((session) => session.actualDuration)
+        .filter((duration) => Number.isFinite(duration) && duration > 0);
+      const postStressDuration = sessionItems
+        .slice(mostRecentStressIndex + 1, mostRecentStressIndex + 3)
+        .map((session) => session.actualDuration)
+        .filter((duration) => Number.isFinite(duration) && duration > 0);
+      if (preStressDuration.length && postStressDuration.length) {
+        if (average(postStressDuration) <= average(preStressDuration) * 0.82) {
+          insightPool.push("Shorter sessions after a stress event.");
+        }
+      }
+    }
+
+    if (sessionItems.length >= 4) {
+      const lastTwoScores = sessionItems.slice(-2).map(scoreDistress);
+      const priorScores = sessionItems.slice(-6, -2).map(scoreDistress);
+      const hadStressBefore = priorScores.some((score) => score >= 2);
+      const nowCalm = lastTwoScores.every((score) => score <= 1);
+      if (hadStressBefore && nowCalm) {
+        insightPool.push("Back on track.");
+      }
+    }
+
+    if (!insightPool.length) {
+      return ["Steady rhythm this week."];
+    }
+    return insightPool.slice(0, 2);
+  })();
   const trendMax = Math.max(1, ...recentTrend.map((day) => day.count));
   const trendLevel = (count) => {
     if (count <= 0) return 0;
@@ -498,6 +577,13 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                   ))}
                 </div>
               </div>
+              {historyInsights.length > 0 ? (
+                <div className="history-insights" aria-label="History summary insights">
+                  {historyInsights.map((insight) => (
+                    <span className="history-insight-pill" key={insight}>{insight}</span>
+                  ))}
+                </div>
+              ) : null}
               {lastSession ? <div className="history-summary-note">Latest training session: {fmtDate(lastSession.date)}.</div> : null}
             </div>
           )}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1231,6 +1231,8 @@
   .history-mini-trend-bar--level-3 { height:74%; }
   .history-mini-trend-bar--level-4 { height:100%; }
   .history-mini-trend-day span { font-size:var(--type-micro-text-size); line-height:var(--type-micro-text-line); letter-spacing:var(--type-micro-text-track); color:var(--text-muted); text-transform:uppercase; }
+  .history-insights { display:flex; flex-wrap:wrap; gap:8px; }
+  .history-insight-pill { display:inline-flex; align-items:center; min-height:28px; padding:6px 10px; border-radius:999px; font-size:var(--type-helper-text-size); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); color:var(--brown-muted); background:color-mix(in srgb, var(--surface-muted) 90%, white); border:1px solid color-mix(in srgb, var(--mutedBlue) 18%, var(--border)); }
   .history-day-group { display:grid; gap:var(--space-control-gap); margin-bottom:var(--space-section-gap); }
   .history-day-label { font-size:var(--type-overline-size); line-height:var(--type-overline-line); letter-spacing:var(--type-overline-track); font-weight:var(--type-overline-weight); text-transform:uppercase; color:var(--text-muted); }
   .history-day-track { position:relative; display:grid; gap:var(--space-density-compact-control-gap); }


### PR DESCRIPTION
### Motivation
- Provide a compact, gentle interpretation layer on the History screen so users can quickly understand recent session behavior without cluttering the UI.
- Keep insights short, minimal, and product-intelligence-like (e.g., “Improving”, “More stable today”, “Shorter sessions after a stress event”, “Back on track”).

### Description
- Add `historyInsights` computation in `src/features/history/HistoryFeature.jsx` that derives short insights from recent session items using a small distress-scoring helper and simple rules (recent-vs-prior distress drop, same-day stability, post-stress duration shrink, recovery after earlier stress), and limits output to two concise items or a calm fallback message.
- Render compact insight pills inside the existing History summary surface and map each insight to a `history-insight-pill` element, keeping the summary minimal and non-verbose.
- Add matching styles in `src/styles/app.css` for `.history-insights` and `.history-insight-pill` so pills fit the current History visual language.
- Small internal change to how the most-recent stress index is computed (use `reduce` over mapped scores) to make the rule robust.

### Testing
- Ran unit tests with `npm run test` and all test suites passed (`18 files, 233 tests`), status: ✅.
- Produced a production build with `npm run build` and the build completed successfully, status: ✅.
- Ran `npm run check:inline-styles` which failed due to a pre-existing inline-style issue in `src/features/train/TrainComponents.jsx` not introduced by this change, status: ⚠️.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e275e3d08332b56d48ce33a6f08c)