### PR TITLE
Refine in-app copy to emphasize calm-alone dog training

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1189,7 +1189,7 @@ export default function PawTimer() {
               </label>
               <div className="identity-copy">
                 <div className="app-title">{appData.name}</div>
-                <div className="app-subtitle">Separation anxiety training</div>
+                <div className="app-subtitle">Calm-alone plan for real departures</div>
               </div>
             </div>
           </div>

--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -39,7 +39,7 @@ function HistoryDetailGroup({ label, children }) {
 }
 
 function HistoryChipList({ items }) {
-  if (!items?.length) return <div className="h-detail-empty">No extra details recorded.</div>;
+  if (!items?.length) return <div className="h-detail-empty">No extra context recorded for this dog yet.</div>;
   return (
     <div className="h-chip-list">
       {items.map((item) => <span className="h-chip" key={item}>{item}</span>)}
@@ -540,7 +540,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
           <div className="history-section-head">
             <div>
               <div className="section-title">History</div>
-              <div className="t-helper">A calm view of {name}&rsquo;s training progress.</div>
+              <div className="t-helper">A timeline of {name}&rsquo;s calm-alone reps and support routine.</div>
             </div>
             {sessions.length > 0 && <button className="clear-btn surface-text-button secondary-control secondary-control--inline-text" onClick={actions.clearSessions}>Clear sessions</button>}
           </div>
@@ -549,21 +549,21 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
               <div className="history-summary-grid">
                 <div className="history-summary-item">
                   <div className="history-summary-value">{sessionCount}</div>
-                  <div className="history-summary-label">Training sessions</div>
+                  <div className="history-summary-label">Calm-alone reps</div>
                 </div>
                 <div className="history-summary-item">
                   <div className="history-summary-value">{careCount}</div>
-                  <div className="history-summary-label">Care routine logs</div>
+                  <div className="history-summary-label">Support routine logs</div>
                 </div>
                 <div className="history-summary-item">
                   <div className="history-summary-value">{recentCount}</div>
-                  <div className="history-summary-label">Recent moments</div>
+                  <div className="history-summary-label">Recent training moments</div>
                 </div>
               </div>
               <div className="history-mini-trend" aria-label="Last seven days of training sessions">
                 <div className="history-mini-trend-head">
-                  <span>7-day training rhythm</span>
-                  <span>{recentTrend.reduce((sum, day) => sum + day.count, 0)} sessions</span>
+                  <span>7-day calm-alone rhythm</span>
+                  <span>{recentTrend.reduce((sum, day) => sum + day.count, 0)} reps</span>
                 </div>
                 <div className="history-mini-trend-bars" role="img" aria-label="Each bar shows number of sessions completed each day">
                   {recentTrend.map((day) => (
@@ -584,12 +584,12 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                   ))}
                 </div>
               ) : null}
-              {lastSession ? <div className="history-summary-note">Latest training session: {fmtDate(lastSession.date)}.</div> : null}
+              {lastSession ? <div className="history-summary-note">Latest calm-alone rep: {fmtDate(lastSession.date)}.</div> : null}
             </div>
           )}
 
           {timeline.length === 0 ? (
-            <EmptyState media={<TrendIcon />} title="No activity yet" body={`Start ${name}'s first session and your training history will appear here.`} ctaLabel="Go to Train →" onCta={() => setTab("home")} />
+            <EmptyState media={<TrendIcon />} title="No calm-alone logs yet" body={`Start ${name}&apos;s first calm-alone rep to build a separation-training history.`} ctaLabel="Go to Train →" onCta={() => setTab("home")} />
           ) : dayGroups.map(([dayKey, items]) => (
             <div className="history-day-group" key={dayKey}>
               <div className="history-day-label">{new Date(`${dayKey}T00:00:00`).toLocaleDateString(undefined, { weekday: "long", month: "short", day: "numeric" })}</div>
@@ -603,10 +603,10 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
               );
               return renderHistoryCard({
                 itemKey: `s-${s.id}`,
-                title: "Training session",
+                title: "Calm-alone training rep",
                 date: fmtDate(s.date),
                 value: fmt(s.actualDuration),
-                kindLabel: "Training",
+                kindLabel: "Calm-alone",
                 onActivate: () => setSessionDetail(s),
                 badge: <span className={`h-badge badge-${lv}`}>{lv === "none" ? "No distress" : lv === "subtle" ? "Subtle stress" : lv === "active" ? "Active distress" : "Severe distress"}</span>,
                 syncBadge: renderSyncBadge(s),
@@ -625,7 +625,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                 expandedContent: <>
                   <div className="h-expand-grid">
                     <HistoryDetailGroup label="Walk details">
-                      <HistoryChipList items={["Walk logged", `Type: ${walkTypeLabel(w.type)}`]} />
+                      <HistoryChipList items={["Walk logged for decompression support", `Type: ${walkTypeLabel(w.type)}`]} />
                     </HistoryDetailGroup>
                   </div>
                   <div className="h-expand-footer">
@@ -655,7 +655,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                 expandedContent: <>
                   <div className="h-expand-grid">
                     <HistoryDetailGroup label="Pattern details">
-                      <HistoryChipList items={["Routine support item", pt.desc]} />
+                      <HistoryChipList items={["Departure-cue support item", pt.desc]} />
                     </HistoryDetailGroup>
                   </div>
                   <div className="h-expand-footer">
@@ -683,7 +683,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                 expandedContent: <>
                   <div className="h-expand-grid">
                     <HistoryDetailGroup label="Meal details">
-                      <HistoryChipList items={["Meal recorded", `Amount: ${f.amount}`, `Type: ${f.foodType}`]} />
+                      <HistoryChipList items={["Meal recorded for routine consistency", `Amount: ${f.amount}`, `Type: ${f.foodType}`]} />
                     </HistoryDetailGroup>
                   </div>
                   <div className="h-expand-footer">
@@ -715,7 +715,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
             </div>
 
             {historyModal.mode === "datetime" && <>
-              <div className="t-helper activity-time-hint">Choose a date and time. Duration is edited separately.</div>
+              <div className="t-helper activity-time-hint">Choose when this dog activity happened. Duration is edited separately.</div>
               <label className="activity-time-field">
                 <span className="t-helper">Date</span>
                 <input type="date" value={historyModal.date} onChange={(e) => setHistoryModal((prev) => (prev ? { ...prev, date: e.target.value } : prev))} />
@@ -750,7 +750,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
             {historyModal.mode === "delete" && <>
               <div className="history-delete-copy">
                 <div className="history-delete-label">{historyModal.label}</div>
-                <p>This action removes the item from the timeline for this dog. You can’t undo it after confirmation.</p>
+                <p>This removes the item from this dog&apos;s training timeline. You can’t undo it after confirmation.</p>
               </div>
               <div className="feeding-actions">
                 <button className="walk-cancel-btn button-base button-ghost button--md button--pill" type="button" onClick={() => setHistoryModal(null)}>Keep item</button>
@@ -772,7 +772,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
           <div className="history-session-sheet modal-card modal-card--dialog-md" onClick={(event) => event.stopPropagation()}>
             <div className="history-session-sheet-grabber" aria-hidden="true" />
             <div className="quick-modal-head">
-              <div className="section-title section-title--flush" id="history-session-sheet-title">Session details</div>
+              <div className="section-title section-title--flush" id="history-session-sheet-title">Calm-alone rep details</div>
               <ModalCloseButton onClick={() => setSessionDetail(null)} />
             </div>
             <div className="history-session-sheet-meta">

--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -100,7 +100,7 @@ export default function HomeScreen(props) {
           <div className="train-identity-header__copy">
             <div className="train-identity-header__eyebrow">{name}'s calm practice</div>
             <h2 className="train-identity-header__name">Train with {name}</h2>
-            <p className="train-identity-header__mood">A short, gentle rep to help {name} feel safer when alone.</p>
+            <p className="train-identity-header__mood">Short, humane separation reps to help {name} stay calm during real departures.</p>
           </div>
         </header>
 
@@ -128,18 +128,18 @@ export default function HomeScreen(props) {
               aria-expanded={trainExplainOpen}
             >
               <span className="train-inline-guidance__label">Tap to explain</span>
-              <span className="train-inline-guidance__copy">What this circle and target mean</span>
+              <span className="train-inline-guidance__copy">How this calm circle connects to separation training</span>
             </button>
             {trainExplainOpen && (
               <div className="train-inline-explain" role="note" aria-live="polite">
-                <p><strong>Big circle:</strong> this rep's timer. During a session, the number counts down and the ring fills as calm time is completed.</p>
-                <p><strong>Target time ({fmtClock(target)}):</strong> your current safe goal for one calm rep. End while {name} is still settled.</p>
+                <p><strong>Big circle:</strong> this is {name}&apos;s calm-alone window for one rep. The ring fills as settled alone time is completed.</p>
+                <p><strong>Target time ({fmtClock(target)}):</strong> your current safe threshold before stress rises. End while {name} is still relaxed.</p>
               </div>
             )}
           </div>
         )}
         <section className="train-context-block surface-card">
-          <p className="train-context-block__title">Today's target time</p>
+          <p className="train-context-block__title">Today&apos;s calm-alone target</p>
           <p className="train-context-block__value">{fmtClock(target)} calm for {name}</p>
           <p className="train-context-block__meta">
             Sessions today: <strong>{daily.count}</strong> · Daily pace target: <strong>{fmt(goalSec)}</strong>
@@ -155,8 +155,8 @@ export default function HomeScreen(props) {
               className="train-inline-guidance"
               onClick={dismissTrainFirstRunHint}
             >
-              <span className="train-inline-guidance__label">Target adapts gently</span>
-              <span className="train-inline-guidance__copy">Calm reps step up over time. Stress signs lower the next goal.</span>
+              <span className="train-inline-guidance__label">Targets adapt to your dog</span>
+              <span className="train-inline-guidance__copy">Consistent calm nudges targets upward. Stress signs bring the next step down.</span>
             </button>
           )}
           {phase === "idle" && recoveryMode?.active && (
@@ -204,8 +204,8 @@ export default function HomeScreen(props) {
             onClick={() => setTodayOpen((prev) => !prev)}
           >
             <div>
-              <div className="section-title section-title--flush">Today&apos;s logs</div>
-              <div className="t-helper">{todaySessions.length} calm sessions · support activity</div>
+              <div className="section-title section-title--flush">Today&apos;s training + care log</div>
+              <div className="t-helper">{todaySessions.length} calm-alone reps · support activity</div>
             </div>
             <span className="settings-collapsible-arrow" aria-hidden="true">{todayOpen ? "−" : "+"}</span>
           </button>
@@ -213,7 +213,7 @@ export default function HomeScreen(props) {
             <div className="settings-collapsible-inner">
               <div className="train-today-list" role="list" aria-label="Today's logged activity">
                 <div className="train-today-row" role="listitem">
-                  <span className="train-today-row__label">Calm sessions</span>
+                  <span className="train-today-row__label">Calm-alone reps</span>
                   <span className="train-today-row__meta">{todaySessions.length} logged</span>
                 </div>
                 <button className="train-today-row train-today-row--action" type="button" onClick={walkPhase === "idle" ? startWalk : undefined}>
@@ -230,7 +230,7 @@ export default function HomeScreen(props) {
                 </button>
               </div>
               {recentSessionLogs.length > 0 && (
-                <div className="train-today-mini-log" role="list" aria-label="Recent calm sessions">
+                <div className="train-today-mini-log" role="list" aria-label="Recent calm-alone reps">
                   {recentSessionLogs.map((session) => (
                     <div className="train-today-mini-log__row" role="listitem" key={session.id || `${session.date}-${session.actualDuration || 0}`}>
                       <span>{new Date(session.date).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}</span>

--- a/src/features/settings/DogProfileCard.jsx
+++ b/src/features/settings/DogProfileCard.jsx
@@ -26,7 +26,7 @@ export default function DogProfileCard({
           {String(dogName || "D").trim().charAt(0).toUpperCase()}
         </div>
         <div className="settings-dog-profile-card__titles">
-          <div className="settings-simple-title">Active dog profile</div>
+          <div className="settings-simple-title">Active calm-alone profile</div>
           <div className="settings-dog-profile-card__name">{dogName}</div>
           <div className="settings-dog-profile-card__state">
             <span className={`settings-dog-profile-card__state-dot settings-dog-profile-card__state-dot--${syncTone}`} aria-hidden="true" />
@@ -39,8 +39,8 @@ export default function DogProfileCard({
       </div>
 
       <div className="settings-dog-profile-card__meta" aria-label="Dog status summary">
-        <div className="settings-profile-chip">{reminderSummary} reminders</div>
-        <div className="settings-profile-chip">Plan: max {sessionsPerDayMax} sessions/day</div>
+        <div className="settings-profile-chip">{reminderSummary} training reminders</div>
+        <div className="settings-profile-chip">Plan: max {sessionsPerDayMax} calm-alone reps/day</div>
         <div className="settings-profile-chip">{customLabelCount} custom labels</div>
       </div>
     </button>

--- a/src/features/settings/SettingsScreen.jsx
+++ b/src/features/settings/SettingsScreen.jsx
@@ -101,8 +101,8 @@ export default function SettingsScreen(props) {
     <>
       <div className="tab-content">
         <div className="section settings-shell">
-          <div className="section-title">Calm control</div>
-          <div className="t-helper">Elegant control for {name}&rsquo;s training rhythm, routine, and account.</div>
+          <div className="section-title">{name}&rsquo;s calm-alone settings</div>
+          <div className="t-helper">Tune routines, reminders, and profile details for separation training.</div>
 
           <DogProfileCard
             dogName={name}
@@ -114,10 +114,10 @@ export default function SettingsScreen(props) {
           />
 
           <div className="settings-group" role="list" aria-label="Training routine settings">
-            <div className="settings-section-label">Training routine</div>
+            <div className="settings-section-label">Calm-alone routine</div>
             <div className="settings-inline-card">
               <div className="settings-row-head">
-                <span className="settings-inline-title">Daily reminder</span>
+                <span className="settings-inline-title">Daily training reminder</span>
                 <button className={`notif-toggle secondary-control secondary-control--toggle ${notifEnabled ? "on" : ""}`} onClick={handleToggleNotif} type="button">{notifEnabled ? "On" : "Off"}</button>
               </div>
               <div className="settings-inline-row">
@@ -143,7 +143,7 @@ export default function SettingsScreen(props) {
                 )}
               </div>
             </div>
-            <SettingsNavRow label="Training settings" value={`Up to ${activeProto.sessionsPerDayMax}/day`} onClick={() => setTrainingSettingsOpen(true)} />
+            <SettingsNavRow label="Training settings" value={`Up to ${activeProto.sessionsPerDayMax} reps/day`} onClick={() => setTrainingSettingsOpen(true)} />
             <SettingsNavRow label="Custom labels" value={`${Object.keys(patLabels).length} custom`} onClick={() => setActivePanel(SETTINGS_PANEL.LABELS)} />
           </div>
 
@@ -241,12 +241,12 @@ export default function SettingsScreen(props) {
 
       {activePanel === SETTINGS_PANEL.HELP && (
         <SettingsSheet title="Help" titleId="settings-help-title" onClose={() => setActivePanel(null)}>
-              <div className="proto-section u-mt-none"><div className="proto-title">Sync devices</div><div className="proto-row">Share your Dog ID, then join with the same ID on the other device.</div></div>
-              <div className="proto-section"><div className="proto-title">Session flow</div><div className="proto-row">Start a session, return before distress escalates, then rate how {name} did.</div></div>
+              <div className="proto-section u-mt-none"><div className="proto-title">Sync devices</div><div className="proto-row">Share your Dog ID so everyone tracks the same calm-alone plan for {name}.</div></div>
+              <div className="proto-section"><div className="proto-title">Session flow</div><div className="proto-row">Start a calm-alone rep, return before stress escalates, then rate how {name} handled being alone.</div></div>
               <div className="proto-section"><div className="proto-title">Current recommendation state</div><div className="proto-row">Now: <strong>{recommendationType}</strong>. {recommendationSummary} It currently weighs {(recommendation?.details?.factors || []).join(" ")}</div></div>
               <div className="proto-section"><div className="proto-title">Recommendation states emitted</div><div className="proto-row">baseline_start, keep_same_duration, repeat_current_duration, departure_cues_first, recovery_mode_active, recovery_mode_resume.</div></div>
               <div className="proto-section"><div className="proto-title">Recovery behavior</div><div className="proto-row">Any subtle/active/severe distress can activate recovery. While recovery_mode_active, targets use short fixed steps (typically 60s then 120s; severe can add a third 120s step). Subtle recovery accepts any calm follow-up duration; active/severe count calm sessions at short recovery lengths. After enough calm sessions, recovery_mode_resume emits once, then normal progression continues.</div></div>
-              <div className="proto-section"><div className="proto-title">Daily rhythm</div><div className="proto-row">Aim for up to {activeProto.sessionsPerDayMax} sessions, {activeProto.maxDailyAloneMinutes} min/day, and {pattern.recMin}–{pattern.recMax} pattern breaks.</div></div>
+              <div className="proto-section"><div className="proto-title">Daily rhythm</div><div className="proto-row">Aim for up to {activeProto.sessionsPerDayMax} calm-alone reps, {activeProto.maxDailyAloneMinutes} min/day, and {pattern.recMin}–{pattern.recMax} pattern-break supports.</div></div>
         </SettingsSheet>
       )}
 
@@ -312,7 +312,7 @@ export default function SettingsScreen(props) {
       )}
 
       {trainingSettingsOpen && (
-        <SettingsSheet title="Edit training plan" titleId="training-settings-title" onClose={() => setTrainingSettingsOpen(false)}>
+        <SettingsSheet title="Edit calm-alone plan" titleId="training-settings-title" onClose={() => setTrainingSettingsOpen(false)}>
             <div className="share-sub">Adjust protocol values only if a trainer has advised you to. Full guidance is kept in Help.</div>
             {!protoWarnAck ? (
               <div className="proto-warn-banner">

--- a/src/features/setup/SetupScreens.jsx
+++ b/src/features/setup/SetupScreens.jsx
@@ -21,7 +21,7 @@ export function WelcomeScreen({ onStart, onManageDogs }) {
         <div className="ws-eyebrow">Calm dog training</div>
         <h1 className="ws-title">PawTimer</h1>
         <p className="ws-copy">
-          Gentle, science-led sessions that help your dog feel safer when home alone.
+          Guided separation-training reps that teach your dog to settle calmly when left alone.
         </p>
       </div>
 
@@ -62,9 +62,9 @@ export function Onboarding({ onComplete, onBack }) {
     <div className="onboarding">
       <div className="ob-hero">
         <div className="ob-hero-icon"><PawIcon size={48} /></div>
-        <div className="ob-eyebrow">Create dog</div>
-        <div className="ob-title">{displayName === "your dog" ? "Start a calm journey" : `${displayName}'s calm journey`}</div>
-        <div className="ob-subtitle">{activeStep.progressLabel} • One focused choice at a time.</div>
+        <div className="ob-eyebrow">Build {displayName}&apos;s plan</div>
+        <div className="ob-title">{displayName === "your dog" ? "Start calm-alone training" : `${displayName}&apos;s calm-alone training`}</div>
+        <div className="ob-subtitle">{activeStep.progressLabel} • We&apos;ll set a safe starting pace.</div>
         <div className="ob-step-indicator">
           {[0, 1, 2, 3].map((i) => <div key={i} className={`ob-step-dot ${i < step ? "done" : i === step ? "active" : ""}`} />)}
         </div>
@@ -72,14 +72,14 @@ export function Onboarding({ onComplete, onBack }) {
       <div className="ob-body">
         <div key={step} className="ob-step-panel">
           {step === 0 && <>
-            <div className="ob-question">Who are we training with today?</div>
-            <div className="ob-note prose">Your dog's name personalizes every cue and progress view.</div>
+            <div className="ob-question">Which dog are you training for calm-alone time?</div>
+            <div className="ob-note prose">Your dog&apos;s name personalizes each training cue, log, and progress insight.</div>
             <div className="ob-hint">You can update this later in settings if needed.</div>
             <input className="ob-input" placeholder="e.g. Luna, Mochi, Rocco…" value={name} onChange={(e) => setName(e.target.value)} onKeyDown={(e) => e.key === "Enter" && canNext && handleNext()} autoFocus />
           </>}
           {step === 1 && <>
-            <div className="ob-question">How often is {displayName} home alone?</div>
-            <div className="ob-hint">This helps shape your weekly rhythm and guidance intensity.</div>
+            <div className="ob-question">How often is {displayName} left home alone?</div>
+            <div className="ob-hint">We use this to pace reps so practice fits real-life departure routines.</div>
             <div className="ob-options">
               {LEAVE_OPTIONS.map((o) => (
                 <button key={o.value} className={`ob-option ${leaves === o.value ? "selected" : ""}`} onClick={() => setLeaves(o.value)}>
@@ -89,8 +89,8 @@ export function Onboarding({ onComplete, onBack }) {
             </div>
           </>}
           {step === 2 && <>
-            <div className="ob-question">How long does {displayName} stay calm right now?</div>
-            <div className="ob-hint">We'll start gently from this baseline and build calm confidence over time.</div>
+            <div className="ob-question">Right now, how long can {displayName} stay settled alone?</div>
+            <div className="ob-hint">This baseline sets your first safe reps and helps prevent stress spikes.</div>
             <div className="ob-duration-grid">
               {CALM_DURATIONS.map((d) => (
                 <button key={d.value} className={`ob-dur-btn ${calm === d.value ? "selected" : ""}`} onClick={() => setCalm(d.value)}>
@@ -100,9 +100,9 @@ export function Onboarding({ onComplete, onBack }) {
             </div>
           </>}
           {step === 3 && <>
-            <div className="ob-question">Choose a future calm goal for {displayName}</div>
+            <div className="ob-question">Choose a future calm-alone goal for {displayName}</div>
             <div className="ob-note prose">Optional: skip for now and set this after a few sessions.</div>
-            <div className="ob-hint">Goals keep motivation high — training still works even without one.</div>
+            <div className="ob-hint">A goal helps you plan for real errands while keeping training humane and gradual.</div>
             <div className="ob-duration-grid">
               {GOAL_DURATIONS.map((d) => (
                 <button key={d.value} className={`ob-dur-btn ${goal === d.value ? "selected" : ""}`} onClick={() => setGoal(d.value)}>
@@ -115,7 +115,7 @@ export function Onboarding({ onComplete, onBack }) {
       </div>
       <div className="ob-footer">
         <button className="ob-btn-next button-base button-primary button--lg button-size-primary-cta button--block" onClick={handleNext} disabled={!canNext}>
-          {step < 3 ? "Continue →" : `Begin ${displayName}'s plan`}
+          {step < 3 ? "Continue →" : `Start ${displayName}&apos;s calm-alone plan`}
         </button>
         <button className="ob-back-btn" onClick={() => step === 0 ? onBack?.() : setStep((s) => s - 1)}>
           ← {step === 0 ? "Back to dogs" : "Back"}
@@ -178,7 +178,7 @@ export function DogSelect({ dogs, onSelect, onCreateNew }) {
       <div className="ds-hero">
         <div className="ds-logo"><PawIcon size={68} /></div>
         <div className="ds-title">PawTimer</div>
-        <div className="ds-sub">Choose how you want to get started.</div>
+        <div className="ds-sub">Choose how you want to begin your dog&apos;s calm-alone training.</div>
       </div>
       <div className="ds-body">
         <div className="ds-path-grid">
@@ -190,8 +190,8 @@ export function DogSelect({ dogs, onSelect, onCreateNew }) {
               onCreateNew();
             }}
           >
-            <div className="ds-path-title">Create new dog</div>
-            <div className="ds-path-copy">Set up your dog's calm plan in under a minute.</div>
+            <div className="ds-path-title">Create new dog plan</div>
+            <div className="ds-path-copy">Set a calm-alone baseline and training rhythm in under a minute.</div>
           </button>
           <button
             className={`ds-path-card ${activePath === "join" ? "selected" : ""}`}
@@ -199,7 +199,7 @@ export function DogSelect({ dogs, onSelect, onCreateNew }) {
             onClick={() => setActivePath("join")}
           >
             <div className="ds-path-title">Join existing dog by ID</div>
-            <div className="ds-path-copy">Use a shared ID to track the same dog together.</div>
+            <div className="ds-path-copy">Use a shared ID so everyone follows the same calm-alone plan.</div>
           </button>
         </div>
 

--- a/src/features/stats/StatsScreen.jsx
+++ b/src/features/stats/StatsScreen.jsx
@@ -10,7 +10,7 @@ export default function StatsScreen({ name, totalCount, setTab, bestCalm, recomm
   const headlineSurfaceState = headlineStatusTone?.surfaceState || "today";
   const riskSurfaceState = relapseTone?.surfaceState || "today";
 
-  const emotionalMomentum = chartTrendLabel || `${name} is building consistency with each calm session.`;
+  const emotionalMomentum = chartTrendLabel || `${name} is building calm-alone resilience rep by rep.`;
   const progressDelta = Math.max(0, target - bestCalm);
   const nextTargetLabel = progressDelta > 0
     ? `Next milestone (+${fmt(progressDelta)})`
@@ -22,18 +22,18 @@ export default function StatsScreen({ name, totalCount, setTab, bestCalm, recomm
       : `${name} is building calm confidence.`;
   const cadenceLabel = avgSessionsPerDay != null
     ? avgSessionsPerDay >= 1
-      ? `Strong cadence: ${avgSessionsPerDay.toFixed(1)} sessions/day.`
-      : `Steady cadence: ${avgSessionsPerDay.toFixed(1)} sessions/day.`
-    : "Cadence will appear after a few more sessions.";
+      ? `Strong cadence: ${avgSessionsPerDay.toFixed(1)} calm-alone reps/day.`
+      : `Steady cadence: ${avgSessionsPerDay.toFixed(1)} calm-alone reps/day.`
+    : "Cadence appears after a few calm-alone reps.";
   const walkSupportLabel = avgWalkDuration != null
-    ? `Walks are averaging ${fmt(avgWalkDuration, { hoursMinutesOnly: true })}, helping emotional reset.`
-    : "Add walks to strengthen recovery between sessions.";
+    ? `Walks average ${fmt(avgWalkDuration, { hoursMinutesOnly: true })}, supporting decompression between alone-time reps.`
+    : "Add decompression walks to support recovery between alone-time reps.";
 
   return (
     <div className="tab-content stats-tab-content" data-ring-metric-variant={ringMetricVariant}>
       <div className="section">
         {totalCount === 0 ? (
-          <EmptyState media={<SproutIcon />} title="Progress starts here" body={`Complete your first session and ${name}'s progress, streak, and chart will appear here.`} ctaLabel="Go to Train →" onCta={() => setTab("home")} />
+          <EmptyState media={<SproutIcon />} title="Calm-alone progress starts here" body={`Log your first calm-alone rep and ${name}&apos;s progress curve will appear here.`} ctaLabel="Go to Train →" onCta={() => setTab("home")} />
         ) : <>
           <StatsSection className="stats-section-hero stats-section-priority">
             <ProgressHero
@@ -42,7 +42,7 @@ export default function StatsScreen({ name, totalCount, setTab, bestCalm, recomm
               headline={heroHeadline}
               headlineSurfaceState={headlineSurfaceState}
               currentValue={fmt(bestCalm)}
-              currentLabel="Current calm window"
+              currentLabel="Current calm-alone window"
               currentSeconds={bestCalm}
               targetValue={fmt(target)}
               targetLabel={nextTargetLabel}
@@ -51,30 +51,30 @@ export default function StatsScreen({ name, totalCount, setTab, bestCalm, recomm
             />
           </StatsSection>
 
-          <StatsSection title="What is shaping today" className="stats-section-signals">
+          <StatsSection title="What is shaping today&apos;s alone-time training" className="stats-section-signals">
             <div className="stats-row stats-row-core stats-row-core-calm">
               <StatsMetricCard
                 value={fmt(bestCalm)}
-                label="Best calm window"
-                detail="Your strongest moment so far"
+                label="Best calm-alone window"
+                detail="Longest settled alone-time rep so far"
                 className="stat-card--key-metric"
                 variant={standardMetricVariant}
               />
               <StatsMetricCard
                 value={relapseTone.label}
                 label="Recovery pressure"
-                detail="How gently to pace the next step"
+                detail="How conservatively to pace the next alone-time rep"
                 className={`stat-card--key-metric stat-card-risk surface-state--${riskSurfaceState}`}
                 variant={standardMetricVariant}
               />
             </div>
           </StatsSection>
 
-          <StatsSection title="Journey curve" className="stats-section-journey">
+          <StatsSection title="Calm-alone journey curve" className="stats-section-journey">
             <StatsChartSection chartData={chartData} goalSec={goalSec} setTab={setTab} name={name} fmt={fmt} insightLabel={chartTrendLabel} />
           </StatsSection>
 
-          <StatsSection title="Contextual insights" className="stats-section-supporting">
+          <StatsSection title="Context around your dog&apos;s calm-alone trend" className="stats-section-supporting">
             {contextualInsights.length > 0 ? (
               <div className="stats-insight-stack" role="list" aria-label="Progress movement insights">
                 {contextualInsights.map((insight, index) => (
@@ -89,7 +89,7 @@ export default function StatsScreen({ name, totalCount, setTab, bestCalm, recomm
               </div>
             ) : null}
             <div className="stats-support-list stats-support-list--insights">
-              <StatsSupportRow label="Weekly solo time" value={fmt(aloneLastWeek)} />
+              <StatsSupportRow label="Weekly alone-time practice" value={fmt(aloneLastWeek)} />
               <StatsSupportRow label="Session cadence" value={cadenceLabel} />
               <StatsSupportRow label="Walk support" value={walkSupportLabel} />
               <StatsSupportRow label="Daily walks" value={avgWalksPerDay != null ? `${avgWalksPerDay.toFixed(1)} walks/day` : "Tracking after more walk logs"} />

--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -30,7 +30,7 @@ function SessionActionRow({
         onClick={handlePrimary}
         disabled={!isRunning && !canRunStart && !canExplain}
       >
-        {isRunning ? "End and save session" : "Start calm session"}
+        {isRunning ? "End and save rep" : "Start calm-alone rep"}
       </button>
       <button
         className="session-cancel-btn button-base button-ghost button--md button--pill"
@@ -38,7 +38,7 @@ function SessionActionRow({
         aria-hidden={!isRunning}
         tabIndex={isRunning ? 0 : -1}
       >
-        Cancel session (don&apos;t save)
+        Cancel rep (don&apos;t save)
       </button>
       {!isRunning && !canStart && (
         <p className="session-action-meta" role="status">{startBlockedMessage}</p>
@@ -81,19 +81,19 @@ export function SessionControl({
         ? "active"
         : "idle";
   const innerCaption = displayState === "warning"
-    ? "Calm practice is paused for today"
+    ? "Calm-alone practice is paused for today"
     : displayState === "success"
       ? `${name} hit this calm target`
       : displayState === "active"
         ? isPastTarget
           ? `Past target — end while ${name} is still settled`
           : `${name}'s calm hold for this rep`
-        : `Next calm session target for ${name}`;
+        : `Next calm-alone target for ${name}`;
   const helperCaption = displayState === "active"
     ? (isPastTarget ? `+${fmt(overTargetSeconds)} calm hold` : `${fmt(elapsed)} completed this rep`)
     : displayState === "warning"
       ? "Come back tomorrow for the next rep"
-      : "Builds comfort with short solo reps";
+      : "Builds calm alone-time tolerance with short reps";
 
   const startWithFeedback = () => {
     if (!onStart || !canStart) return;
@@ -151,7 +151,7 @@ export function SessionControl({
               <div className="sc-caption">{innerCaption}</div>
               <div className="sc-support">{helperCaption}</div>
               <div className={`sc-state-chip ${isRunning ? "is-running" : ""}`}>
-                {isRunning ? `Session live · ${fmt(elapsed)} elapsed` : "Ready when you are"}
+                {isRunning ? `Rep live · ${fmt(elapsed)} elapsed` : "Ready for a calm-alone rep"}
               </div>
             </div>
           </div>
@@ -210,9 +210,9 @@ export function SessionRatingPanel({
     <div className="rating-overlay" role="presentation">
       <div className="rating-screen session-feedback modal-card modal-card--dialog-md rating-sheet" role="dialog" aria-modal="true" aria-labelledby="session-rating-title" aria-describedby="session-rating-sub">
         <div className="rating-sheet-grabber" aria-hidden="true" />
-        <div className="rating-title" id="session-rating-title">Was there any stress?</div>
+        <div className="rating-title" id="session-rating-title">How did {name} handle being alone?</div>
         <div className="rating-sub" id="session-rating-sub">
-          {fmt(finalElapsed)} session with {name}. Your choice updates the next training target.
+          {fmt(finalElapsed)} alone-time rep with {name}. Your choice adjusts the next target gently.
         </div>
         <div className="result-grid">
           <button className="btn-result btn-none" onClick={() => recordResult("none")}>


### PR DESCRIPTION
### Motivation
- Make the app feel purpose-built for training dogs to stay calm when left alone rather than a generic timer or productivity tool. 
- Strengthen a tasteful, subtle dog identity across onboarding, Train, History, Progress, and Settings so the product reads as humane separation training. 
- Clarify the Train hero/timer meaning so the big circle communicates a dog’s calm-alone threshold and supports humane pacing decisions. 

### Description
- Rephrased onboarding and dog-selection copy to frame setup as a calm-alone training plan and to surface the dog’s name across prompts (`src/features/setup/SetupScreens.jsx`).
- Updated Train header, inline explanations, timer captions, action labels, and rating copy to use dog- and calm-alone specific language (e.g. “rep”, “calm-alone rep”, “calm-alone target”) and to link the hero circle to separation training (`src/features/home/HomeScreen.jsx`, `src/features/train/TrainComponents.jsx`).
- Tuned History and support logs to present timeline items as calm-alone reps and support activities (decompression walks, pattern/ departure-cue support, meal consistency) and improved empty-state and detail microcopy (`src/features/history/HistoryFeature.jsx`).
- Adjusted Progress and Settings surfaces to keep dog identity tasteful and explicit (profile chips, headings, help text, training plan labels), and updated the app header subtitle (`src/features/stats/StatsScreen.jsx`, `src/features/settings/SettingsScreen.jsx`, `src/features/settings/DogProfileCard.jsx`, `src/App.jsx`).

### Testing
- Ran the unit/test suite with `npm run test`, which completed successfully (19 test files, 235 tests passed).
- Built the production bundle with `npm run build`, which completed successfully and produced the `dist/` output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0fc69803483328d2705c1570d2ff1)