### PR TITLE
Soften abrupt UI interruptions with inline confirms and sheet flows

### DIFF
--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import EmptyState from "../../components/EmptyState";
+import { InlineBanner } from "../../components/primitives";
 import { buildEditedActivityIso, sortByDateAsc, toDateInputValue, toTimeInputValue } from "../../lib/activityDateTime";
 import { normalizeDistressLevel } from "../../lib/protocol";
 import { PATTERN_TYPES, fmt, fmtDate, parseDurationInput, sessionDetailBadges, walkTypeLabel } from "../app/helpers";
@@ -307,15 +308,13 @@ export function useHistoryEditing({
       setHistoryModal(null);
     },
     clearSessions: () => {
-      if (window.confirm("Clear all training sessions?")) {
-        commitSessions((prev) => {
-          // Canonical bulk-clear sync contract:
-          // clear locally and emit per-session tombstones for durable retry.
-          prev.forEach((entry) => addTombstone("session", entry));
-          return [];
-        });
-        showToast("Sessions cleared");
-      }
+      commitSessions((prev) => {
+        // Canonical bulk-clear sync contract:
+        // clear locally and emit per-session tombstones for durable retry.
+        prev.forEach((entry) => addTombstone("session", entry));
+        return [];
+      });
+      showToast("Sessions cleared");
     },
   };
 }
@@ -335,6 +334,7 @@ const renderSyncBadge = (entry) => {
 export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, historyModal, setHistoryModal, actions }) {
   const [expandedItemKey, setExpandedItemKey] = useState(null);
   const [sessionDetail, setSessionDetail] = useState(null);
+  const [clearSessionsConfirmOpen, setClearSessionsConfirmOpen] = useState(false);
   const parsedDuration = historyModal?.mode === "duration" ? parseDurationInput(historyModal.value) : null;
   const requiresPositiveDuration = historyModal?.kind === "session";
   const durationHasInput = historyModal?.mode === "duration" && String(historyModal.value ?? "").trim().length > 0;
@@ -542,8 +542,31 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
               <div className="section-title">History</div>
               <div className="t-helper">A timeline of {name}&rsquo;s calm-alone reps and support routine.</div>
             </div>
-            {sessions.length > 0 && <button className="clear-btn surface-text-button secondary-control secondary-control--inline-text" onClick={actions.clearSessions}>Clear sessions</button>}
+            {sessions.length > 0 && <button className="clear-btn surface-text-button secondary-control secondary-control--inline-text" onClick={() => setClearSessionsConfirmOpen((prev) => !prev)}>{clearSessionsConfirmOpen ? "Cancel" : "Clear sessions"}</button>}
           </div>
+          {clearSessionsConfirmOpen && sessions.length > 0 ? (
+            <InlineBanner
+              className="history-clear-banner"
+              tone="warning"
+              title="Clear all calm-alone reps?"
+              body="This clears session entries from this device and sync queue. Walks, feeding logs, and pattern breaks stay untouched."
+              action={(
+                <div className="history-clear-banner-actions">
+                  <button className="button-base button-ghost button--sm button--pill" type="button" onClick={() => setClearSessionsConfirmOpen(false)}>Keep sessions</button>
+                  <button
+                    className="button-base button-danger button--sm button--pill"
+                    type="button"
+                    onClick={() => {
+                      actions.clearSessions();
+                      setClearSessionsConfirmOpen(false);
+                    }}
+                  >
+                    Clear now
+                  </button>
+                </div>
+              )}
+            />
+          ) : null}
           {timeline.length > 0 && (
             <div className="history-summary-surface">
               <div className="history-summary-grid">
@@ -705,8 +728,9 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
       </div>
 
       {historyModal && (
-        <div className="activity-time-overlay" role="dialog" aria-modal="true" aria-labelledby="history-modal-title" onClick={() => setHistoryModal(null)}>
-          <div className="activity-time-card history-modal-card modal-card modal-card--dialog-sm" onClick={(e) => e.stopPropagation()}>
+        <div className="activity-time-overlay quick-modal-overlay--sheet" role="dialog" aria-modal="true" aria-labelledby="history-modal-title" onClick={() => setHistoryModal(null)}>
+          <div className="activity-time-card history-modal-card modal-card modal-card--dialog-sm modal-card--sheet" onClick={(e) => e.stopPropagation()}>
+            <div className="history-session-sheet-grabber" aria-hidden="true" />
             <div className="quick-modal-head">
               <div className="section-title section-title--flush" id="history-modal-title">
                 {historyModal.mode === "delete" ? `Delete ${historyModal.kind === "pattern" ? "pattern break" : historyModal.kind}` : `Edit ${historyModal.kind} ${historyModal.mode === "datetime" ? "date & time" : "duration"}`}

--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -244,8 +244,9 @@ export default function HomeScreen(props) {
         </section>
 
         {(walkPhase !== "idle" || patOpen) && (
-          <div className="quick-modal-overlay" role="dialog" aria-modal="true" onClick={() => { if (walkPhase !== "idle") cancelWalk(); if (patOpen) setPatOpen(false); }}>
-            <div className="quick-modal-card modal-card modal-card--dialog-md" onClick={(e) => e.stopPropagation()}>
+          <div className="quick-modal-overlay quick-modal-overlay--sheet" role="dialog" aria-modal="true" onClick={() => { if (walkPhase !== "idle") cancelWalk(); if (patOpen) setPatOpen(false); }}>
+            <div className="quick-modal-card modal-card modal-card--dialog-md modal-card--sheet quick-modal-card--sheet" onClick={(e) => e.stopPropagation()}>
+              <div className="history-session-sheet-grabber" aria-hidden="true" />
               <div className="quick-modal-head">
                 <div className="quick-modal-title">{walkPhase !== "idle" ? "Log walk" : "Log pattern break"}</div>
                 <ModalCloseButton onClick={() => { if (walkPhase !== "idle") cancelWalk(); if (patOpen) setPatOpen(false); }} />
@@ -301,12 +302,14 @@ export default function HomeScreen(props) {
         )}
 
         {feedingOpen && (
-          <div className="feeding-overlay" role="dialog" aria-modal="true" aria-labelledby="feeding-title" onClick={cancelFeedingForm}>
-            <div className="feeding-card modal-card modal-card--dialog-sm" onClick={(e) => e.stopPropagation()}>
+          <div className="feeding-overlay quick-modal-overlay--sheet" role="dialog" aria-modal="true" aria-labelledby="feeding-title" onClick={cancelFeedingForm}>
+            <div className="feeding-card modal-card modal-card--dialog-sm modal-card--sheet quick-modal-card--sheet quick-modal-card--sheet-compact" onClick={(e) => e.stopPropagation()}>
+              <div className="history-session-sheet-grabber" aria-hidden="true" />
               <div className="quick-modal-head">
                 <div className="section-title section-title--flush" id="feeding-title">Log feeding</div>
                 <ModalCloseButton onClick={cancelFeedingForm} />
               </div>
+              <div className="t-helper activity-time-hint">Quick log for routine consistency. You can fine-tune details in History later.</div>
               <label className="feeding-field">
                 <span className="t-helper">Feeding time</span>
                 <input type="datetime-local" value={feedingDraft.time} onChange={(e) => setFeedingDraft((prev) => ({ ...prev, time: e.target.value }))} />

--- a/src/features/settings/SettingsScreen.jsx
+++ b/src/features/settings/SettingsScreen.jsx
@@ -51,6 +51,7 @@ export default function SettingsScreen(props) {
   const [diagDetailsOpen, setDiagDetailsOpen] = useState(false);
   const [dangerOpen, setDangerOpen] = useState(false);
   const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false);
+  const [rerunSetupConfirmOpen, setRerunSetupConfirmOpen] = useState(false);
   const {
     name,
     activeDogId,
@@ -299,14 +300,29 @@ export default function SettingsScreen(props) {
         <SettingsSheet title="Account" titleId="settings-account-title" onClose={() => setActivePanel(null)} compact>
           <SettingsNavRow
             label={`Edit ${name}’s profile`}
-            value="Re-run setup"
-            onClick={() => {
-              if (window.confirm(`Re-run setup for ${name}? All sessions are kept.`)) {
-                setOnboardingState({ mode: "claim", dogId: activeDogId });
-                setScreen("onboard");
-              }
-            }}
+            value={rerunSetupConfirmOpen ? "Confirm below" : "Re-run setup"}
+            onClick={() => setRerunSetupConfirmOpen((prev) => !prev)}
           />
+          <div className={`settings-inline-reveal ${rerunSetupConfirmOpen ? "is-open" : ""}`} aria-hidden={!rerunSetupConfirmOpen}>
+            <div className="settings-danger-confirm">
+              <div className="settings-secondary-text">
+                Re-run setup for {name}? Existing reps and support logs are kept, and only onboarding preferences are refreshed.
+              </div>
+              <div className="settings-danger-actions">
+                <button type="button" className="settings-inline-btn button-size-secondary-pill secondary-control secondary-control--compact-button" onClick={() => setRerunSetupConfirmOpen(false)}>Keep current setup</button>
+                <button
+                  type="button"
+                  className="settings-inline-btn button-size-secondary-pill secondary-control secondary-control--compact-button"
+                  onClick={() => {
+                    setOnboardingState({ mode: "claim", dogId: activeDogId });
+                    setScreen("onboard");
+                  }}
+                >
+                  Re-run setup
+                </button>
+              </div>
+            </div>
+          </div>
           <SettingsNavRow label="Switch dog" onClick={() => setScreen("select")} />
         </SettingsSheet>
       )}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1223,6 +1223,8 @@
   .section { padding:var(--space-3); overflow-x:hidden; }
   .section > .section-title:first-child { margin-bottom:var(--space-section-gap); }
   .history-section-head { display:flex; justify-content:space-between; align-items:baseline; margin-bottom:var(--space-3); }
+  .history-clear-banner { margin:0 0 var(--space-section-gap); animation:surfaceEnter var(--motion-enter) var(--ease-out); }
+  .history-clear-banner-actions { display:flex; gap:var(--space-control-gap); justify-content:flex-end; flex-wrap:wrap; }
   .history-summary-surface { margin:0 0 var(--space-section-gap); padding:var(--space-card-padding); border-radius:var(--radius-sm); border:1px solid color-mix(in srgb, var(--mutedBlue) 16%, var(--border)); background:color-mix(in srgb, var(--surface-muted) 80%, white); display:grid; gap:var(--space-control-gap); }
   .history-summary-grid { display:grid; grid-template-columns:repeat(3, minmax(0, 1fr)); gap:var(--space-control-gap); }
   .history-summary-item { display:grid; gap:2px; min-width:0; }
@@ -1831,13 +1833,13 @@
   .empty-state .es-body  { font-size:var(--type-body-size); color:var(--text-muted); line-height:var(--type-body-line); letter-spacing:var(--type-body-track); font-weight:var(--type-body-weight); margin-bottom:var(--space-card-row-gap); }
   .empty-state .es-cta   { border:none; box-shadow:var(--shadow); }
 
-  .feeding-overlay { position:fixed; inset:0; background:var(--surface-overlay); display:flex; align-items:center; justify-content:center; padding:var(--space-card-padding); z-index:220; animation:overlayFadeIn var(--motion-sheet-enter) var(--ease-standard); backdrop-filter:blur(8px); }
+  .feeding-overlay { position:fixed; inset:0; background:var(--surface-overlay); display:flex; align-items:flex-end; justify-content:center; padding:var(--space-card-padding); z-index:220; animation:overlayFadeIn var(--motion-sheet-enter) var(--ease-standard); backdrop-filter:blur(8px); }
   .feeding-card { --modal-card-max-width:360px; }
   .feeding-field { display:flex; flex-direction:column; gap:var(--space-card-row-gap); }
   .feeding-field input, .feeding-field select { width:100%; border:1.5px solid var(--border); border-radius:10px; padding:var(--space-field-padding-default); background:var(--surface-muted); color:var(--brown); font-size:var(--type-body-size); line-height:var(--type-body-line); font-weight:var(--type-body-weight); letter-spacing:var(--type-body-track); }
   .feeding-actions { display:flex; justify-content:flex-end; gap:var(--space-control-gap); margin-top:var(--space-modal-footer-gap); }
-  .activity-time-overlay { position:fixed; inset:0; background:var(--surface-overlay); display:flex; align-items:center; justify-content:center; padding:var(--space-card-padding); z-index:230; animation:overlayFadeIn var(--motion-sheet-enter) var(--ease-standard); backdrop-filter:blur(8px); }
-  .activity-time-card { --modal-card-max-width:360px; }
+  .activity-time-overlay { position:fixed; inset:0; background:var(--surface-overlay); display:flex; align-items:flex-end; justify-content:center; padding:var(--space-card-padding); z-index:230; animation:overlayFadeIn var(--motion-sheet-enter) var(--ease-standard); backdrop-filter:blur(8px); }
+  .activity-time-card { --modal-card-max-width:390px; }
   .history-modal-card { --modal-card-max-width:390px; }
   .activity-time-hint { margin-bottom:var(--space-1); }
   .activity-time-field { display:flex; flex-direction:column; gap:var(--space-card-row-gap); }


### PR DESCRIPTION
### Motivation
- Remove sudden, blocking UI interruptions (browser confirm dialogs and centered modals) and replace them with gentler, contextual patterns that preserve user orientation and reduce cognitive disruption.

### Description
- Replace account-level `window.confirm` for “Re-run setup” with an inline reveal confirmation and explicit keep/confirm actions in `src/features/settings/SettingsScreen.jsx`.
- Move `Clear sessions` confirmation out of a blocking dialog into a soft inline `InlineBanner` with “Keep sessions” / “Clear now” actions and make the action itself execute directly in `src/features/history/HistoryFeature.jsx`.
- Convert several centered overlays to sheet-style presentation (add grabber affordance and sheet classes) for history activity edit/delete modal, home walk/pattern logger, and feeding logger in `src/features/history/HistoryFeature.jsx` and `src/features/home/HomeScreen.jsx`.
- Add a small CSS payload to support the inline confirmation banner and to align feeding/history overlays as bottom sheets in `src/styles/app.css` and wire in the `InlineBanner` primitive import where needed.

### Testing
- Ran unit tests with `npm run test`, which passed (all test files and test cases succeeded).
- Built a production bundle with `npm run build`, which completed successfully.
- Ran `npm run check:inline-styles`, which failed due to pre-existing inline-style hygiene violations in unrelated files (not introduced by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e104bbb38c833288f1a81df4dd90a1)