### PR TITLE
Align remaining legacy dashboard UI with PawTimer redesign

### DIFF
--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -341,10 +341,10 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
   const durationIsValid = historyModal?.mode === "duration"
     ? Number.isFinite(parsedDuration) && (requiresPositiveDuration ? parsedDuration > 0 : parsedDuration >= 0)
     : true;
-  const recentCount = timeline.slice(0, 7).length;
   const sessionCount = timeline.filter((item) => item.kind === "session").length;
   const careCount = timeline.filter((item) => item.kind !== "session").length;
   const lastSession = timeline.find((item) => item.kind === "session");
+  const lastSessionLabel = lastSession ? fmtDate(lastSession.date) : "—";
   const timelineByDay = timeline.reduce((acc, item) => {
     const isoDate = item?.date;
     if (!isoDate) return acc;
@@ -579,8 +579,8 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                   <div className="history-summary-label">Support routine logs</div>
                 </div>
                 <div className="history-summary-item">
-                  <div className="history-summary-value">{recentCount}</div>
-                  <div className="history-summary-label">Recent training moments</div>
+                  <div className="history-summary-value">{lastSessionLabel}</div>
+                  <div className="history-summary-label">Latest calm-alone rep</div>
                 </div>
               </div>
               <div className="history-mini-trend" aria-label="Last seven days of training sessions">
@@ -607,7 +607,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                   ))}
                 </div>
               ) : null}
-              {lastSession ? <div className="history-summary-note">Latest calm-alone rep: {fmtDate(lastSession.date)}.</div> : null}
+              {lastSession ? <div className="history-summary-note">Use recent detail cards below to edit or clean up timeline entries.</div> : null}
             </div>
           )}
 

--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -69,9 +69,9 @@ export default function HomeScreen(props) {
   const [trainExplainOpen, setTrainExplainOpen] = useState(false);
   const todaySessions = sessions.filter((s) => isToday(s.date));
   const todayFeedingCount = feedings.filter((f) => isToday(f.date)).length;
-  const recentSessionLogs = [...todaySessions]
+  const latestSession = [...todaySessions]
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-    .slice(0, 4);
+    .at(0);
   const sessionBlockedMessage = daily.blockReason === "cap"
     ? `Daily alone-time cap reached (${fmtClock(daily.capSec)}). Try again tomorrow.`
     : daily.blockReason === "max_sessions"
@@ -215,10 +215,6 @@ export default function HomeScreen(props) {
           <div className={`collapsible-body train-today-body ${todayOpen ? "open" : "closed"}`}>
             <div className="settings-collapsible-inner">
               <div className="train-today-list" role="list" aria-label="Today's logged activity">
-                <div className="train-today-row" role="listitem">
-                  <span className="train-today-row__label">Calm-alone reps</span>
-                  <span className="train-today-row__meta">{todaySessions.length} today</span>
-                </div>
                 <button className="train-today-row train-today-row--action" type="button" onClick={walkPhase === "idle" ? startWalk : undefined}>
                   <span className="train-today-row__label">Walk</span>
                   <span className="train-today-row__meta">{walkPhase === "timing" ? `${fmt(walkElapsed)} live` : `${pattern.todayWalks} today`}</span>
@@ -232,16 +228,11 @@ export default function HomeScreen(props) {
                   <span className="train-today-row__meta">{todayFeedingCount} today</span>
                 </button>
               </div>
-              {recentSessionLogs.length > 0 && (
-                <div className="train-today-mini-log" role="list" aria-label="Recent calm-alone reps">
-                  {recentSessionLogs.map((session) => (
-                    <div className="train-today-mini-log__row" role="listitem" key={session.id || `${session.date}-${session.actualDuration || 0}`}>
-                      <span>{new Date(session.date).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}</span>
-                      <span>{fmt(session.actualDuration || session.seconds || 0)}</span>
-                    </div>
-                  ))}
+              {latestSession ? (
+                <div className="train-today-mini-log" role="status" aria-live="polite">
+                  Latest calm-alone rep: {new Date(latestSession.date).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })} · {fmt(latestSession.actualDuration || latestSession.seconds || 0)}
                 </div>
-              )}
+              ) : null}
             </div>
           </div>
         </section>

--- a/src/features/stats/StatsComponents.jsx
+++ b/src/features/stats/StatsComponents.jsx
@@ -90,10 +90,10 @@ export function StatsSupportRow({ label, value }) {
 }
 
 export function StatsInsightCard({ message, detail, tone = "neutral", index = 0 }) {
+  const staggerIndex = Math.max(0, Math.min(index, 5));
   return (
     <article
-      className={`stats-insight-card stats-insight-card--${tone}`.trim()}
-      style={{ "--insight-index": index }}
+      className={`stats-insight-card stats-insight-card--${tone} stats-insight-card--stagger-${staggerIndex}`.trim()}
       aria-live="polite"
     >
       <p className="stats-insight-message">{message}</p>
@@ -151,9 +151,10 @@ export function ProgressHero({
 
       {progressPct != null ? (
         <div className="stats-progress-rail-wrap" aria-label={`${progressPct}% toward next target`}>
-          <div className="stats-progress-rail">
-            <span className="stats-progress-rail-fill" style={{ width: `${Math.max(progressPct, 6)}%` }} />
-          </div>
+          <svg className="stats-progress-rail" viewBox="0 0 100 7" preserveAspectRatio="none" aria-hidden="true">
+            <rect className="stats-progress-rail-track" x="0" y="0" width="100" height="7" rx="3.5" ry="3.5" />
+            <rect className="stats-progress-rail-fill" x="0" y="0" width={Math.max(progressPct, 6)} height="7" rx="3.5" ry="3.5" />
+          </svg>
           <span className="stats-progress-rail-text">{progressPct}% to next step</span>
         </div>
       ) : null}

--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -176,7 +176,7 @@ export function SessionControl({
 
 export function TrainProgressBar({ goalPct, target, goalSec, fmt }) {
   const clampedGoalPct = Math.max(0, Math.min(goalPct, 100));
-  const thumbPct = Math.max(Math.min(clampedGoalPct, 98), 2);
+  const thumbPosition = Math.max(Math.min(clampedGoalPct, 98), 2);
 
   return (
     <div className="prog-section surface-card surface-card--progress">
@@ -184,8 +184,8 @@ export function TrainProgressBar({ goalPct, target, goalSec, fmt }) {
         <svg className="prog-track" viewBox="0 0 100 8" preserveAspectRatio="none" aria-hidden="true">
           <rect className="prog-fill-track" x="0" y="0" width="100" height="8" rx="4" ry="4" />
           <rect className="prog-fill" x="0" y="0" width={clampedGoalPct} height="8" rx="4" ry="4" />
+          <circle className="prog-thumb" cx={thumbPosition} cy="4" r="1.65" />
         </svg>
-        <span className="prog-thumb" style={{ left: `${thumbPct}%` }} aria-hidden="true" />
       </div>
       <div className="prog-meta">
         <span>Current target <strong className="num-stable">{fmt(target)}</strong></span>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -360,14 +360,9 @@
     transition:width 0.8s cubic-bezier(0.34,1.56,0.64,1);
   }
   .prog-thumb {
-    position:absolute;
-    top:50%;
-    width:6px;
-    height:6px;
-    border-radius:50%;
-    transform:translate(-50%, -50%);
-    border:1.35px solid var(--surf);
-    background:var(--progress-thumb-core-bg);
+    fill:var(--progress-thumb-core-bg);
+    stroke:var(--surf);
+    stroke-width:0.85;
     filter:drop-shadow(0 1px 4px color-mix(in srgb, var(--green-dark) 25%, transparent));
   }
   .prog-meta  { display:flex; justify-content:space-between; margin-top:var(--space-1); font-size:var(--type-secondary-size); line-height:var(--type-secondary-line); letter-spacing:var(--type-secondary-track); color:var(--text-muted); font-weight:var(--type-secondary-weight); }
@@ -831,18 +826,10 @@
   .train-today-mini-log {
     border-top:1px solid color-mix(in srgb, var(--border) 74%, transparent);
     margin-top:6px;
-    padding-top:8px;
-    display:grid;
-    gap:2px;
-  }
-  .train-today-mini-log__row {
-    display:flex;
-    align-items:center;
-    justify-content:space-between;
+    padding:8px 2px 2px;
     color:var(--text-muted);
     font-size:var(--type-helper-text-size);
     line-height:var(--type-helper-text-line);
-    padding:5px 2px;
   }
   .ring-sub-btn {
     margin-top:var(--space-card-row-gap);
@@ -1616,8 +1603,9 @@
   .stats-progress-label { font-size:var(--type-metric-label-size); line-height:var(--type-metric-label-line); letter-spacing:var(--type-metric-label-track); font-weight:var(--type-metric-label-weight); color:var(--text-muted); }
   .stats-progress-value-divider { width:1px; align-self:stretch; background:color-mix(in srgb, var(--border) 78%, transparent); }
   .stats-progress-rail-wrap { position:relative; z-index:1; display:grid; gap:5px; }
-  .stats-progress-rail { height:7px; border-radius:999px; background:color-mix(in srgb, var(--green-light) 18%, var(--surf)); overflow:hidden; border:1px solid color-mix(in srgb, var(--green-dark) 16%, transparent); }
-  .stats-progress-rail-fill { display:block; height:100%; min-width:6%; background:linear-gradient(90deg, color-mix(in srgb, var(--green-dark) 90%, var(--brown)), var(--green)); border-radius:inherit; transition:width 620ms var(--ease-out); animation:statsRailBreathe 3.2s ease-in-out infinite; }
+  .stats-progress-rail { display:block; width:100%; height:7px; }
+  .stats-progress-rail-track { fill:color-mix(in srgb, var(--green-light) 18%, var(--surf)); stroke:color-mix(in srgb, var(--green-dark) 16%, transparent); stroke-width:0.6; }
+  .stats-progress-rail-fill { fill:color-mix(in srgb, var(--green-dark) 86%, var(--brown)); animation:statsRailBreathe 3.2s ease-in-out infinite; }
   .stats-progress-rail-text { font-size:var(--type-helper-text-size); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); font-weight:var(--type-helper-text-weight); color:var(--text-muted); }
   .stats-progress-insight { position:relative; z-index:1; margin:0; font-size:var(--type-body-size); line-height:var(--type-body-line); letter-spacing:var(--type-body-track); font-weight:var(--type-body-weight); color:color-mix(in srgb, var(--text) 90%, var(--text-muted)); max-width:56ch; }
 
@@ -1675,8 +1663,13 @@
     gap:4px;
     box-shadow:var(--shadow);
     animation:statsInsightEnter 460ms var(--ease-out) both;
-    animation-delay:calc(var(--insight-index, 0) * 80ms);
   }
+  .stats-insight-card--stagger-0 { animation-delay:0ms; }
+  .stats-insight-card--stagger-1 { animation-delay:80ms; }
+  .stats-insight-card--stagger-2 { animation-delay:160ms; }
+  .stats-insight-card--stagger-3 { animation-delay:240ms; }
+  .stats-insight-card--stagger-4 { animation-delay:320ms; }
+  .stats-insight-card--stagger-5 { animation-delay:400ms; }
   .stats-insight-card::after {
     content:"";
     position:absolute;


### PR DESCRIPTION
### Motivation
- Reduce legacy visual noise and duplicated dashboard patterns to match the new PawTimer design language while preserving business logic. 
- Replace ad-hoc inline styling and per-component layout hacks with system-aligned, maintainable primitives for progress visuals and insight animations. 

### Description
- Simplified the Home screen by removing the redundant calm-reps row and replacing the heavy mini-log list with a single concise latest-rep status line while keeping walk/pattern/feeding actions intact (`src/features/home/HomeScreen.jsx`).
- Toned down the History summary by removing the ambiguous "Recent training moments" metric and showing a clear "Latest calm-alone rep" timestamp with supportive guidance copy (`src/features/history/HistoryFeature.jsx`).
- Replaced inline JSX style usage for insight staggering and progress rail widths with attribute-driven SVG rendering and deterministic stagger classes in the stats components (`src/features/stats/StatsComponents.jsx`).
- Moved the train progress thumb into the progress SVG (circle) to remove ad-hoc `style` positioning and keep rendering under the same vector layout system (`src/features/train/TrainComponents.jsx`).
- Updated CSS rules to support the SVG-based progress rail and thumb, added insight stagger classes, and compacted the latest-rep mini-log styles to match the redesign (`src/styles/app.css`).

### Testing
- Ran the inline-style hygiene check with `node scripts/check-inline-style-hygiene.mjs`, which passed. 
- Ran unit tests with `npm test`; all test files completed successfully and project tests passed (all tests green). 
- Built a production bundle with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1483fe4048332a0825a8d1dcb6943)