### PR TITLE
Redesign Settings into a calm, premium control surface

### DIFF
--- a/src/features/settings/SettingsScreen.jsx
+++ b/src/features/settings/SettingsScreen.jsx
@@ -32,6 +32,7 @@ export default function SettingsScreen(props) {
   const [activePanel, setActivePanel] = useState(null);
   const [reminderEditorOpen, setReminderEditorOpen] = useState(false);
   const [diagDetailsOpen, setDiagDetailsOpen] = useState(false);
+  const [dangerOpen, setDangerOpen] = useState(false);
   const {
     name,
     activeDogId,
@@ -81,42 +82,96 @@ export default function SettingsScreen(props) {
   return (
     <>
       <div className="tab-content">
-        <div className="section">
+        <div className="section settings-shell">
           <div className="section-title">Calm control</div>
-          <div className="t-helper">Manage profile, routine defaults, and device behavior for {name}.</div>
+          <div className="t-helper">Elegant control for {name}&rsquo;s training rhythm, routine, and account.</div>
 
-          <div className="settings-nav-list" role="list" aria-label="Settings destinations">
-            <div className="settings-section-label">Dog + routine</div>
-            <SettingsNavRow label="Dog profile" value={name} onClick={() => setActivePanel(SETTINGS_PANEL.PROFILE)} />
-            <SettingsNavRow label="Reminders" value={reminderSummary} onClick={() => setActivePanel(SETTINGS_PANEL.REMINDERS)} />
+          <section className="surface-card settings-profile-card" aria-label={`${name} profile`}>
+            <div className="settings-profile-card__head">
+              <div>
+                <div className="settings-simple-title">Active dog</div>
+                <div className="settings-profile-card__name">{name}</div>
+              </div>
+              <button className="settings-inline-btn button-size-secondary-pill secondary-control secondary-control--compact-button" onClick={() => setActivePanel(SETTINGS_PANEL.PROFILE)} type="button">
+                View profile
+              </button>
+            </div>
+            <div className="settings-profile-card__meta">
+              <div className="settings-profile-chip">{reminderSummary} reminders</div>
+              <div className="settings-profile-chip">Max {activeProto.sessionsPerDayMax} sessions/day</div>
+              <div className="settings-profile-chip">{Object.keys(patLabels).length} custom labels</div>
+            </div>
+          </section>
+
+          <div className="settings-group" role="list" aria-label="Training routine settings">
+            <div className="settings-section-label">Training routine</div>
+            <div className="settings-inline-card">
+              <div className="settings-row-head">
+                <span className="settings-inline-title">Daily reminder</span>
+                <button className={`notif-toggle secondary-control secondary-control--toggle ${notifEnabled ? "on" : ""}`} onClick={handleToggleNotif} type="button">{notifEnabled ? "On" : "Off"}</button>
+              </div>
+              <div className="settings-inline-row">
+                <span className="settings-secondary-text">Reminder time</span>
+                <button
+                  type="button"
+                  className="settings-inline-btn button-size-secondary-pill secondary-control secondary-control--compact-button"
+                  onClick={() => setReminderEditorOpen((prev) => !prev)}
+                >
+                  {reminderEditorOpen ? "Done" : notifTime}
+                </button>
+              </div>
+              {notifEnabled && reminderEditorOpen && (
+                <input type="time" value={notifTime} onChange={async (e) => {
+                  const nextTime = e.target.value;
+                  const dogName = dogs.find((d) => String(d.id || "").trim().toUpperCase() === String(activeDogId || "").trim().toUpperCase())?.dogName ?? "your dog";
+                  const ok = await scheduleNotif(nextTime, dogName);
+                  if (ok) setNotifTime(nextTime);
+                }} className="notif-time-input settings-time-input" />
+              )}
+              {!notifEnabled && reminderEditorOpen && (
+                <div className="settings-secondary-text">Turn reminders on first, then choose a time.</div>
+              )}
+            </div>
             <SettingsNavRow label="Training settings" value={`Up to ${activeProto.sessionsPerDayMax}/day`} onClick={() => setTrainingSettingsOpen(true)} />
             <SettingsNavRow label="Custom labels" value={`${Object.keys(patLabels).length} custom`} onClick={() => setActivePanel(SETTINGS_PANEL.LABELS)} />
           </div>
 
-          <div className="settings-nav-list" role="list" aria-label="Support destinations">
-            <div className="settings-section-label">Guidance + diagnostics</div>
+          <div className="settings-group settings-group--muted" role="list" aria-label="Support destinations">
+            <div className="settings-section-label">Help + diagnostics</div>
             <SettingsNavRow label="Help" value="Guidance" onClick={() => setActivePanel(SETTINGS_PANEL.HELP)} />
             <SettingsNavRow label="Advanced" value="Diagnostics" onClick={() => setActivePanel(SETTINGS_PANEL.ADVANCED)} />
           </div>
 
-          <div className="settings-nav-list" role="list" aria-label="Account destinations">
+          <div className="settings-group" role="list" aria-label="Account destinations">
             <div className="settings-section-label">Account + device</div>
             <SettingsNavRow label="Account" value="Profile & device" onClick={() => setActivePanel(SETTINGS_PANEL.ACCOUNT)} />
           </div>
 
-          <div className="settings-danger-sep" />
-          <div className="settings-nav-list settings-nav-list--danger" role="list" aria-label="Danger zone">
-            <div className="settings-section-label settings-section-label--danger">Danger zone</div>
-            <SettingsNavRow label={`Remove ${name} from this device`} danger onClick={() => {
-              if (window.confirm(`Remove ${name} from this device? This deletes local sessions, walks, feeding history, labels, and photo for this dog on this device. Synced/shared data elsewhere is unaffected.`)) {
-                clearDogActivityState(activeDogId);
-                const newDogs = dogsState.filter((d) => d.id !== activeDogId);
-                setDogs(newDogs);
-                save(ACTIVE_DOG_KEY, null);
-                setActiveDogId(null);
-              }
-            }} />
-          </div>
+          <section className="settings-collapsible-card settings-collapsible-card--quiet settings-danger-zone" aria-label="Danger zone">
+            <button
+              className="settings-collapsible-toggle secondary-control--toggle"
+              type="button"
+              onClick={() => setDangerOpen((prev) => !prev)}
+              aria-expanded={dangerOpen}
+              aria-controls="settings-danger-content"
+            >
+              <span className="settings-section-label settings-section-label--danger">Danger zone</span>
+              <span className="settings-collapsible-arrow" aria-hidden="true">{dangerOpen ? "−" : "+"}</span>
+            </button>
+            {dangerOpen ? (
+              <div className="settings-collapsible-inner" id="settings-danger-content">
+                <SettingsNavRow label={`Remove ${name} from this device`} danger onClick={() => {
+                  if (window.confirm(`Remove ${name} from this device? This deletes local sessions, walks, feeding history, labels, and photo for this dog on this device. Synced/shared data elsewhere is unaffected.`)) {
+                    clearDogActivityState(activeDogId);
+                    const newDogs = dogsState.filter((d) => d.id !== activeDogId);
+                    setDogs(newDogs);
+                    save(ACTIVE_DOG_KEY, null);
+                    setActiveDogId(null);
+                  }
+                }} />
+              </div>
+            ) : null}
+          </section>
         </div>
       </div>
 
@@ -142,44 +197,6 @@ export default function SettingsScreen(props) {
                 </div>
                 <div className="settings-sync-copy">{syncSummary.detail}</div>
               </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {activePanel === SETTINGS_PANEL.REMINDERS && (
-        <div className="quick-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="settings-reminders-title" onClick={() => setActivePanel(null)}>
-          <div className="quick-modal-card modal-card modal-card--dialog-md" onClick={(e) => e.stopPropagation()}>
-            <div className="quick-modal-head">
-              <div className="quick-modal-title" id="settings-reminders-title">Reminders</div>
-              <ModalCloseButton onClick={() => setActivePanel(null)} />
-            </div>
-            <div className="settings-modal-stack">
-              <div className="settings-native-control-row">
-                <span>Daily reminder</span>
-                <button className={`notif-toggle secondary-control secondary-control--toggle ${notifEnabled ? "on" : ""}`} onClick={handleToggleNotif}>{notifEnabled ? "On" : "Off"}</button>
-              </div>
-              <div className="settings-native-control-row">
-                <span>Reminder time</span>
-                <button
-                  type="button"
-                  className="settings-inline-btn button-size-secondary-pill secondary-control secondary-control--compact-button"
-                  onClick={() => setReminderEditorOpen((prev) => !prev)}
-                >
-                  {reminderEditorOpen ? "Done" : notifTime}
-                </button>
-              </div>
-              {notifEnabled && reminderEditorOpen && (
-                <input type="time" value={notifTime} onChange={async (e) => {
-                  const nextTime = e.target.value;
-                  const dogName = dogs.find((d) => String(d.id || "").trim().toUpperCase() === String(activeDogId || "").trim().toUpperCase())?.dogName ?? "your dog";
-                  const ok = await scheduleNotif(nextTime, dogName);
-                  if (ok) setNotifTime(nextTime);
-                }} className="notif-time-input" />
-              )}
-              {!notifEnabled && reminderEditorOpen && (
-                <div className="settings-secondary-text">Turn reminders on first, then choose a time.</div>
-              )}
             </div>
           </div>
         </div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1851,6 +1851,38 @@
   .session-control.is-complete { animation:ringPulse 0.9s ease-in-out 2; }
 
   /* ── Settings: simplified native list pattern ── */
+  .settings-shell { display:grid; gap:var(--space-section-gap); }
+  .settings-profile-card {
+    border:1px solid color-mix(in srgb, var(--border) 70%, transparent);
+    border-radius:var(--radius-lg);
+    background:linear-gradient(165deg, color-mix(in srgb, var(--surface-card-bg) 94%, var(--surface-overlay-soft) 6%), var(--surface-card-bg));
+    padding:var(--space-card-padding);
+    display:grid;
+    gap:var(--space-control-gap);
+    box-shadow:var(--shadow-soft);
+  }
+  .settings-profile-card__head { display:flex; justify-content:space-between; align-items:flex-start; gap:var(--space-control-gap); }
+  .settings-profile-card__name {
+    color:var(--text);
+    font-size:var(--type-card-heading-size);
+    line-height:var(--type-card-heading-line);
+    letter-spacing:var(--type-card-heading-track);
+    font-weight:var(--type-card-heading-weight);
+  }
+  .settings-profile-card__meta { display:flex; flex-wrap:wrap; gap:8px; }
+  .settings-profile-chip {
+    display:inline-flex;
+    align-items:center;
+    min-height:28px;
+    padding:0 10px;
+    border-radius:999px;
+    background:color-mix(in srgb, var(--surface-muted) 92%, transparent);
+    color:var(--text-muted);
+    font-size:var(--type-helper-text-size);
+    line-height:var(--type-helper-text-line);
+  }
+  .settings-group { display:grid; }
+  .settings-group--muted { opacity:0.92; }
   .settings-nav-list { display:grid; margin-bottom:var(--space-section-gap); }
   .settings-section-label {
     margin:0 0 var(--space-1);
@@ -1875,7 +1907,32 @@
     gap:var(--space-control-gap);
     text-align:left;
     cursor:pointer;
+    transition:color var(--motion-base) var(--ease-out), border-color var(--motion-base) var(--ease-out), transform var(--motion-press) var(--ease-out);
   }
+  .settings-nav-row:hover { color:var(--brown); }
+  .settings-nav-row:active { transform:translateY(1px); }
+  .settings-inline-card {
+    border:1px solid color-mix(in srgb, var(--border) 70%, transparent);
+    border-radius:var(--radius-md);
+    background:color-mix(in srgb, var(--surface-card-bg) 94%, transparent);
+    padding:var(--space-card-row-gap) var(--space-control-gap);
+    margin-bottom:var(--space-card-row-gap);
+    display:grid;
+    gap:var(--space-control-gap);
+    transition:border-color var(--motion-base) var(--ease-out), box-shadow var(--motion-base) var(--ease-out), background-color var(--motion-base) var(--ease-out);
+  }
+  .settings-inline-card:focus-within {
+    border-color:color-mix(in srgb, var(--primaryBlue) 30%, var(--border));
+    box-shadow:0 0 0 3px color-mix(in srgb, var(--primaryBlue) 12%, transparent);
+  }
+  .settings-inline-title {
+    color:var(--text);
+    font-size:var(--type-body-size);
+    line-height:var(--type-body-line);
+    letter-spacing:var(--type-body-track);
+    font-weight:var(--type-body-weight);
+  }
+  .settings-time-input { animation:fadeIn 180ms ease; }
   .settings-nav-row__label,
   .settings-nav-row__value {
     font-size:var(--type-body-size);
@@ -1899,7 +1956,11 @@
   .settings-native-control-row { display:flex; justify-content:space-between; gap:var(--space-control-gap); align-items:center; color:var(--text); min-height:44px; }
   .settings-secondary-text { color:var(--text-muted); font-size:var(--type-helper-text-size); line-height:var(--type-helper-text-line); }
   .settings-section-label--danger { color:var(--red); }
-  .settings-danger-sep { height:1px; background:var(--border); margin:var(--space-section-gap) 0 var(--space-control-gap); opacity:0.5; }
+  .settings-danger-zone {
+    margin-top:calc(var(--space-control-gap) * -1);
+    border-top:1px solid color-mix(in srgb, var(--border) 72%, transparent);
+    padding-top:var(--space-control-gap);
+  }
   .history-food-type { text-transform:capitalize; }
   .icon-img { display:inline-block; flex-shrink:0; object-fit:contain; }
   .paw-icon-img { display:inline-block; object-fit:contain; }


### PR DESCRIPTION
### Motivation
- Make Settings feel product-native and premium instead of a plain utility list while preserving the existing visual system and low friction for training flows.
- Surface the most-used routine controls inline so the user can act without modal hopping and keep help/diagnostics lower emphasis.
- Reduce visual clutter and accidental destructive actions by grouping settings and collapsing the Danger zone.

### Description
- Reworked `SettingsScreen.jsx` to introduce a top dog profile card (`settings-profile-card`) with quick profile access and compact status chips showing reminders, session caps, and label count.
- Reorganized settings into grouped sections and moved reminders from a modal into inline controls (toggle + time editor), adding `dangerOpen` state and collapsing the Danger zone behind a `settings-collapsible-card` pattern.
- Kept existing modals for profile, labels, help, advanced, account, and training plan editing intact while changing main surface layout and navigation rows to `SettingsNavRow` usage.
- Added styling in `src/styles/app.css` for `settings-shell`, profile card, chips, `settings-inline-card`, subtle transitions, focus states, and the new `settings-danger-zone` to match the app's tokens and ensure smooth motion.

### Testing
- Built the production bundle with `npm run build` and the build completed successfully.
- No automated unit tests were run as part of this change; no test failures introduced during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0eb3feab88332bb5cd7f2b595f721)