### PR TITLE
Improve redesigned Settings interactions with sheets and inline confirmations

### DIFF
--- a/src/features/settings/SettingsScreen.jsx
+++ b/src/features/settings/SettingsScreen.jsx
@@ -1,5 +1,5 @@
 import { PATTERN_TYPES } from "../app/helpers";
-import { DeleteIcon, ModalCloseButton } from "../app/ui";
+import { ModalCloseButton } from "../app/ui";
 import { useState } from "react";
 import DogProfileCard from "./DogProfileCard";
 
@@ -29,11 +29,28 @@ function SettingsNavRow({ label, value, onClick, danger = false }) {
   );
 }
 
+function SettingsSheet({ title, titleId, onClose, children, compact = false }) {
+  return (
+    <div className="quick-modal-overlay quick-modal-overlay--sheet" role="dialog" aria-modal="true" aria-labelledby={titleId} onClick={onClose}>
+      <div className={`quick-modal-card modal-card modal-card--dialog-md quick-modal-card--sheet ${compact ? "quick-modal-card--sheet-compact" : ""}`} onClick={(e) => e.stopPropagation()}>
+        <div className="quick-modal-head">
+          <div className="quick-modal-title" id={titleId}>{title}</div>
+          <ModalCloseButton onClick={onClose} />
+        </div>
+        <div className="settings-modal-stack">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function SettingsScreen(props) {
   const [activePanel, setActivePanel] = useState(null);
   const [reminderEditorOpen, setReminderEditorOpen] = useState(false);
   const [diagDetailsOpen, setDiagDetailsOpen] = useState(false);
   const [dangerOpen, setDangerOpen] = useState(false);
+  const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false);
   const {
     name,
     activeDogId,
@@ -113,17 +130,18 @@ export default function SettingsScreen(props) {
                   {reminderEditorOpen ? "Done" : notifTime}
                 </button>
               </div>
-              {notifEnabled && reminderEditorOpen && (
-                <input type="time" value={notifTime} onChange={async (e) => {
-                  const nextTime = e.target.value;
-                  const dogName = dogs.find((d) => String(d.id || "").trim().toUpperCase() === String(activeDogId || "").trim().toUpperCase())?.dogName ?? "your dog";
-                  const ok = await scheduleNotif(nextTime, dogName);
-                  if (ok) setNotifTime(nextTime);
-                }} className="notif-time-input settings-time-input" />
-              )}
-              {!notifEnabled && reminderEditorOpen && (
-                <div className="settings-secondary-text">Turn reminders on first, then choose a time.</div>
-              )}
+              <div className={`settings-inline-reveal ${reminderEditorOpen ? "is-open" : ""}`} aria-hidden={!reminderEditorOpen}>
+                {notifEnabled ? (
+                  <input type="time" value={notifTime} onChange={async (e) => {
+                    const nextTime = e.target.value;
+                    const dogName = dogs.find((d) => String(d.id || "").trim().toUpperCase() === String(activeDogId || "").trim().toUpperCase())?.dogName ?? "your dog";
+                    const ok = await scheduleNotif(nextTime, dogName);
+                    if (ok) setNotifTime(nextTime);
+                  }} className="notif-time-input settings-time-input" />
+                ) : (
+                  <div className="settings-secondary-text">Turn reminders on first, then choose a time.</div>
+                )}
+              </div>
             </div>
             <SettingsNavRow label="Training settings" value={`Up to ${activeProto.sessionsPerDayMax}/day`} onClick={() => setTrainingSettingsOpen(true)} />
             <SettingsNavRow label="Custom labels" value={`${Object.keys(patLabels).length} custom`} onClick={() => setActivePanel(SETTINGS_PANEL.LABELS)} />
@@ -153,15 +171,31 @@ export default function SettingsScreen(props) {
             </button>
             {dangerOpen ? (
               <div className="settings-collapsible-inner" id="settings-danger-content">
-                <SettingsNavRow label={`Remove ${name} from this device`} danger onClick={() => {
-                  if (window.confirm(`Remove ${name} from this device? This deletes local sessions, walks, feeding history, labels, and photo for this dog on this device. Synced/shared data elsewhere is unaffected.`)) {
-                    clearDogActivityState(activeDogId);
-                    const newDogs = dogsState.filter((d) => d.id !== activeDogId);
-                    setDogs(newDogs);
-                    save(ACTIVE_DOG_KEY, null);
-                    setActiveDogId(null);
-                  }
-                }} />
+                <button className="settings-nav-row settings-nav-row--danger" type="button" onClick={() => setRemoveConfirmOpen((prev) => !prev)}>
+                  <span className="settings-nav-row__label">{`Remove ${name} from this device`}</span>
+                  <span className="settings-nav-row__meta">
+                    <span className="settings-nav-row__chevron" aria-hidden="true">{removeConfirmOpen ? "−" : "›"}</span>
+                  </span>
+                </button>
+                <div className={`settings-inline-reveal ${removeConfirmOpen ? "is-open" : ""}`} aria-hidden={!removeConfirmOpen}>
+                  <div className="settings-danger-confirm">
+                    <div className="settings-secondary-text">
+                      This removes local sessions, walks, feeding history, labels, and photo for this dog on this device. Synced/shared data elsewhere is unaffected.
+                    </div>
+                    <div className="settings-danger-actions">
+                      <button type="button" className="settings-inline-btn button-size-secondary-pill secondary-control secondary-control--compact-button" onClick={() => setRemoveConfirmOpen(false)}>Cancel</button>
+                      <button type="button" className="settings-inline-btn button-size-secondary-pill button-danger" onClick={() => {
+                        clearDogActivityState(activeDogId);
+                        const newDogs = dogsState.filter((d) => d.id !== activeDogId);
+                        setDogs(newDogs);
+                        save(ACTIVE_DOG_KEY, null);
+                        setActiveDogId(null);
+                      }}>
+                        Remove
+                      </button>
+                    </div>
+                  </div>
+                </div>
               </div>
             ) : null}
           </section>
@@ -169,85 +203,55 @@ export default function SettingsScreen(props) {
       </div>
 
       {activePanel === SETTINGS_PANEL.PROFILE && (
-        <div className="quick-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="settings-profile-title" onClick={() => setActivePanel(null)}>
-          <div className="quick-modal-card modal-card modal-card--dialog-md" onClick={(e) => e.stopPropagation()}>
-            <div className="quick-modal-head">
-              <div className="quick-modal-title" id="settings-profile-title">Dog profile</div>
-              <ModalCloseButton onClick={() => setActivePanel(null)} />
+        <SettingsSheet title="Dog profile" titleId="settings-profile-title" onClose={() => setActivePanel(null)} compact>
+          <div className="settings-profile-id-row" aria-label="Dog ID">
+            <div>
+              <div className="settings-simple-title">Dog ID</div>
+              <div className="settings-id-value">{activeDogId}</div>
             </div>
-            <div className="settings-modal-stack">
-              <div className="settings-profile-id-row" aria-label="Dog ID">
-                <div>
-                  <div className="settings-simple-title">Dog ID</div>
-                  <div className="settings-id-value">{activeDogId}</div>
-                </div>
-                <button className="copy-btn button-size-secondary-pill secondary-control secondary-control--compact-button" onClick={copyDogId} aria-label="Copy dog ID">Copy</button>
-              </div>
-              <div className="settings-sync-summary" aria-live="polite">
-                <div className={`sync-badge sync-state-${syncSummary.badgeState}`} title={syncSummary.detail}>
-                  <span className={`sync-dot sync-${syncSummary.badgeState}`} />
-                  <span>{syncSummary.label}</span>
-                </div>
-                <div className="settings-sync-copy">{syncSummary.detail}</div>
-              </div>
-            </div>
+            <button className="copy-btn button-size-secondary-pill secondary-control secondary-control--compact-button" onClick={copyDogId} aria-label="Copy dog ID">Copy</button>
           </div>
-        </div>
+          <div className="settings-sync-summary" aria-live="polite">
+            <div className={`sync-badge sync-state-${syncSummary.badgeState}`} title={syncSummary.detail}>
+              <span className={`sync-dot sync-${syncSummary.badgeState}`} />
+              <span>{syncSummary.label}</span>
+            </div>
+            <div className="settings-sync-copy">{syncSummary.detail}</div>
+          </div>
+        </SettingsSheet>
       )}
 
       {activePanel === SETTINGS_PANEL.LABELS && (
-        <div className="quick-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="settings-labels-title" onClick={() => setActivePanel(null)}>
-          <div className="quick-modal-card modal-card modal-card--dialog-md" onClick={(e) => e.stopPropagation()}>
-            <div className="quick-modal-head">
-              <div className="quick-modal-title" id="settings-labels-title">Custom labels</div>
-              <ModalCloseButton onClick={() => setActivePanel(null)} />
+        <SettingsSheet title="Custom labels" titleId="settings-labels-title" onClose={() => setActivePanel(null)}>
+          {PATTERN_TYPES.map((pt) => (
+            <div key={pt.type} className="pat-edit-row">
+              {editingPat === pt.type ? (
+                <input className="pat-edit-input" autoFocus aria-label={`Rename ${pt.label}`} defaultValue={patLabels[pt.type] || pt.label} onBlur={(e) => { const val = e.target.value.trim(); if (val) setPatLabels((prev) => ({ ...prev, [pt.type]: val })); setEditingPat(null); }} onKeyDown={(e) => { if (e.key === "Enter") e.target.blur(); if (e.key === "Escape") setEditingPat(null); }} />
+              ) : (
+                <span className="pat-edit-label">{patLabels[pt.type] || pt.label}</span>
+              )}
+              <div className="pat-edit-actions">
+                <button className="pat-edit-btn t-helper secondary-control secondary-control--inline-text" onClick={() => setEditingPat(pt.type)} aria-label={`Edit ${pt.label} name`}>Edit</button>
+                {editingPat === pt.type && patLabels[pt.type] && <button className="settings-inline-reset-btn t-helper secondary-control secondary-control--inline-text" onMouseDown={(e) => e.preventDefault()} onClick={() => setPatLabels((prev) => { const n = { ...prev }; delete n[pt.type]; return n; })} aria-label="Reset to default">Reset</button>}
+              </div>
             </div>
-            <div className="settings-modal-stack">
-              {PATTERN_TYPES.map((pt) => (
-                <div key={pt.type} className="pat-edit-row">
-                  {editingPat === pt.type ? (
-                    <input className="pat-edit-input" autoFocus aria-label={`Rename ${pt.label}`} defaultValue={patLabels[pt.type] || pt.label} onBlur={(e) => { const val = e.target.value.trim(); if (val) setPatLabels((prev) => ({ ...prev, [pt.type]: val })); setEditingPat(null); }} onKeyDown={(e) => { if (e.key === "Enter") e.target.blur(); if (e.key === "Escape") setEditingPat(null); }} />
-                  ) : (
-                    <span className="pat-edit-label">{patLabels[pt.type] || pt.label}</span>
-                  )}
-                  <div className="pat-edit-actions">
-                    <button className="pat-edit-btn t-helper secondary-control secondary-control--inline-text" onClick={() => setEditingPat(pt.type)} aria-label={`Edit ${pt.label} name`}>Edit</button>
-                    {editingPat === pt.type && patLabels[pt.type] && <button className="settings-inline-reset-btn t-helper secondary-control secondary-control--inline-text" onMouseDown={(e) => e.preventDefault()} onClick={() => setPatLabels((prev) => { const n = { ...prev }; delete n[pt.type]; return n; })} aria-label="Reset to default">Reset</button>}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
+          ))}
+        </SettingsSheet>
       )}
 
       {activePanel === SETTINGS_PANEL.HELP && (
-        <div className="quick-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="settings-help-title" onClick={() => setActivePanel(null)}>
-          <div className="quick-modal-card modal-card modal-card--dialog-md" onClick={(e) => e.stopPropagation()}>
-            <div className="quick-modal-head">
-              <div className="quick-modal-title" id="settings-help-title">Help</div>
-              <ModalCloseButton onClick={() => setActivePanel(null)} />
-            </div>
-            <div className="settings-modal-stack">
+        <SettingsSheet title="Help" titleId="settings-help-title" onClose={() => setActivePanel(null)}>
               <div className="proto-section u-mt-none"><div className="proto-title">Sync devices</div><div className="proto-row">Share your Dog ID, then join with the same ID on the other device.</div></div>
               <div className="proto-section"><div className="proto-title">Session flow</div><div className="proto-row">Start a session, return before distress escalates, then rate how {name} did.</div></div>
               <div className="proto-section"><div className="proto-title">Current recommendation state</div><div className="proto-row">Now: <strong>{recommendationType}</strong>. {recommendationSummary} It currently weighs {(recommendation?.details?.factors || []).join(" ")}</div></div>
               <div className="proto-section"><div className="proto-title">Recommendation states emitted</div><div className="proto-row">baseline_start, keep_same_duration, repeat_current_duration, departure_cues_first, recovery_mode_active, recovery_mode_resume.</div></div>
               <div className="proto-section"><div className="proto-title">Recovery behavior</div><div className="proto-row">Any subtle/active/severe distress can activate recovery. While recovery_mode_active, targets use short fixed steps (typically 60s then 120s; severe can add a third 120s step). Subtle recovery accepts any calm follow-up duration; active/severe count calm sessions at short recovery lengths. After enough calm sessions, recovery_mode_resume emits once, then normal progression continues.</div></div>
               <div className="proto-section"><div className="proto-title">Daily rhythm</div><div className="proto-row">Aim for up to {activeProto.sessionsPerDayMax} sessions, {activeProto.maxDailyAloneMinutes} min/day, and {pattern.recMin}–{pattern.recMax} pattern breaks.</div></div>
-            </div>
-          </div>
-        </div>
+        </SettingsSheet>
       )}
 
       {activePanel === SETTINGS_PANEL.ADVANCED && (
-        <div className="quick-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="settings-advanced-title" onClick={() => setActivePanel(null)}>
-          <div className="quick-modal-card modal-card modal-card--dialog-md" onClick={(e) => e.stopPropagation()}>
-            <div className="quick-modal-head">
-              <div className="quick-modal-title" id="settings-advanced-title">Advanced</div>
-              <ModalCloseButton onClick={() => setActivePanel(null)} />
-            </div>
-            <div className="settings-modal-stack">
+        <SettingsSheet title="Advanced" titleId="settings-advanced-title" onClose={() => setActivePanel(null)}>
               <div className="settings-advanced-group">
                 <div className="diag-head">
                   <button className="diag-run-btn button-size-compact-tertiary secondary-control secondary-control--compact-button" type="button" disabled={syncDiagRunning} onClick={runSyncDiagnostics}>{syncDiagRunning ? "Running…" : "Run connection test"}</button>
@@ -288,45 +292,27 @@ export default function SettingsScreen(props) {
                 )}
               </div>}
               {diagDetailsOpen && syncDiagResult && <div className="settings-advanced-group settings-advanced-group--technical"><div className={`diag-summary ${syncDiagResult.checks?.summary?.ok ? "ok" : "err"}`}>{syncDiagResult.checks?.summary?.ok ? "All checks passed" : "Some checks failed"}</div><pre className="diag-json">{JSON.stringify(syncDiagResult, null, 2)}</pre></div>}
-            </div>
-          </div>
-        </div>
+        </SettingsSheet>
       )}
 
       {activePanel === SETTINGS_PANEL.ACCOUNT && (
-        <div className="quick-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="settings-account-title" onClick={() => setActivePanel(null)}>
-          <div className="quick-modal-card modal-card modal-card--dialog-md" onClick={(e) => e.stopPropagation()}>
-            <div className="quick-modal-head">
-              <div className="quick-modal-title" id="settings-account-title">Account</div>
-              <ModalCloseButton onClick={() => setActivePanel(null)} />
-            </div>
-            <div className="settings-modal-stack">
-              <button
-                className="settings-btn button-size-secondary-pill"
-                onClick={() => {
-                  if (window.confirm(`Re-run setup for ${name}? All sessions are kept.`)) {
-                    setOnboardingState({ mode: "claim", dogId: activeDogId });
-                    setScreen("onboard");
-                  }
-                }}
-              >
-                Edit {name}&rsquo;s profile
-              </button>
-              <button className="settings-btn button-size-secondary-pill" onClick={() => setScreen("select")}>
-                <span className="settings-btn__label">Switch dog</span>
-              </button>
-            </div>
-          </div>
-        </div>
+        <SettingsSheet title="Account" titleId="settings-account-title" onClose={() => setActivePanel(null)} compact>
+          <SettingsNavRow
+            label={`Edit ${name}’s profile`}
+            value="Re-run setup"
+            onClick={() => {
+              if (window.confirm(`Re-run setup for ${name}? All sessions are kept.`)) {
+                setOnboardingState({ mode: "claim", dogId: activeDogId });
+                setScreen("onboard");
+              }
+            }}
+          />
+          <SettingsNavRow label="Switch dog" onClick={() => setScreen("select")} />
+        </SettingsSheet>
       )}
 
       {trainingSettingsOpen && (
-        <div className="quick-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="training-settings-title" onClick={() => setTrainingSettingsOpen(false)}>
-          <div className="quick-modal-card modal-card modal-card--dialog-md" onClick={(e) => e.stopPropagation()}>
-            <div className="quick-modal-head">
-              <div className="quick-modal-title" id="training-settings-title">Edit training plan</div>
-              <ModalCloseButton onClick={() => setTrainingSettingsOpen(false)} />
-            </div>
+        <SettingsSheet title="Edit training plan" titleId="training-settings-title" onClose={() => setTrainingSettingsOpen(false)}>
             <div className="share-sub">Adjust protocol values only if a trainer has advised you to. Full guidance is kept in Help.</div>
             {!protoWarnAck ? (
               <div className="proto-warn-banner">
@@ -354,8 +340,7 @@ export default function SettingsScreen(props) {
                 <button onClick={() => { setProtoOverride({}); setProtoWarnAck(false); }} className="settings-inline-reset-btn t-helper u-mt-row secondary-control secondary-control--inline-text" type="button">Reset to defaults</button>
               </div>
             )}
-          </div>
-        </div>
+        </SettingsSheet>
       )}
     </>
   );

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1045,6 +1045,14 @@
   .tool-expand--modal { border-top:none; border-radius:12px; }
   .quick-modal-overlay { position:fixed; inset:0; background:var(--surface-overlay-strong); display:flex; align-items:center; justify-content:center; z-index:80; backdrop-filter:blur(2px); padding:var(--space-card-padding); animation:fadeIn 220ms ease; }
   .quick-modal-card { --modal-card-max-width:min(430px, calc(100vw - (2 * var(--space-card-padding)))); --modal-card-max-height:min(82vh, 760px); }
+  .quick-modal-overlay--sheet { align-items:flex-end; }
+  .quick-modal-card--sheet {
+    width:min(460px, 100%);
+    border-radius:20px 20px 14px 14px;
+    animation:sheetRise 280ms var(--ease-emphasized, cubic-bezier(.2,.8,.2,1));
+    transform-origin:bottom center;
+  }
+  .quick-modal-card--sheet-compact { --modal-card-max-height:min(68vh, 560px); }
   .quick-modal-head { display:flex; align-items:flex-start; justify-content:space-between; gap:var(--space-modal-footer-gap); margin-bottom:var(--space-modal-footer-gap); }
   .quick-modal-title { font-size:var(--type-modal-title-size); line-height:var(--type-modal-title-line); letter-spacing:var(--type-modal-title-track); font-weight:var(--type-modal-title-weight); color:var(--brown); }
   .modal-close-btn {
@@ -1962,9 +1970,12 @@
     gap:var(--space-control-gap);
     text-align:left;
     cursor:pointer;
-    transition:color var(--motion-base) var(--ease-out), border-color var(--motion-base) var(--ease-out), transform var(--motion-press) var(--ease-out);
+    transition:color var(--motion-base) var(--ease-out), border-color var(--motion-base) var(--ease-out), background-color var(--motion-base) var(--ease-out), transform var(--motion-press) var(--ease-out);
   }
-  .settings-nav-row:hover { color:var(--brown); }
+  .settings-nav-row:hover {
+    color:var(--brown);
+    background:color-mix(in srgb, var(--surface-muted) 64%, transparent);
+  }
   .settings-nav-row:active { transform:translateY(1px); }
   .settings-inline-card {
     border:1px solid color-mix(in srgb, var(--border) 70%, transparent);
@@ -1988,6 +1999,22 @@
     font-weight:var(--type-body-weight);
   }
   .settings-time-input { animation:fadeIn 180ms ease; }
+  .settings-inline-reveal {
+    display:grid;
+    grid-template-rows:0fr;
+    opacity:0;
+    transition:grid-template-rows 220ms var(--ease-out), opacity 200ms var(--ease-out), margin-top 200ms var(--ease-out);
+    margin-top:0;
+  }
+  .settings-inline-reveal > * {
+    overflow:hidden;
+    min-height:0;
+  }
+  .settings-inline-reveal.is-open {
+    grid-template-rows:1fr;
+    opacity:1;
+    margin-top:2px;
+  }
   .settings-nav-row__label,
   .settings-nav-row__value {
     font-size:var(--type-body-size);
@@ -2015,6 +2042,27 @@
     margin-top:calc(var(--space-control-gap) * -1);
     border-top:1px solid color-mix(in srgb, var(--border) 72%, transparent);
     padding-top:var(--space-control-gap);
+  }
+  .settings-danger-confirm {
+    padding:var(--space-control-gap) 0 var(--space-1);
+    display:grid;
+    gap:var(--space-control-gap);
+  }
+  .settings-danger-actions {
+    display:flex;
+    justify-content:flex-end;
+    flex-wrap:wrap;
+    gap:var(--space-control-gap);
+  }
+  @keyframes sheetRise {
+    from {
+      opacity:0;
+      transform:translateY(14px) scale(0.985);
+    }
+    to {
+      opacity:1;
+      transform:translateY(0) scale(1);
+    }
   }
   .history-food-type { text-transform:capitalize; }
   .icon-img { display:inline-block; flex-shrink:0; object-fit:contain; }


### PR DESCRIPTION
### Motivation
- Reduce abrupt full-screen dialog jumps in the redesigned Settings screen and prefer smooth sheet-style subviews to keep context and maintain a calm premium interaction model.
- Surface small controls (like reminder time) inline where appropriate to avoid unnecessary context switches and keep interactions subtle and low-friction.
- Make destructive actions in the Danger zone less jarring by replacing browser confirms with an inline, collapsible flow and add subtle tap/motion feedback throughout.

### Description
- Added a reusable `SettingsSheet` component and migrated Profile, Labels, Help, Advanced, Account, and Training settings to open as bottom sheets instead of centered modal dialogs, and added a `compact` option for tighter sheets (`src/features/settings/SettingsScreen.jsx`).
- Replaced the reminder time show/hide with an animated inline reveal (`.settings-inline-reveal`) so time editing happens in-place without a full modal, and added `removeConfirmOpen` flow to provide an inline Cancel/Remove confirmation in the Danger zone (`src/features/settings/SettingsScreen.jsx`).
- Replaced the destructive `window.confirm` pattern with a collapsible inline confirmation block and wired Cancel/Remove buttons to the existing cleanup logic (`src/features/settings/SettingsScreen.jsx`).
- Polished UI motion and tap feedback by adding sheet rise animation, hover surface tint for settings rows, reveal animations, and danger-action layout styles, and removed an unused `DeleteIcon` import (`src/styles/app.css`, `src/features/settings/SettingsScreen.jsx`).

### Testing
- Built the production bundle with `npm run build` and the build completed successfully.
- Ran the unit test suite with `npm test` and all tests passed (Test Files: 19 passed, Tests: 235 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0faf742d48332985881c5a1b897e6)