### PR TITLE
Add reusable ProgressHero and integrate into Progress screen

### DIFF
--- a/src/features/stats/StatsComponents.jsx
+++ b/src/features/stats/StatsComponents.jsx
@@ -115,6 +115,51 @@ export function StatsSupportRow({ label, value }) {
   );
 }
 
+export function ProgressHero({
+  name,
+  headlineStatus,
+  headlineSurfaceState = "today",
+  currentValue,
+  currentLabel = "Current window",
+  targetValue,
+  targetLabel = "Next target",
+  insight,
+}) {
+  const dogInitial = (name || "D").trim().charAt(0).toUpperCase();
+
+  return (
+    <div
+      className={`stats-progress-hero metric-surface metric-surface--headline surface-state--${headlineSurfaceState}`.trim()}
+      aria-label={`${name}'s progress hero`}
+    >
+      <span className="stats-progress-hero-aura" aria-hidden="true" />
+      <div className="stats-progress-hero-topline">
+        <div className="stats-progress-dog-chip">
+          <span className="stats-progress-dog-mark" aria-hidden="true">{dogInitial}</span>
+          <span className="stats-progress-dog-name">{name}</span>
+        </div>
+        <span className="stats-progress-headline-status">{headlineStatus}</span>
+      </div>
+
+      <h3 className="stats-progress-headline">{headlineStatus}</h3>
+
+      <div className="stats-progress-values" role="group" aria-label="Current value and next milestone">
+        <div className="stats-progress-value-block">
+          <div className="stats-progress-value">{currentValue}</div>
+          <div className="stats-progress-label">{currentLabel}</div>
+        </div>
+        <div className="stats-progress-value-divider" aria-hidden="true" />
+        <div className="stats-progress-value-block">
+          <div className="stats-progress-value stats-progress-value--target">{targetValue}</div>
+          <div className="stats-progress-label">{targetLabel}</div>
+        </div>
+      </div>
+
+      {insight ? <p className="stats-progress-insight">{insight}</p> : null}
+    </div>
+  );
+}
+
 export function StatsProgressRing({
   value,
   numericValue = null,

--- a/src/features/stats/StatsScreen.jsx
+++ b/src/features/stats/StatsScreen.jsx
@@ -1,17 +1,20 @@
 import EmptyState from "../../components/EmptyState";
-import { METRIC_VARIANTS, StatsChartSection, StatsMetricCard, StatsSection, StatsSupportRow } from "./StatsComponents";
+import { METRIC_VARIANTS, ProgressHero, StatsChartSection, StatsMetricCard, StatsSection, StatsSupportRow } from "./StatsComponents";
 import { fmt } from "../app/helpers";
 import { SproutIcon } from "../app/ui";
 
 export default function StatsScreen({ name, totalCount, setTab, bestCalm, recommendation, relapseTone, chartData, goalSec, CustomDot, distressLabel, chartTrendLabel, aloneLastWeek, avgWalkDuration, avgSessionsPerDay, avgWalksPerDay, headlineStatus, headlineStatusTone }) {
   const target = recommendation?.duration ?? 0;
-  const headlineMetricVariant = METRIC_VARIANTS.HEADLINE;
   const standardMetricVariant = METRIC_VARIANTS.STANDARD;
   const ringMetricVariant = METRIC_VARIANTS.RING;
   const headlineSurfaceState = headlineStatusTone?.surfaceState || "today";
   const riskSurfaceState = relapseTone?.surfaceState || "today";
 
   const emotionalMomentum = chartTrendLabel || `${name} is building consistency with each calm session.`;
+  const progressDelta = Math.max(0, target - bestCalm);
+  const nextTargetLabel = progressDelta > 0
+    ? `Next milestone (+${fmt(progressDelta)})`
+    : "Milestone met — hold this rhythm";
   const cadenceLabel = avgSessionsPerDay != null
     ? avgSessionsPerDay >= 1
       ? `Strong cadence: ${avgSessionsPerDay.toFixed(1)} sessions/day.`
@@ -28,21 +31,16 @@ export default function StatsScreen({ name, totalCount, setTab, bestCalm, recomm
           <EmptyState media={<SproutIcon />} title="Progress starts here" body={`Complete your first session and ${name}'s progress, streak, and chart will appear here.`} ctaLabel="Go to Train →" onCta={() => setTab("home")} />
         ) : <>
           <StatsSection className="stats-section-hero stats-section-priority">
-            <div
-              className={`stats-headline-card stats-headline-card--hero metric-surface metric-surface--${headlineMetricVariant} surface-state--${headlineSurfaceState}`.trim()}
-              data-metric-variant={headlineMetricVariant}
-              aria-label="Current recommendation"
-            >
-              <div className="stats-headline-topline">
-                <span className="stats-headline-label">{name}'s progress pulse</span>
-                <span className="stats-headline-status">{headlineStatus}</span>
-              </div>
-              <div className="stats-headline-main stats-headline-main--hero">
-                <span className="stats-headline-value">{fmt(target)}</span>
-                <span className="stats-headline-sub">recommended solo stretch</span>
-              </div>
-              <p className="stats-hero-insight">{emotionalMomentum}</p>
-            </div>
+            <ProgressHero
+              name={name}
+              headlineStatus={headlineStatus}
+              headlineSurfaceState={headlineSurfaceState}
+              currentValue={fmt(bestCalm)}
+              currentLabel="Current calm window"
+              targetValue={fmt(target)}
+              targetLabel={nextTargetLabel}
+              insight={emotionalMomentum}
+            />
           </StatsSection>
 
           <StatsSection title="What is shaping today" className="stats-section-signals">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1529,6 +1529,36 @@
   .stats-headline-value { font-family:var(--font-ui); font-size:var(--type-metric-headline-size); line-height:var(--type-metric-headline-line); letter-spacing:var(--type-metric-headline-track); font-weight:var(--type-metric-headline-weight); font-variant-numeric:tabular-nums; margin:0; padding:0; white-space:nowrap; color:var(--brown); min-width:0; }
   .stats-headline-status { font-family:var(--font-ui); font-size:var(--type-field-value-size); line-height:var(--type-field-value-line); letter-spacing:var(--type-field-value-track); font-weight:var(--type-field-value-weight); font-variant-numeric:tabular-nums; margin:0; padding:0; text-align:right; flex:0 1 clamp(12ch, 36%, 20ch); min-width:0; max-width:100%; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; color:var(--metric-surface-accent); transition:color var(--motion-base) var(--ease-out), background-color var(--motion-base) var(--ease-out), border-color var(--motion-base) var(--ease-out); }
   .stats-hero-insight { margin:0; position:relative; z-index:1; font-size:var(--type-body-size); line-height:var(--type-body-line); letter-spacing:var(--type-body-track); font-weight:var(--type-body-weight); color:color-mix(in srgb, var(--text) 90%, var(--text-muted)); max-width:56ch; }
+  .stats-progress-hero { position:relative; overflow:hidden; padding:clamp(16px, 3.5vw, 22px); gap:clamp(12px, 2.4vw, 18px); isolation:isolate; }
+  .stats-progress-hero-aura { position:absolute; inset:auto -16% -66% auto; width:min(66vw, 280px); aspect-ratio:1; background:radial-gradient(circle, color-mix(in srgb, var(--green-light) 28%, transparent) 0%, transparent 70%); animation:statsHeroAura 6s ease-in-out infinite; pointer-events:none; z-index:0; }
+  .stats-progress-hero-topline { position:relative; z-index:1; display:flex; align-items:center; justify-content:space-between; gap:var(--space-control-gap); }
+  .stats-progress-dog-chip { display:inline-flex; align-items:center; gap:8px; min-width:0; }
+  .stats-progress-dog-mark { display:inline-grid; place-items:center; width:24px; height:24px; border-radius:999px; background:color-mix(in srgb, var(--green-light) 40%, white); border:1px solid color-mix(in srgb, var(--green-dark) 16%, transparent); font-size:var(--type-helper-text-size); font-weight:700; color:var(--brown); }
+  .stats-progress-dog-name { font-size:var(--type-section-eyebrow-size); line-height:var(--type-section-eyebrow-line); letter-spacing:var(--type-section-eyebrow-track); font-weight:var(--type-section-eyebrow-weight); color:var(--text-muted); text-transform:uppercase; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24ch; }
+  .stats-progress-headline-status { font-size:var(--type-field-value-size); line-height:var(--type-field-value-line); letter-spacing:var(--type-field-value-track); font-weight:var(--type-field-value-weight); color:var(--metric-surface-accent); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:48%; }
+  .stats-progress-headline { position:relative; z-index:1; margin:0; font-size:clamp(1.1rem, 2.5vw, 1.35rem); line-height:1.2; font-weight:var(--type-card-heading-weight); letter-spacing:var(--type-card-heading-track); color:var(--brown); }
+  .stats-progress-values { position:relative; z-index:1; display:grid; grid-template-columns:1fr auto 1fr; align-items:end; gap:clamp(10px, 2.2vw, 16px); }
+  .stats-progress-value-block { min-width:0; display:grid; gap:3px; }
+  .stats-progress-value { font-family:var(--font-ui); font-size:var(--type-metric-headline-size); line-height:var(--type-metric-headline-line); letter-spacing:var(--type-metric-headline-track); font-weight:var(--type-metric-headline-weight); color:var(--brown); font-variant-numeric:tabular-nums; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .stats-progress-value--target { color:color-mix(in srgb, var(--brown) 86%, var(--green-dark)); }
+  .stats-progress-label { font-size:var(--type-metric-label-size); line-height:var(--type-metric-label-line); letter-spacing:var(--type-metric-label-track); font-weight:var(--type-metric-label-weight); color:var(--text-muted); }
+  .stats-progress-value-divider { width:1px; align-self:stretch; background:color-mix(in srgb, var(--border) 78%, transparent); }
+  .stats-progress-insight { position:relative; z-index:1; margin:0; font-size:var(--type-body-size); line-height:var(--type-body-line); letter-spacing:var(--type-body-track); font-weight:var(--type-body-weight); color:color-mix(in srgb, var(--text) 90%, var(--text-muted)); max-width:56ch; }
+
+  @keyframes statsHeroAura {
+    0%, 100% { transform:translate3d(0, 0, 0) scale(1); opacity:0.45; }
+    50% { transform:translate3d(-8px, -8px, 0) scale(1.06); opacity:0.66; }
+  }
+
+  @media (max-width: 380px) {
+    .stats-progress-values { grid-template-columns:1fr; align-items:start; }
+    .stats-progress-value-divider { display:none; }
+    .stats-progress-headline-status { max-width:56%; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .stats-progress-hero-aura { animation:none; }
+  }
   .stats-section-supporting { margin-bottom:var(--space-card-row-gap); }
   .stats-support-list { background:var(--surf); border:1px solid var(--border); border-radius:var(--radius-sm); box-shadow:var(--shadow); overflow:hidden; }
   .stats-support-list--insights { background:var(--surface-gradient-raised); border-color:color-mix(in srgb, var(--border) 88%, var(--warm-accent-border)); }


### PR DESCRIPTION
### Motivation
- Surface the dog’s current progress in a minimal but emotionally resonant hero that keeps the dog identity present and uses subtle motion. 
- Make current main value and the next milestone explicit and programmatically driven so the Progress screen clearly communicates state and next target. 
- Provide a reusable component that can be used elsewhere and respects reduced-motion accessibility preferences. 

### Description
- Added a new `ProgressHero` component in `src/features/stats/StatsComponents.jsx` that renders a dog chip, progress headline/status, current value, next target, and supporting insight and accepts all content via props. 
- Replaced the previous headline block in `src/features/stats/StatsScreen.jsx` with `ProgressHero` and wired it to `bestCalm`, `recommendation.duration`, and `headlineStatus`, including a computed milestone label that shows the gap or a milestone-met message. 
- Added styles and subtle ambient motion for the hero in `src/styles/app.css`, plus a `prefers-reduced-motion` fallback that disables the animation. 
- Kept the hero surface-state styling consistent with existing metric variants and ensured responsive layout for small viewports. 

### Testing
- Built the production bundle using `npm run build` which completed successfully. 
- Ran the automated test suite with `npm test`, and all tests passed (`Tests 233 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e5fc18588332ad4ee6e68e4b3ea2)