### PR TITLE
Add premium DogProfileCard to top of Settings

### DIFF
--- a/src/features/settings/DogProfileCard.jsx
+++ b/src/features/settings/DogProfileCard.jsx
@@ -1,0 +1,48 @@
+export default function DogProfileCard({
+  dogName,
+  reminderSummary,
+  sessionsPerDayMax,
+  customLabelCount,
+  syncSummary,
+  onOpenProfile,
+}) {
+  const syncTone = syncSummary?.badgeState || "neutral";
+  const syncLabel = syncSummary?.label || "Status unavailable";
+  const cardStatus = syncTone === "ok"
+    ? "Steady"
+    : syncTone === "warn"
+      ? "Needs review"
+      : "Attention needed";
+
+  return (
+    <button
+      type="button"
+      className="settings-dog-profile-card"
+      aria-label={`Open ${dogName} profile settings`}
+      onClick={onOpenProfile}
+    >
+      <div className="settings-dog-profile-card__identity">
+        <div className="settings-dog-profile-avatar" aria-hidden="true">
+          {String(dogName || "D").trim().charAt(0).toUpperCase()}
+        </div>
+        <div className="settings-dog-profile-card__titles">
+          <div className="settings-simple-title">Active dog profile</div>
+          <div className="settings-dog-profile-card__name">{dogName}</div>
+          <div className="settings-dog-profile-card__state">
+            <span className={`settings-dog-profile-card__state-dot settings-dog-profile-card__state-dot--${syncTone}`} aria-hidden="true" />
+            <span>{cardStatus}</span>
+            <span className="settings-dog-profile-card__divider" aria-hidden="true">•</span>
+            <span>{syncLabel}</span>
+          </div>
+        </div>
+        <span className="settings-dog-profile-card__chevron" aria-hidden="true">›</span>
+      </div>
+
+      <div className="settings-dog-profile-card__meta" aria-label="Dog status summary">
+        <div className="settings-profile-chip">{reminderSummary} reminders</div>
+        <div className="settings-profile-chip">Plan: max {sessionsPerDayMax} sessions/day</div>
+        <div className="settings-profile-chip">{customLabelCount} custom labels</div>
+      </div>
+    </button>
+  );
+}

--- a/src/features/settings/SettingsScreen.jsx
+++ b/src/features/settings/SettingsScreen.jsx
@@ -1,6 +1,7 @@
 import { PATTERN_TYPES } from "../app/helpers";
 import { DeleteIcon, ModalCloseButton } from "../app/ui";
 import { useState } from "react";
+import DogProfileCard from "./DogProfileCard";
 
 const SETTINGS_PANEL = {
   PROFILE: "profile",
@@ -86,22 +87,14 @@ export default function SettingsScreen(props) {
           <div className="section-title">Calm control</div>
           <div className="t-helper">Elegant control for {name}&rsquo;s training rhythm, routine, and account.</div>
 
-          <section className="surface-card settings-profile-card" aria-label={`${name} profile`}>
-            <div className="settings-profile-card__head">
-              <div>
-                <div className="settings-simple-title">Active dog</div>
-                <div className="settings-profile-card__name">{name}</div>
-              </div>
-              <button className="settings-inline-btn button-size-secondary-pill secondary-control secondary-control--compact-button" onClick={() => setActivePanel(SETTINGS_PANEL.PROFILE)} type="button">
-                View profile
-              </button>
-            </div>
-            <div className="settings-profile-card__meta">
-              <div className="settings-profile-chip">{reminderSummary} reminders</div>
-              <div className="settings-profile-chip">Max {activeProto.sessionsPerDayMax} sessions/day</div>
-              <div className="settings-profile-chip">{Object.keys(patLabels).length} custom labels</div>
-            </div>
-          </section>
+          <DogProfileCard
+            dogName={name}
+            reminderSummary={reminderSummary}
+            sessionsPerDayMax={activeProto.sessionsPerDayMax}
+            customLabelCount={Object.keys(patLabels).length}
+            syncSummary={syncSummary}
+            onOpenProfile={() => setActivePanel(SETTINGS_PANEL.PROFILE)}
+          />
 
           <div className="settings-group" role="list" aria-label="Training routine settings">
             <div className="settings-section-label">Training routine</div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1852,24 +1852,79 @@
 
   /* ── Settings: simplified native list pattern ── */
   .settings-shell { display:grid; gap:var(--space-section-gap); }
-  .settings-profile-card {
-    border:1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  .settings-dog-profile-card {
+    width:100%;
+    border:1px solid color-mix(in srgb, var(--border) 66%, transparent);
     border-radius:var(--radius-lg);
-    background:linear-gradient(165deg, color-mix(in srgb, var(--surface-card-bg) 94%, var(--surface-overlay-soft) 6%), var(--surface-card-bg));
+    background:linear-gradient(160deg, color-mix(in srgb, var(--surface-card-bg) 94%, var(--surface-overlay-soft) 6%), color-mix(in srgb, var(--surface-card-bg) 86%, var(--surface-muted) 14%));
     padding:var(--space-card-padding);
     display:grid;
     gap:var(--space-control-gap);
     box-shadow:var(--shadow-soft);
+    text-align:left;
+    color:var(--text);
+    cursor:pointer;
+    transition:transform var(--motion-press) var(--ease-out), border-color var(--motion-base) var(--ease-out), box-shadow var(--motion-base) var(--ease-out);
   }
-  .settings-profile-card__head { display:flex; justify-content:space-between; align-items:flex-start; gap:var(--space-control-gap); }
-  .settings-profile-card__name {
+  .settings-dog-profile-card:hover {
+    border-color:color-mix(in srgb, var(--brown) 28%, var(--border));
+    box-shadow:0 10px 24px color-mix(in srgb, var(--shadow-soft) 72%, transparent);
+  }
+  .settings-dog-profile-card:active { transform:translateY(1px); }
+  .settings-dog-profile-card:focus-visible {
+    outline:none;
+    box-shadow:0 0 0 3px color-mix(in srgb, var(--primaryBlue) 18%, transparent), var(--shadow-soft);
+  }
+  .settings-dog-profile-card__identity { display:flex; align-items:flex-start; gap:var(--space-control-gap); }
+  .settings-dog-profile-avatar {
+    inline-size:42px;
+    block-size:42px;
+    border-radius:999px;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    font-size:var(--type-body-lg-size);
+    font-weight:var(--type-card-heading-weight);
+    color:var(--text);
+    background:radial-gradient(circle at 24% 22%, color-mix(in srgb, var(--surface-overlay-soft) 82%, #fff 18%), color-mix(in srgb, var(--surface-muted) 78%, var(--surface-card-bg) 22%));
+    border:1px solid color-mix(in srgb, var(--border) 60%, transparent);
+    box-shadow:inset 0 0 0 1px color-mix(in srgb, var(--surface-card-bg) 66%, transparent);
+    flex-shrink:0;
+  }
+  .settings-dog-profile-card__titles { display:grid; gap:2px; flex:1; }
+  .settings-dog-profile-card__name {
     color:var(--text);
     font-size:var(--type-card-heading-size);
     line-height:var(--type-card-heading-line);
     letter-spacing:var(--type-card-heading-track);
     font-weight:var(--type-card-heading-weight);
   }
-  .settings-profile-card__meta { display:flex; flex-wrap:wrap; gap:8px; }
+  .settings-dog-profile-card__state {
+    display:flex;
+    flex-wrap:wrap;
+    align-items:center;
+    gap:6px;
+    color:var(--text-muted);
+    font-size:var(--type-helper-text-size);
+    line-height:var(--type-helper-text-line);
+  }
+  .settings-dog-profile-card__state-dot {
+    inline-size:7px;
+    block-size:7px;
+    border-radius:999px;
+    background:var(--text-muted);
+  }
+  .settings-dog-profile-card__state-dot--ok { background:var(--green); }
+  .settings-dog-profile-card__state-dot--warn { background:var(--amber); }
+  .settings-dog-profile-card__state-dot--err { background:var(--red); }
+  .settings-dog-profile-card__divider { color:color-mix(in srgb, var(--text-muted) 70%, transparent); }
+  .settings-dog-profile-card__chevron {
+    color:color-mix(in srgb, var(--text-muted) 82%, transparent);
+    font-size:20px;
+    line-height:1;
+    padding-top:3px;
+  }
+  .settings-dog-profile-card__meta { display:flex; flex-wrap:wrap; gap:8px; }
   .settings-profile-chip {
     display:inline-flex;
     align-items:center;


### PR DESCRIPTION
### Motivation
- Surface the active dog as the clear visual anchor for the Settings screen so the app feels tied to the dog rather than generic UI. 
- Provide a calm, premium, and compact summary of identity and small state so users can scan status and reach dog-specific settings quickly. 
- Replace the previous thin profile block with a reusable entry-point that is not childish and supports future styling/behavior changes.

### Description
- Add a new reusable component `src/features/settings/DogProfileCard.jsx` that renders a full-width button with avatar initial, dog name, sync-aware state tone, and summarizing chips. 
- Integrate `DogProfileCard` into `src/features/settings/SettingsScreen.jsx` at the top of the settings surface and wire its `onOpenProfile` handler to open the existing profile modal. 
- Introduce dedicated styles in `src/styles/app.css` (`.settings-dog-profile-card*`) implementing a soft premium gradient, avatar treatment, status dot variants (`--ok`, `--warn`, `--err`), hover/focus affordances, and summary chip layout. 
- Preserve existing semantics for reminders, sessions-per-day, and custom label counts while centralizing presentation in the new card component. 

### Testing
- Ran the test suite with `npm run test` and all automated tests passed (`19 files, 235 tests`). 
- Built the production assets with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f836337c83329a665ff909561b0c)