### PR TITLE
Polish first-time setup and Train session guidance

### DIFF
--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -134,6 +134,7 @@ export default function HomeScreen(props) {
               <div className="train-inline-explain" role="note" aria-live="polite">
                 <p><strong>Circle:</strong> this is {name}&apos;s target for one rep. The ring fills as calm alone time is completed.</p>
                 <p><strong>Target ({fmtClock(target)}):</strong> your current safe step. End while {name} is still relaxed.</p>
+                <p><strong>Session flow:</strong> start, observe calm body language, then end and rate what you saw.</p>
               </div>
             )}
           </div>
@@ -153,6 +154,11 @@ export default function HomeScreen(props) {
             <div className="train-inline-tip" role="note">
               <span className="train-inline-tip__label">Targets adapt to your dog</span>
               <span className="train-inline-tip__copy">Calm reps nudge targets up. Stress signs nudge them down.</span>
+              <ol className="train-inline-tip__steps">
+                <li>Press <strong>Start rep</strong> when the space is calm.</li>
+                <li>Watch quietly, then end before stress builds.</li>
+                <li>Rate what you saw so tomorrow&apos;s target fits better.</li>
+              </ol>
               <button
                 type="button"
                 className="train-inline-tip__dismiss"

--- a/src/features/setup/SetupScreens.jsx
+++ b/src/features/setup/SetupScreens.jsx
@@ -21,7 +21,10 @@ export function WelcomeScreen({ onStart, onManageDogs }) {
         <div className="ws-eyebrow">Separation training for dogs</div>
         <h1 className="ws-title">PawTimer</h1>
         <p className="ws-copy">
-          Short, guided reps that help your dog feel safer when home alone.
+          Calm, guided reps that help your dog build confidence when home alone.
+        </p>
+        <p className="ws-copy ws-copy--support">
+          Start in about a minute, then follow one clear rep at a time.
         </p>
       </div>
 
@@ -31,10 +34,10 @@ export function WelcomeScreen({ onStart, onManageDogs }) {
           type="button"
           onClick={onStart}
         >
-          Set up my dog
+          Start first-time setup
         </button>
         <button className="ws-secondary" type="button" onClick={onManageDogs}>
-          I already have a profile
+          I already have a dog ID
         </button>
       </div>
     </div>
@@ -64,7 +67,7 @@ export function Onboarding({ onComplete, onBack }) {
         <div className="ob-hero-icon"><PawIcon size={48} /></div>
         <div className="ob-eyebrow">Build {displayName}&apos;s plan</div>
         <div className="ob-title">{displayName === "your dog" ? "Start calm-alone training" : `${displayName}'s calm-alone training`}</div>
-        <div className="ob-subtitle">{activeStep.progressLabel} • We&apos;ll start gently.</div>
+        <div className="ob-subtitle">{activeStep.progressLabel} • We&apos;ll keep this calm and simple.</div>
         <div className="ob-step-indicator">
           {[0, 1, 2, 3].map((i) => <div key={i} className={`ob-step-dot ${i < step ? "done" : i === step ? "active" : ""}`} />)}
         </div>
@@ -110,12 +113,15 @@ export function Onboarding({ onComplete, onBack }) {
                 </button>
               ))}
             </div>
+            <button className="ob-skip-goal-btn" type="button" onClick={handleNext}>
+              Skip goal for now
+            </button>
           </>}
         </div>
       </div>
       <div className="ob-footer">
         <button className="ob-btn-next button-base button-primary button--lg button-size-primary-cta button--block" onClick={handleNext} disabled={!canNext}>
-          {step < 3 ? "Continue →" : `Start ${displayName}'s plan`}
+          {step < 3 ? "Continue →" : `Open ${displayName}'s Train screen`}
         </button>
         <button className="ob-back-btn" onClick={() => step === 0 ? onBack?.() : setStep((s) => s - 1)}>
           ← {step === 0 ? "Back to dogs" : "Back"}
@@ -178,7 +184,7 @@ export function DogSelect({ dogs, onSelect, onCreateNew }) {
       <div className="ds-hero">
         <div className="ds-logo"><PawIcon size={68} /></div>
         <div className="ds-title">PawTimer</div>
-        <div className="ds-sub">Choose how you want to start your dog&apos;s plan.</div>
+        <div className="ds-sub">Pick the fastest way to get into your dog&apos;s training plan.</div>
       </div>
       <div className="ds-body">
         <div className="ds-path-grid">
@@ -191,7 +197,7 @@ export function DogSelect({ dogs, onSelect, onCreateNew }) {
             }}
           >
             <div className="ds-path-title">Create a new plan</div>
-            <div className="ds-path-copy">Set a calm baseline in about a minute.</div>
+            <div className="ds-path-copy">Best for first-time setup. We&apos;ll choose a calm starting target.</div>
           </button>
           <button
             className={`ds-path-card ${activePath === "join" ? "selected" : ""}`}
@@ -199,7 +205,7 @@ export function DogSelect({ dogs, onSelect, onCreateNew }) {
             onClick={() => setActivePath("join")}
           >
             <div className="ds-path-title">Join with dog ID</div>
-            <div className="ds-path-copy">Use a shared ID so everyone follows one plan.</div>
+            <div className="ds-path-copy">Best when someone already set up this dog profile.</div>
           </button>
         </div>
 

--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -90,7 +90,7 @@ export function SessionControl({
           : `${name}'s calm hold for this rep`
         : `Next target for ${name}`;
   const helperCaption = displayState === "active"
-    ? (isPastTarget ? `+${fmt(overTargetSeconds)} calm hold` : `${fmt(elapsed)} completed this rep`)
+    ? (isPastTarget ? `+${fmt(overTargetSeconds)} calm hold` : `${fmt(elapsed)} completed this rep · keep departures quiet and predictable`)
     : displayState === "warning"
       ? "Come back tomorrow for the next rep"
       : "Short reps build comfort with alone time";

--- a/src/features/train/timeChangeInsight.js
+++ b/src/features/train/timeChangeInsight.js
@@ -19,8 +19,16 @@ export function buildTrainTimeChangeInsight({
   const name = dogName || "your dog";
   const dropped = next < previous;
   const increased = next > previous;
+  const recommendationReason = (() => {
+    if (recommendationType === "decrease_duration") return `${name} showed stress signs in the last rep, so we stepped down.`;
+    if (recommendationType === "increase_duration") return `Recent calm reps looked stable, so we added a small amount of time.`;
+    if (recommendationType === "maintain_duration") return `Recent results were mixed, so we held steady.`;
+    if (recommendationType === "cap_by_daily_limit") return `Today's daily limit is near, so we kept this target conservative.`;
+    if (recommendationType === "floor_at_start_duration") return `We kept the minimum starter duration to protect confidence.`;
+    return "";
+  })();
 
-  if (!dropped && !increased && recommendationType !== "recovery_mode_active" && recommendationType !== "recovery_mode_resume") {
+  if (!dropped && !increased && recommendationType !== "recovery_mode_active" && recommendationType !== "recovery_mode_resume" && !recommendationReason) {
     return null;
   }
 
@@ -28,7 +36,7 @@ export function buildTrainTimeChangeInsight({
     return {
       tone: "caution",
       title: `Recovery mode on · next target is ${formattedNext}`,
-      body: `${name} showed stress signs, so we moved to shorter reset reps.`,
+      body: `${name} showed stress signs, so we moved to shorter reset reps. We'll step back up after calm sessions.`,
     };
   }
 
@@ -45,8 +53,8 @@ export function buildTrainTimeChangeInsight({
       tone: "caution",
       title: `Target eased to ${formattedNext}`,
       body: distressLevel === "none"
-        ? `We lowered the next rep slightly to keep training steady.`
-        : `${name} showed stress signs, so the next rep is shorter.`,
+        ? `We lowered the next rep slightly to keep training steady. ${recommendationReason}`.trim()
+        : `${name} showed stress signs, so the next rep is shorter. ${recommendationReason}`.trim(),
     };
   }
 
@@ -54,13 +62,13 @@ export function buildTrainTimeChangeInsight({
     return {
       tone: "positive",
       title: `Target increased to ${formattedNext}`,
-      body: `Recent calm reps went well, so the next step is a little longer.`,
+      body: recommendationReason || `Recent calm reps went well, so the next step is a little longer.`,
     };
   }
 
   return {
     tone: "neutral",
     title: `Target stays at ${formattedNext}`,
-    body: `We're holding this duration to keep progress steady.`,
+    body: recommendationReason || `We're holding this duration to keep progress steady.`,
   };
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -145,6 +145,12 @@
     letter-spacing: var(--type-body-track);
     font-weight: var(--type-body-lg-weight);
   }
+  .ws-copy--support {
+    margin-top: 8px;
+    font-size: var(--type-helper-text-size);
+    line-height: var(--type-helper-text-line);
+    color: color-mix(in srgb, var(--text-muted) 88%, var(--text));
+  }
   .ws-footer { display: flex; flex-direction: column; gap: 12px; animation: ws-fade-up .9s .08s var(--ease-out-soft, ease-out) both; }
   .ws-cta { box-shadow: 0 12px 34px rgba(70, 90, 72, 0.2); }
   .ws-secondary {
@@ -312,6 +318,17 @@
     min-height:var(--small-tertiary-size);
     text-align:center;
     padding:0 var(--space-2);
+  }
+  .ob-skip-goal-btn {
+    margin-top:var(--space-card-row-gap);
+    width:100%;
+    min-height:44px;
+    border:none;
+    border-radius:var(--radius-pill);
+    color:var(--text-muted);
+    background:transparent;
+    font:inherit;
+    cursor:pointer;
   }
 
   /* ── Header ── */
@@ -804,6 +821,15 @@
     font-size:var(--type-helper-text-size);
     line-height:var(--type-helper-text-line);
     color:var(--text-muted);
+  }
+  .train-inline-tip__steps {
+    margin:0;
+    padding-left:18px;
+    color:var(--text-muted);
+    font-size:var(--type-helper-text-size);
+    line-height:var(--type-helper-text-line);
+    display:grid;
+    gap:4px;
   }
   .train-inline-tip__dismiss {
     justify-self:end;

--- a/tests/timeChangeInsight.test.js
+++ b/tests/timeChangeInsight.test.js
@@ -40,4 +40,17 @@ describe("buildTrainTimeChangeInsight", () => {
 
     expect(insight?.title).toContain("Recovery mode on");
   });
+
+  it("includes recommendation reason context when available", () => {
+    const insight = buildTrainTimeChangeInsight({
+      previousDuration: 90,
+      recommendedDuration: 90,
+      recommendationType: "maintain_duration",
+      distressLevel: "subtle",
+      dogName: "Milo",
+    });
+
+    expect(insight?.tone).toBe("neutral");
+    expect(insight?.body).toContain("held steady");
+  });
 });


### PR DESCRIPTION
### Motivation
- Improve the first-time user flow from app launch through the first Train session so onboarding feels clear, calm, and premium.
- Make the create vs join-by-ID entry paths explicit and natural so users choose the right path without confusion.
- Help first-time users understand the Train screen and why target times change so early sessions feel guided and low-friction.

### Description
- Updated the welcome screen copy and CTAs in `src/features/setup/SetupScreens.jsx` to read as clearer, premium entry points and added a small supporting line about starting quickly. 
- Smoothed onboarding flow in `Onboarding` by clarifying the subtitle, making completion text explicit (`Open … Train screen`), and adding a `Skip goal for now` button to reduce friction on step 4. 
- Improved Dog selection language in `DogSelect` so the create and join paths clearly state which scenario they’re for. 
- Added inline first-session guidance in `src/features/home/HomeScreen.jsx` (a concise `Session flow` line) and a 3-step checklist for first-run visibility to help users start, observe, and rate calmly. 
- Tuned active-session helper copy in `src/features/train/TrainComponents.jsx` to reinforce calm, predictable reps. 
- Expanded `buildTrainTimeChangeInsight` in `src/features/train/timeChangeInsight.js` to include contextual reasons for target changes (increase, decrease, maintain, cap, floor, and recovery states) and adjusted recovery messaging to explain next steps. 
- Added test coverage in `tests/timeChangeInsight.test.js` for maintain/neutral insight behavior and updated styles in `src/styles/app.css` to support the new copy and UI elements. 

### Testing
- Ran unit tests with `npm test -- tests/timeChangeInsight.test.js` and all tests passed (4 tests). 
- Built a production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14cecb6ac83329b93e9a444b1cc27)