### PR TITLE
Refine app microcopy for calmer, clearer training UX

### DIFF
--- a/src/features/app/helpers.js
+++ b/src/features/app/helpers.js
@@ -170,26 +170,26 @@ export const normalizeWalkType = (value) => {
 export const walkTypeLabel = (walkType) => (WALK_TYPE_OPTIONS.find((option) => option.value === normalizeWalkType(walkType))?.label ?? "regular walk");
 
 export const LEAVE_OPTIONS = [
-  { value: 1, label: "1–2 times", sub: "Work from home / rarely leave" },
-  { value: 3, label: "3–4 times", sub: "Short errands, occasional walks" },
-  { value: 5, label: "5–6 times", sub: "Regular commute or active lifestyle" },
-  { value: 8, label: "7+ times", sub: "Frequent short trips during the day" },
+  { value: 1, label: "1–2 times", sub: "Usually someone is home" },
+  { value: 3, label: "3–4 times", sub: "A few short departures" },
+  { value: 5, label: "5–6 times", sub: "Most weekdays are busy" },
+  { value: 8, label: "7+ times", sub: "Many short in-and-out trips" },
 ];
 
 export const CALM_DURATIONS = [
-  { value: 30, label: "30s", sub: "Just starting out" },
-  { value: 120, label: "2 min", sub: "A little bit" },
-  { value: 300, label: "5 min", sub: "Getting there" },
-  { value: 600, label: "10 min", sub: "Doing okay" },
-  { value: 1200, label: "20 min", sub: "Pretty good" },
-  { value: 1800, label: "30 min", sub: "Almost there" },
+  { value: 30, label: "30s", sub: "Very new to this" },
+  { value: 120, label: "2 min", sub: "Early baseline" },
+  { value: 300, label: "5 min", sub: "Can settle briefly" },
+  { value: 600, label: "10 min", sub: "Settles with support" },
+  { value: 1200, label: "20 min", sub: "Steady on good days" },
+  { value: 1800, label: "30 min", sub: "Consistent short departures" },
 ];
 
 export const GOAL_DURATIONS = [
-  { value: 1800, label: "30 min", sub: "Short errands" },
-  { value: 2400, label: "40 min", sub: "Standard goal" },
-  { value: 3600, label: "1 hour", sub: "Longer walks" },
-  { value: 7200, label: "2 hours", sub: "Half workday" },
-  { value: 14400, label: "4 hours", sub: "Morning/afternoon" },
+  { value: 1800, label: "30 min", sub: "Quick errand" },
+  { value: 2400, label: "40 min", sub: "Local trip" },
+  { value: 3600, label: "1 hour", sub: "One longer outing" },
+  { value: 7200, label: "2 hours", sub: "Half-day stretch" },
+  { value: 14400, label: "4 hours", sub: "Extended outing" },
   { value: 28800, label: "8 hours", sub: "Full workday" },
 ];

--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -39,7 +39,7 @@ function HistoryDetailGroup({ label, children }) {
 }
 
 function HistoryChipList({ items }) {
-  if (!items?.length) return <div className="h-detail-empty">No extra context recorded for this dog yet.</div>;
+  if (!items?.length) return <div className="h-detail-empty">No extra notes logged yet.</div>;
   return (
     <div className="h-chip-list">
       {items.map((item) => <span className="h-chip" key={item}>{item}</span>)}
@@ -589,7 +589,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
           )}
 
           {timeline.length === 0 ? (
-            <EmptyState media={<TrendIcon />} title="No calm-alone logs yet" body={`Start ${name}&apos;s first calm-alone rep to build a separation-training history.`} ctaLabel="Go to Train →" onCta={() => setTab("home")} />
+            <EmptyState media={<TrendIcon />} title="No logs yet" body={`Start ${name}&apos;s first rep to build a training history.`} ctaLabel="Go to Train →" onCta={() => setTab("home")} />
           ) : dayGroups.map(([dayKey, items]) => (
             <div className="history-day-group" key={dayKey}>
               <div className="history-day-label">{new Date(`${dayKey}T00:00:00`).toLocaleDateString(undefined, { weekday: "long", month: "short", day: "numeric" })}</div>

--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -73,9 +73,9 @@ export default function HomeScreen(props) {
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
     .slice(0, 4);
   const sessionBlockedMessage = daily.blockReason === "cap"
-    ? `Daily alone-time cap reached (${fmtClock(daily.capSec)}). Log more sessions tomorrow.`
+    ? `Daily alone-time cap reached (${fmtClock(daily.capSec)}). Try again tomorrow.`
     : daily.blockReason === "max_sessions"
-      ? `Daily session max reached (${daily.maxCount}). Log more sessions tomorrow.`
+      ? `Daily session max reached (${daily.maxCount}). Try again tomorrow.`
       : "";
   const toggleTrainExplain = () => {
     setTrainExplainOpen((prev) => !prev);
@@ -100,7 +100,7 @@ export default function HomeScreen(props) {
           <div className="train-identity-header__copy">
             <div className="train-identity-header__eyebrow">{name}'s calm practice</div>
             <h2 className="train-identity-header__name">Train with {name}</h2>
-            <p className="train-identity-header__mood">Short, humane separation reps to help {name} stay calm during real departures.</p>
+            <p className="train-identity-header__mood">Short, gentle reps to help {name} feel safer during real departures.</p>
           </div>
         </header>
 
@@ -127,22 +127,22 @@ export default function HomeScreen(props) {
               onClick={toggleTrainExplain}
               aria-expanded={trainExplainOpen}
             >
-              <span className="train-inline-guidance__label">Tap to explain</span>
-              <span className="train-inline-guidance__copy">How this calm circle connects to separation training</span>
+              <span className="train-inline-guidance__label">What this means</span>
+              <span className="train-inline-guidance__copy">How the circle supports separation training</span>
             </button>
             {trainExplainOpen && (
               <div className="train-inline-explain" role="note" aria-live="polite">
-                <p><strong>Big circle:</strong> this is {name}&apos;s calm-alone window for one rep. The ring fills as settled alone time is completed.</p>
-                <p><strong>Target time ({fmtClock(target)}):</strong> your current safe threshold before stress rises. End while {name} is still relaxed.</p>
+                <p><strong>Circle:</strong> this is {name}&apos;s target for one rep. The ring fills as calm alone time is completed.</p>
+                <p><strong>Target ({fmtClock(target)}):</strong> your current safe step. End while {name} is still relaxed.</p>
               </div>
             )}
           </div>
         )}
         <section className="train-context-block surface-card">
-          <p className="train-context-block__title">Today&apos;s calm-alone target</p>
+          <p className="train-context-block__title">Today&apos;s target</p>
           <p className="train-context-block__value">{fmtClock(target)} calm for {name}</p>
           <p className="train-context-block__meta">
-            Sessions today: <strong>{daily.count}</strong> · Daily pace target: <strong>{fmt(goalSec)}</strong>
+            Reps today: <strong>{daily.count}</strong> · Longer-term goal: <strong>{fmt(goalSec)}</strong>
           </p>
           {!daily.canAdd && (
             <p className="status-msg status-msg--warning">
@@ -156,7 +156,7 @@ export default function HomeScreen(props) {
               onClick={dismissTrainFirstRunHint}
             >
               <span className="train-inline-guidance__label">Targets adapt to your dog</span>
-              <span className="train-inline-guidance__copy">Consistent calm nudges targets upward. Stress signs bring the next step down.</span>
+              <span className="train-inline-guidance__copy">Calm reps nudge targets up. Stress signs nudge them down.</span>
             </button>
           )}
           {phase === "idle" && recoveryMode?.active && (
@@ -192,7 +192,7 @@ export default function HomeScreen(props) {
 
         {daily.canAdd && daily.count >= Math.max(1, activeProto.sessionsPerDayMax - (pattern.normalizedLeaves >= 7 ? 1 : 0)) && (
           <p className="status-msg status-msg--warning">
-            {daily.count} sessions today — for ~{pattern.normalizedLeaves} departures/day, keep it around {Math.max(1, activeProto.sessionsPerDayMax - (pattern.normalizedLeaves >= 7 ? 1 : 0))} to avoid overloading real departures.
+            {daily.count} reps today — with ~{pattern.normalizedLeaves} departures/day, try to stay near {Math.max(1, activeProto.sessionsPerDayMax - (pattern.normalizedLeaves >= 7 ? 1 : 0))} so training stays sustainable.
           </p>
         )}
 
@@ -205,7 +205,7 @@ export default function HomeScreen(props) {
           >
             <div>
               <div className="section-title section-title--flush">Today&apos;s training + care log</div>
-              <div className="t-helper">{todaySessions.length} calm-alone reps · support activity</div>
+              <div className="t-helper">{todaySessions.length} calm-alone reps · support logs</div>
             </div>
             <span className="settings-collapsible-arrow" aria-hidden="true">{todayOpen ? "−" : "+"}</span>
           </button>
@@ -214,7 +214,7 @@ export default function HomeScreen(props) {
               <div className="train-today-list" role="list" aria-label="Today's logged activity">
                 <div className="train-today-row" role="listitem">
                   <span className="train-today-row__label">Calm-alone reps</span>
-                  <span className="train-today-row__meta">{todaySessions.length} logged</span>
+                  <span className="train-today-row__meta">{todaySessions.length} today</span>
                 </div>
                 <button className="train-today-row train-today-row--action" type="button" onClick={walkPhase === "idle" ? startWalk : undefined}>
                   <span className="train-today-row__label">Walk</span>

--- a/src/features/settings/DogProfileCard.jsx
+++ b/src/features/settings/DogProfileCard.jsx
@@ -26,7 +26,7 @@ export default function DogProfileCard({
           {String(dogName || "D").trim().charAt(0).toUpperCase()}
         </div>
         <div className="settings-dog-profile-card__titles">
-          <div className="settings-simple-title">Active calm-alone profile</div>
+          <div className="settings-simple-title">Active dog profile</div>
           <div className="settings-dog-profile-card__name">{dogName}</div>
           <div className="settings-dog-profile-card__state">
             <span className={`settings-dog-profile-card__state-dot settings-dog-profile-card__state-dot--${syncTone}`} aria-hidden="true" />
@@ -39,8 +39,8 @@ export default function DogProfileCard({
       </div>
 
       <div className="settings-dog-profile-card__meta" aria-label="Dog status summary">
-        <div className="settings-profile-chip">{reminderSummary} training reminders</div>
-        <div className="settings-profile-chip">Plan: max {sessionsPerDayMax} calm-alone reps/day</div>
+        <div className="settings-profile-chip">{reminderSummary} reminders</div>
+        <div className="settings-profile-chip">Plan max: {sessionsPerDayMax} reps/day</div>
         <div className="settings-profile-chip">{customLabelCount} custom labels</div>
       </div>
     </button>

--- a/src/features/settings/SettingsScreen.jsx
+++ b/src/features/settings/SettingsScreen.jsx
@@ -101,8 +101,8 @@ export default function SettingsScreen(props) {
     <>
       <div className="tab-content">
         <div className="section settings-shell">
-          <div className="section-title">{name}&rsquo;s calm-alone settings</div>
-          <div className="t-helper">Tune routines, reminders, and profile details for separation training.</div>
+          <div className="section-title">{name}&rsquo;s settings</div>
+          <div className="t-helper">Adjust reminders, routine settings, and profile details.</div>
 
           <DogProfileCard
             dogName={name}
@@ -114,10 +114,10 @@ export default function SettingsScreen(props) {
           />
 
           <div className="settings-group" role="list" aria-label="Training routine settings">
-            <div className="settings-section-label">Calm-alone routine</div>
+            <div className="settings-section-label">Training routine</div>
             <div className="settings-inline-card">
               <div className="settings-row-head">
-                <span className="settings-inline-title">Daily training reminder</span>
+                <span className="settings-inline-title">Daily reminder</span>
                 <button className={`notif-toggle secondary-control secondary-control--toggle ${notifEnabled ? "on" : ""}`} onClick={handleToggleNotif} type="button">{notifEnabled ? "On" : "Off"}</button>
               </div>
               <div className="settings-inline-row">
@@ -149,7 +149,7 @@ export default function SettingsScreen(props) {
 
           <div className="settings-group settings-group--muted" role="list" aria-label="Support destinations">
             <div className="settings-section-label">Help + diagnostics</div>
-            <SettingsNavRow label="Help" value="Guidance" onClick={() => setActivePanel(SETTINGS_PANEL.HELP)} />
+            <SettingsNavRow label="Help" value="How it works" onClick={() => setActivePanel(SETTINGS_PANEL.HELP)} />
             <SettingsNavRow label="Advanced" value="Diagnostics" onClick={() => setActivePanel(SETTINGS_PANEL.ADVANCED)} />
           </div>
 
@@ -180,7 +180,7 @@ export default function SettingsScreen(props) {
                 <div className={`settings-inline-reveal ${removeConfirmOpen ? "is-open" : ""}`} aria-hidden={!removeConfirmOpen}>
                   <div className="settings-danger-confirm">
                     <div className="settings-secondary-text">
-                      This removes local sessions, walks, feeding history, labels, and photo for this dog on this device. Synced/shared data elsewhere is unaffected.
+                      This removes this dog&apos;s local sessions, walks, feedings, labels, and photo from this device only. Shared data on other devices stays the same.
                     </div>
                     <div className="settings-danger-actions">
                       <button type="button" className="settings-inline-btn button-size-secondary-pill secondary-control secondary-control--compact-button" onClick={() => setRemoveConfirmOpen(false)}>Cancel</button>
@@ -241,12 +241,12 @@ export default function SettingsScreen(props) {
 
       {activePanel === SETTINGS_PANEL.HELP && (
         <SettingsSheet title="Help" titleId="settings-help-title" onClose={() => setActivePanel(null)}>
-              <div className="proto-section u-mt-none"><div className="proto-title">Sync devices</div><div className="proto-row">Share your Dog ID so everyone tracks the same calm-alone plan for {name}.</div></div>
-              <div className="proto-section"><div className="proto-title">Session flow</div><div className="proto-row">Start a calm-alone rep, return before stress escalates, then rate how {name} handled being alone.</div></div>
+              <div className="proto-section u-mt-none"><div className="proto-title">Sync devices</div><div className="proto-row">Share your Dog ID so everyone logs to the same plan for {name}.</div></div>
+              <div className="proto-section"><div className="proto-title">Session flow</div><div className="proto-row">Start a rep, return while {name} is still calm, then rate how it went.</div></div>
               <div className="proto-section"><div className="proto-title">Current recommendation state</div><div className="proto-row">Now: <strong>{recommendationType}</strong>. {recommendationSummary} It currently weighs {(recommendation?.details?.factors || []).join(" ")}</div></div>
               <div className="proto-section"><div className="proto-title">Recommendation states emitted</div><div className="proto-row">baseline_start, keep_same_duration, repeat_current_duration, departure_cues_first, recovery_mode_active, recovery_mode_resume.</div></div>
               <div className="proto-section"><div className="proto-title">Recovery behavior</div><div className="proto-row">Any subtle/active/severe distress can activate recovery. While recovery_mode_active, targets use short fixed steps (typically 60s then 120s; severe can add a third 120s step). Subtle recovery accepts any calm follow-up duration; active/severe count calm sessions at short recovery lengths. After enough calm sessions, recovery_mode_resume emits once, then normal progression continues.</div></div>
-              <div className="proto-section"><div className="proto-title">Daily rhythm</div><div className="proto-row">Aim for up to {activeProto.sessionsPerDayMax} calm-alone reps, {activeProto.maxDailyAloneMinutes} min/day, and {pattern.recMin}–{pattern.recMax} pattern-break supports.</div></div>
+              <div className="proto-section"><div className="proto-title">Daily rhythm</div><div className="proto-row">Aim for up to {activeProto.sessionsPerDayMax} reps, {activeProto.maxDailyAloneMinutes} min/day, and {pattern.recMin}–{pattern.recMax} pattern-break supports.</div></div>
         </SettingsSheet>
       )}
 
@@ -312,7 +312,7 @@ export default function SettingsScreen(props) {
       )}
 
       {trainingSettingsOpen && (
-        <SettingsSheet title="Edit calm-alone plan" titleId="training-settings-title" onClose={() => setTrainingSettingsOpen(false)}>
+        <SettingsSheet title="Edit training plan" titleId="training-settings-title" onClose={() => setTrainingSettingsOpen(false)}>
             <div className="share-sub">Adjust protocol values only if a trainer has advised you to. Full guidance is kept in Help.</div>
             {!protoWarnAck ? (
               <div className="proto-warn-banner">

--- a/src/features/setup/SetupScreens.jsx
+++ b/src/features/setup/SetupScreens.jsx
@@ -18,10 +18,10 @@ export function WelcomeScreen({ onStart, onManageDogs }) {
         <div className="ws-paw">
           <PawIcon size={66} />
         </div>
-        <div className="ws-eyebrow">Calm dog training</div>
+        <div className="ws-eyebrow">Separation training for dogs</div>
         <h1 className="ws-title">PawTimer</h1>
         <p className="ws-copy">
-          Guided separation-training reps that teach your dog to settle calmly when left alone.
+          Short, guided reps that help your dog feel safer when home alone.
         </p>
       </div>
 
@@ -31,10 +31,10 @@ export function WelcomeScreen({ onStart, onManageDogs }) {
           type="button"
           onClick={onStart}
         >
-          Start setup
+          Set up my dog
         </button>
         <button className="ws-secondary" type="button" onClick={onManageDogs}>
-          I already have a dog profile
+          I already have a profile
         </button>
       </div>
     </div>
@@ -63,8 +63,8 @@ export function Onboarding({ onComplete, onBack }) {
       <div className="ob-hero">
         <div className="ob-hero-icon"><PawIcon size={48} /></div>
         <div className="ob-eyebrow">Build {displayName}&apos;s plan</div>
-        <div className="ob-title">{displayName === "your dog" ? "Start calm-alone training" : `${displayName}&apos;s calm-alone training`}</div>
-        <div className="ob-subtitle">{activeStep.progressLabel} • We&apos;ll set a safe starting pace.</div>
+        <div className="ob-title">{displayName === "your dog" ? "Start calm-alone training" : `${displayName}'s calm-alone training`}</div>
+        <div className="ob-subtitle">{activeStep.progressLabel} • We&apos;ll start gently.</div>
         <div className="ob-step-indicator">
           {[0, 1, 2, 3].map((i) => <div key={i} className={`ob-step-dot ${i < step ? "done" : i === step ? "active" : ""}`} />)}
         </div>
@@ -72,14 +72,14 @@ export function Onboarding({ onComplete, onBack }) {
       <div className="ob-body">
         <div key={step} className="ob-step-panel">
           {step === 0 && <>
-            <div className="ob-question">Which dog are you training for calm-alone time?</div>
-            <div className="ob-note prose">Your dog&apos;s name personalizes each training cue, log, and progress insight.</div>
-            <div className="ob-hint">You can update this later in settings if needed.</div>
+            <div className="ob-question">Which dog is this plan for?</div>
+            <div className="ob-note prose">We&apos;ll use this name across training, logs, and insights.</div>
+            <div className="ob-hint">You can change it anytime in Settings.</div>
             <input className="ob-input" placeholder="e.g. Luna, Mochi, Rocco…" value={name} onChange={(e) => setName(e.target.value)} onKeyDown={(e) => e.key === "Enter" && canNext && handleNext()} autoFocus />
           </>}
           {step === 1 && <>
-            <div className="ob-question">How often is {displayName} left home alone?</div>
-            <div className="ob-hint">We use this to pace reps so practice fits real-life departure routines.</div>
+            <div className="ob-question">How often is {displayName} home alone?</div>
+            <div className="ob-hint">This helps us suggest a realistic daily pace.</div>
             <div className="ob-options">
               {LEAVE_OPTIONS.map((o) => (
                 <button key={o.value} className={`ob-option ${leaves === o.value ? "selected" : ""}`} onClick={() => setLeaves(o.value)}>
@@ -89,8 +89,8 @@ export function Onboarding({ onComplete, onBack }) {
             </div>
           </>}
           {step === 2 && <>
-            <div className="ob-question">Right now, how long can {displayName} stay settled alone?</div>
-            <div className="ob-hint">This baseline sets your first safe reps and helps prevent stress spikes.</div>
+            <div className="ob-question">Today, how long can {displayName} stay calm alone?</div>
+            <div className="ob-hint">We&apos;ll use this as your starting point.</div>
             <div className="ob-duration-grid">
               {CALM_DURATIONS.map((d) => (
                 <button key={d.value} className={`ob-dur-btn ${calm === d.value ? "selected" : ""}`} onClick={() => setCalm(d.value)}>
@@ -100,9 +100,9 @@ export function Onboarding({ onComplete, onBack }) {
             </div>
           </>}
           {step === 3 && <>
-            <div className="ob-question">Choose a future calm-alone goal for {displayName}</div>
-            <div className="ob-note prose">Optional: skip for now and set this after a few sessions.</div>
-            <div className="ob-hint">A goal helps you plan for real errands while keeping training humane and gradual.</div>
+            <div className="ob-question">Pick a longer-term goal for {displayName}</div>
+            <div className="ob-note prose">Optional. You can skip this and set it later.</div>
+            <div className="ob-hint">Goals help connect training to real-life departures.</div>
             <div className="ob-duration-grid">
               {GOAL_DURATIONS.map((d) => (
                 <button key={d.value} className={`ob-dur-btn ${goal === d.value ? "selected" : ""}`} onClick={() => setGoal(d.value)}>
@@ -115,7 +115,7 @@ export function Onboarding({ onComplete, onBack }) {
       </div>
       <div className="ob-footer">
         <button className="ob-btn-next button-base button-primary button--lg button-size-primary-cta button--block" onClick={handleNext} disabled={!canNext}>
-          {step < 3 ? "Continue →" : `Start ${displayName}&apos;s calm-alone plan`}
+          {step < 3 ? "Continue →" : `Start ${displayName}'s plan`}
         </button>
         <button className="ob-back-btn" onClick={() => step === 0 ? onBack?.() : setStep((s) => s - 1)}>
           ← {step === 0 ? "Back to dogs" : "Back"}
@@ -155,13 +155,13 @@ export function DogSelect({ dogs, onSelect, onCreateNew }) {
     if (result?.ok) {
       setJoinState({
         status: "ready",
-        message: "Looks good. Review and confirm to join this profile.",
+        message: "ID found. Review and confirm to join.",
         preview: result,
       });
     } else {
       setJoinState({
         status: "not-found",
-        message: result?.message || "We couldn't find that shared ID yet. Please check and retry.",
+        message: result?.message || "We couldn't find that ID. Please check and try again.",
         preview: null,
       });
     }
@@ -178,7 +178,7 @@ export function DogSelect({ dogs, onSelect, onCreateNew }) {
       <div className="ds-hero">
         <div className="ds-logo"><PawIcon size={68} /></div>
         <div className="ds-title">PawTimer</div>
-        <div className="ds-sub">Choose how you want to begin your dog&apos;s calm-alone training.</div>
+        <div className="ds-sub">Choose how you want to start your dog&apos;s plan.</div>
       </div>
       <div className="ds-body">
         <div className="ds-path-grid">
@@ -190,24 +190,24 @@ export function DogSelect({ dogs, onSelect, onCreateNew }) {
               onCreateNew();
             }}
           >
-            <div className="ds-path-title">Create new dog plan</div>
-            <div className="ds-path-copy">Set a calm-alone baseline and training rhythm in under a minute.</div>
+            <div className="ds-path-title">Create a new plan</div>
+            <div className="ds-path-copy">Set a calm baseline in about a minute.</div>
           </button>
           <button
             className={`ds-path-card ${activePath === "join" ? "selected" : ""}`}
             type="button"
             onClick={() => setActivePath("join")}
           >
-            <div className="ds-path-title">Join existing dog by ID</div>
-            <div className="ds-path-copy">Use a shared ID so everyone follows the same calm-alone plan.</div>
+            <div className="ds-path-title">Join with dog ID</div>
+            <div className="ds-path-copy">Use a shared ID so everyone follows one plan.</div>
           </button>
         </div>
 
         <div className={`ds-join-panel ${activePath === "join" ? "is-open" : ""}`}>
-          <div className="ds-section-label">Join with a dog ID</div>
+          <div className="ds-section-label">Join using dog ID</div>
           <div className="ds-note">
-            This shared ID connects one household's dog profile across devices.
-            You'll usually receive it from your partner, trainer, or whoever created the profile in Settings.
+            This ID links one dog profile across devices.
+            You&apos;ll usually get it from your partner, trainer, or whoever set up the profile.
           </div>
           <div className="ds-join-row">
             <input
@@ -233,18 +233,18 @@ export function DogSelect({ dogs, onSelect, onCreateNew }) {
           {joinState.message && <div className={`ds-join-feedback ds-join-feedback--${joinState.status}`}>{joinState.message}</div>}
           {joinState.status === "ready" && joinState.preview && (
             <div className="ds-join-confirm-card">
-              <div className="ds-join-confirm-eyebrow">Ready to join</div>
+              <div className="ds-join-confirm-eyebrow">Ready</div>
               <div className="ds-join-confirm-title">{joinState.preview.dogName || "Shared dog profile"}</div>
               <div className="ds-join-confirm-copy">
                 ID: {joinState.preview.normalizedId}
                 {joinState.preview.source ? ` • ${joinState.preview.source}` : ""}
               </div>
               <button className="ds-join-btn ds-join-confirm-btn" type="button" onClick={handleJoinConfirm}>
-                Confirm and join
+                Join this profile
               </button>
             </div>
           )}
-          <div className="ds-join-hint">Find this ID in PawTimer → Settings → Sync devices.</div>
+          <div className="ds-join-hint">Find this ID in Settings → Dog profile.</div>
         </div>
 
         {dogs.length > 0 && <>

--- a/src/features/stats/StatsComponents.jsx
+++ b/src/features/stats/StatsComponents.jsx
@@ -137,7 +137,7 @@ export function ProgressHero({
 
       <h3 className="stats-progress-headline">{headline || headlineStatus}</h3>
 
-      <div className="stats-progress-values" role="group" aria-label="Current value and next milestone">
+      <div className="stats-progress-values" role="group" aria-label="Current value and next step">
         <div className="stats-progress-value-block">
           <div className="stats-progress-value">{currentValue}</div>
           <div className="stats-progress-label">{currentLabel}</div>
@@ -154,7 +154,7 @@ export function ProgressHero({
           <div className="stats-progress-rail">
             <span className="stats-progress-rail-fill" style={{ width: `${Math.max(progressPct, 6)}%` }} />
           </div>
-          <span className="stats-progress-rail-text">{progressPct}% to milestone</span>
+          <span className="stats-progress-rail-text">{progressPct}% to next step</span>
         </div>
       ) : null}
 
@@ -233,7 +233,7 @@ export function StatsChartSection({ chartData, goalSec, setTab, name, fmt, insig
       <EmptyState
         media={<TrendIcon />}
         title="Almost there"
-        body={`Complete 2 more sessions to see ${name}'s progress chart and trends.`}
+        body={`Complete 2 more reps to see ${name}'s progress chart.`}
         ctaLabel="Start training →"
         onCta={() => setTab("home")}
       />
@@ -277,7 +277,7 @@ export function StatsChartSection({ chartData, goalSec, setTab, name, fmt, insig
   return (
     <div className="chart-wrap chart-wrap-full surface-card surface-card--chart">
       {insightLabel ? <div className="chart-insight">{insightLabel}</div> : null}
-      <div className="chart-title">Session duration over time (min)</div>
+      <div className="chart-title">Rep duration over time (min)</div>
       <div className="stats-progress-wave" role="img" aria-label={`${name}'s recent session durations`}>
         <svg viewBox={`0 0 ${WAVE_CHART_WIDTH} ${WAVE_CHART_HEIGHT}`} className="stats-progress-wave-svg" preserveAspectRatio="none">
           <defs>

--- a/src/features/stats/StatsScreen.jsx
+++ b/src/features/stats/StatsScreen.jsx
@@ -10,30 +10,30 @@ export default function StatsScreen({ name, totalCount, setTab, bestCalm, recomm
   const headlineSurfaceState = headlineStatusTone?.surfaceState || "today";
   const riskSurfaceState = relapseTone?.surfaceState || "today";
 
-  const emotionalMomentum = chartTrendLabel || `${name} is building calm-alone resilience rep by rep.`;
+  const emotionalMomentum = chartTrendLabel || `${name} is building confidence, one rep at a time.`;
   const progressDelta = Math.max(0, target - bestCalm);
   const nextTargetLabel = progressDelta > 0
-    ? `Next milestone (+${fmt(progressDelta)})`
-    : "Milestone met — hold this rhythm";
+    ? `Next step (+${fmt(progressDelta)})`
+    : "Step reached — hold this rhythm";
   const heroHeadline = progressDelta <= 0
     ? `${name} reached this milestone.`
     : progressDelta <= 60
-      ? `${name} is one calm stretch from the next milestone.`
+      ? `${name} is one calm stretch from the next step.`
       : `${name} is building calm confidence.`;
   const cadenceLabel = avgSessionsPerDay != null
     ? avgSessionsPerDay >= 1
-      ? `Strong cadence: ${avgSessionsPerDay.toFixed(1)} calm-alone reps/day.`
-      : `Steady cadence: ${avgSessionsPerDay.toFixed(1)} calm-alone reps/day.`
-    : "Cadence appears after a few calm-alone reps.";
+      ? `Strong cadence: ${avgSessionsPerDay.toFixed(1)} reps/day.`
+      : `Steady cadence: ${avgSessionsPerDay.toFixed(1)} reps/day.`
+    : "Cadence appears after a few reps.";
   const walkSupportLabel = avgWalkDuration != null
-    ? `Walks average ${fmt(avgWalkDuration, { hoursMinutesOnly: true })}, supporting decompression between alone-time reps.`
-    : "Add decompression walks to support recovery between alone-time reps.";
+    ? `Walks average ${fmt(avgWalkDuration, { hoursMinutesOnly: true })}, supporting decompression between reps.`
+    : "Add decompression walks to support recovery between reps.";
 
   return (
     <div className="tab-content stats-tab-content" data-ring-metric-variant={ringMetricVariant}>
       <div className="section">
         {totalCount === 0 ? (
-          <EmptyState media={<SproutIcon />} title="Calm-alone progress starts here" body={`Log your first calm-alone rep and ${name}&apos;s progress curve will appear here.`} ctaLabel="Go to Train →" onCta={() => setTab("home")} />
+          <EmptyState media={<SproutIcon />} title="Progress starts here" body={`Log your first rep and ${name}&apos;s trend will appear here.`} ctaLabel="Go to Train →" onCta={() => setTab("home")} />
         ) : <>
           <StatsSection className="stats-section-hero stats-section-priority">
             <ProgressHero
@@ -51,30 +51,30 @@ export default function StatsScreen({ name, totalCount, setTab, bestCalm, recomm
             />
           </StatsSection>
 
-          <StatsSection title="What is shaping today&apos;s alone-time training" className="stats-section-signals">
+          <StatsSection title="What is shaping today&apos;s training" className="stats-section-signals">
             <div className="stats-row stats-row-core stats-row-core-calm">
               <StatsMetricCard
                 value={fmt(bestCalm)}
                 label="Best calm-alone window"
-                detail="Longest settled alone-time rep so far"
+                detail="Longest calm rep so far"
                 className="stat-card--key-metric"
                 variant={standardMetricVariant}
               />
               <StatsMetricCard
                 value={relapseTone.label}
                 label="Recovery pressure"
-                detail="How conservatively to pace the next alone-time rep"
+                detail="How gently to pace the next rep"
                 className={`stat-card--key-metric stat-card-risk surface-state--${riskSurfaceState}`}
                 variant={standardMetricVariant}
               />
             </div>
           </StatsSection>
 
-          <StatsSection title="Calm-alone journey curve" className="stats-section-journey">
+          <StatsSection title="Progress over time" className="stats-section-journey">
             <StatsChartSection chartData={chartData} goalSec={goalSec} setTab={setTab} name={name} fmt={fmt} insightLabel={chartTrendLabel} />
           </StatsSection>
 
-          <StatsSection title="Context around your dog&apos;s calm-alone trend" className="stats-section-supporting">
+          <StatsSection title="Context for your dog&apos;s progress" className="stats-section-supporting">
             {contextualInsights.length > 0 ? (
               <div className="stats-insight-stack" role="list" aria-label="Progress movement insights">
                 {contextualInsights.map((insight, index) => (
@@ -89,7 +89,7 @@ export default function StatsScreen({ name, totalCount, setTab, bestCalm, recomm
               </div>
             ) : null}
             <div className="stats-support-list stats-support-list--insights">
-              <StatsSupportRow label="Weekly alone-time practice" value={fmt(aloneLastWeek)} />
+              <StatsSupportRow label="Weekly practice time" value={fmt(aloneLastWeek)} />
               <StatsSupportRow label="Session cadence" value={cadenceLabel} />
               <StatsSupportRow label="Walk support" value={walkSupportLabel} />
               <StatsSupportRow label="Daily walks" value={avgWalksPerDay != null ? `${avgWalksPerDay.toFixed(1)} walks/day` : "Tracking after more walk logs"} />

--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -30,7 +30,7 @@ function SessionActionRow({
         onClick={handlePrimary}
         disabled={!isRunning && !canRunStart && !canExplain}
       >
-        {isRunning ? "End and save rep" : "Start calm-alone rep"}
+        {isRunning ? "End and save" : "Start rep"}
       </button>
       <button
         className="session-cancel-btn button-base button-ghost button--md button--pill"
@@ -38,7 +38,7 @@ function SessionActionRow({
         aria-hidden={!isRunning}
         tabIndex={isRunning ? 0 : -1}
       >
-        Cancel rep (don&apos;t save)
+        Cancel (don&apos;t save)
       </button>
       {!isRunning && !canStart && (
         <p className="session-action-meta" role="status">{startBlockedMessage}</p>
@@ -81,19 +81,19 @@ export function SessionControl({
         ? "active"
         : "idle";
   const innerCaption = displayState === "warning"
-    ? "Calm-alone practice is paused for today"
+    ? "Practice is paused for today"
     : displayState === "success"
       ? `${name} hit this calm target`
       : displayState === "active"
         ? isPastTarget
           ? `Past target — end while ${name} is still settled`
           : `${name}'s calm hold for this rep`
-        : `Next calm-alone target for ${name}`;
+        : `Next target for ${name}`;
   const helperCaption = displayState === "active"
     ? (isPastTarget ? `+${fmt(overTargetSeconds)} calm hold` : `${fmt(elapsed)} completed this rep`)
     : displayState === "warning"
       ? "Come back tomorrow for the next rep"
-      : "Builds calm alone-time tolerance with short reps";
+      : "Short reps build comfort with alone time";
 
   const startWithFeedback = () => {
     if (!onStart || !canStart) return;
@@ -151,7 +151,7 @@ export function SessionControl({
               <div className="sc-caption">{innerCaption}</div>
               <div className="sc-support">{helperCaption}</div>
               <div className={`sc-state-chip ${isRunning ? "is-running" : ""}`}>
-                {isRunning ? `Rep live · ${fmt(elapsed)} elapsed` : "Ready for a calm-alone rep"}
+                {isRunning ? `Rep live · ${fmt(elapsed)} elapsed` : "Ready for the next rep"}
               </div>
             </div>
           </div>
@@ -188,7 +188,7 @@ export function TrainProgressBar({ goalPct, target, goalSec, fmt }) {
         <span className="prog-thumb" style={{ left: `${thumbPct}%` }} aria-hidden="true" />
       </div>
       <div className="prog-meta">
-        <span>Threshold <strong className="num-stable">{fmt(target)}</strong></span>
+        <span>Current target <strong className="num-stable">{fmt(target)}</strong></span>
         <span>Goal <strong className="num-stable">{fmt(goalSec)}</strong></span>
       </div>
     </div>
@@ -210,29 +210,29 @@ export function SessionRatingPanel({
     <div className="rating-overlay" role="presentation">
       <div className="rating-screen session-feedback modal-card modal-card--dialog-md rating-sheet" role="dialog" aria-modal="true" aria-labelledby="session-rating-title" aria-describedby="session-rating-sub">
         <div className="rating-sheet-grabber" aria-hidden="true" />
-        <div className="rating-title" id="session-rating-title">How did {name} handle being alone?</div>
+        <div className="rating-title" id="session-rating-title">How did {name} do?</div>
         <div className="rating-sub" id="session-rating-sub">
-          {fmt(finalElapsed)} alone-time rep with {name}. Your choice adjusts the next target gently.
+          {fmt(finalElapsed)} rep with {name}. Your choice gently adjusts the next target.
         </div>
         <div className="result-grid">
           <button className="btn-result btn-none" onClick={() => recordResult("none")}>
             <Img src="result-calm.png" size={36} alt="No stress"/>
-            <div><div>No stress</div><div className="result-desc">Fully calm throughout the session</div></div>
+            <div><div>Calm</div><div className="result-desc">Relaxed the whole rep</div></div>
           </button>
           <button className="btn-result btn-mild" onClick={() => recordResult("subtle")}>
             <Img src="result-mild.png" size={36} alt="Slight stress"/>
-            <div><div>Slight stress</div><div className="result-desc">Small signs, but able to settle</div></div>
+            <div><div>Some stress</div><div className="result-desc">Mild signs, still settled</div></div>
           </button>
           <button className="btn-result btn-strong" onClick={() => recordResult("active")}>
             <Img src="result-strong.png" size={36} alt="Strong stress"/>
-            <div><div>Strong stress</div><div className="result-desc">Clear stress; next step should be easier</div></div>
+            <div><div>High stress</div><div className="result-desc">Clear stress signs; next step should be easier</div></div>
           </button>
         </div>
         <p className="rating-adapt-note" role="status">
-          We use this feedback to adjust pace automatically and keep training in the calm zone.
+          We use this to keep the pace gentle and dog-friendly.
         </p>
         <button className="session-cancel-btn button-base button-ghost button--md button--block" onClick={onCancel}>
-          Discard this session
+          Delete this rep
         </button>
       </div>
     </div>

--- a/src/features/train/timeChangeInsight.js
+++ b/src/features/train/timeChangeInsight.js
@@ -27,16 +27,16 @@ export function buildTrainTimeChangeInsight({
   if (recommendationType === "recovery_mode_active") {
     return {
       tone: "caution",
-      title: `Recovery mode on · target is now ${formattedNext}`,
-      body: `${name} showed stress signs, so we switched to short reset sessions to rebuild calm confidence.`,
+      title: `Recovery mode on · next target is ${formattedNext}`,
+      body: `${name} showed stress signs, so we moved to shorter reset reps.`,
     };
   }
 
   if (recommendationType === "recovery_mode_resume") {
     return {
       tone: "positive",
-      title: `Recovery complete · target is now ${formattedNext}`,
-      body: `Recent calm reset sessions went well, so we are gently stepping back up again.`,
+      title: `Recovery complete · next target is ${formattedNext}`,
+      body: `Recent reset reps went well, so we're gently stepping up again.`,
     };
   }
 
@@ -45,8 +45,8 @@ export function buildTrainTimeChangeInsight({
       tone: "caution",
       title: `Target eased to ${formattedNext}`,
       body: distressLevel === "none"
-        ? `We lowered the next session slightly to keep training comfortable and steady.`
-        : `${name} showed stress signs, so the next session is shorter to protect confidence.`,
+        ? `We lowered the next rep slightly to keep training steady.`
+        : `${name} showed stress signs, so the next rep is shorter.`,
     };
   }
 
@@ -54,13 +54,13 @@ export function buildTrainTimeChangeInsight({
     return {
       tone: "positive",
       title: `Target increased to ${formattedNext}`,
-      body: `Recent calm sessions were successful, so the next step is a little longer.`,
+      body: `Recent calm reps went well, so the next step is a little longer.`,
     };
   }
 
   return {
     tone: "neutral",
     title: `Target stays at ${formattedNext}`,
-    body: `We are holding this duration to keep progress steady and predictable.`,
+    body: `We're holding this duration to keep progress steady.`,
   };
 }


### PR DESCRIPTION
### Motivation
- Make microcopy throughout the app clearer, shorter, and more emotionally intelligent so training feels humane and easy to scan. 
- Prefer dog-specific, calm phrasing and reduce robotic or clinical wording in onboarding, session flows, insights, progress, and settings.

### Description
- Rewrote onboarding and dog-selection copy to be concise and friendlier, including welcome text, step labels, join-by-ID messages, and CTA text (`src/features/setup/SetupScreens.jsx`).
- Simplified session and training UI language, primary CTA labels, helper captions, and rating options for a gentler tone (`src/features/train/TrainComponents.jsx`, `src/features/home/HomeScreen.jsx`).
- Improved time-change and recommendation messages to read clearly and emotionally intelligently (`src/features/train/timeChangeInsight.js`).
- Tightened progress, chart, and empty-state wording and updated duration/goal option captions for clearer dog-focused context (`src/features/stats/StatsScreen.jsx`, `src/features/stats/StatsComponents.jsx`, `src/features/app/helpers.js`).
- Clarified settings and profile labels, danger-zone copy, and history empty states to improve scanability and reduce ambiguity (`src/features/settings/SettingsScreen.jsx`, `src/features/settings/DogProfileCard.jsx`, `src/features/history/HistoryFeature.jsx`).

### Testing
- Ran unit tests with `npm test` (Vitest) and all tests passed (`235 tests, 19 files`).
- Built a production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0fdf6d95c8332bbe927ded201f10c)