### PR TITLE
Polish returning Train flow with target-change summary

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,6 +73,7 @@ export default function PawTimer() {
   const [trainingSettingsOpen, setTrainingSettingsOpen] = useState(false);
   const [trainFirstRunHintVisible, setTrainFirstRunHintVisible] = useState(false);
   const [trainTimeChangeInsight, setTrainTimeChangeInsight] = useState(null);
+  const [returningTrainNudge, setReturningTrainNudge] = useState(null);
   const [walkPhase, setWalkPhase] = useState("idle");
   const [walkElapsed, setWalkElapsed] = useState(0);
   const [walkPendingDuration, setWalkPendingDuration] = useState(0);
@@ -222,6 +223,10 @@ export default function PawTimer() {
     () => (activeDogId ? `pawtimer_train_intro_seen_v1_${canonicalDogId(activeDogId)}` : null),
     [activeDogId],
   );
+  const trainReturnSnapshotKey = useMemo(
+    () => (activeDogId ? `pawtimer_train_last_seen_v1_${canonicalDogId(activeDogId)}` : null),
+    [activeDogId],
+  );
   const canonicalSessions = useMemo(() => sortValidDateAsc(sessions), [sessions]);
   const deriveRecommendation = useCallback((nextSessions, nextWalks = walks, nextPatterns = patterns, nextDog = activeDog || {}) => {
     const logicalSessions = sortValidDateAsc(nextSessions);
@@ -276,6 +281,49 @@ export default function PawTimer() {
     save(trainFirstRunHintKey, true);
     setTrainFirstRunHintVisible(false);
   }, [trainFirstRunHintKey]);
+
+  const acknowledgeReturningTrainNudge = useCallback(() => {
+    if (!trainReturnSnapshotKey) return;
+    save(trainReturnSnapshotKey, {
+      target: recommendation.duration,
+      seenAt: new Date().toISOString(),
+    });
+    setReturningTrainNudge(null);
+  }, [recommendation.duration, trainReturnSnapshotKey]);
+
+  useEffect(() => {
+    if (!trainReturnSnapshotKey || !activeDogId || canonicalSessions.length === 0) {
+      setReturningTrainNudge(null);
+      return;
+    }
+    const snapshot = ensureObject(load(trainReturnSnapshotKey, {}));
+    const previousTarget = Number(snapshot.target);
+    if (!Number.isFinite(previousTarget)) {
+      setReturningTrainNudge(null);
+      return;
+    }
+    const currentTarget = Number(recommendation.duration);
+    if (!Number.isFinite(currentTarget) || currentTarget === previousTarget) {
+      setReturningTrainNudge(null);
+      return;
+    }
+    setReturningTrainNudge({
+      previousTarget,
+      currentTarget,
+      changedBy: currentTarget - previousTarget,
+      seenAt: snapshot.seenAt || null,
+    });
+  }, [activeDogId, canonicalSessions.length, recommendation.duration, trainReturnSnapshotKey]);
+
+  useEffect(() => {
+    if (!trainReturnSnapshotKey || !activeDogId) return;
+    if (tab !== "home") {
+      save(trainReturnSnapshotKey, {
+        target: recommendation.duration,
+        seenAt: new Date().toISOString(),
+      });
+    }
+  }, [activeDogId, recommendation.duration, tab, trainReturnSnapshotKey]);
 
   const reportLocalWriteFailure = useCallback((errorMessage) => {
     setSyncStatus("err");
@@ -988,6 +1036,7 @@ export default function PawTimer() {
       return;
     }
     completeTrainFirstRunHint();
+    acknowledgeReturningTrainNudge();
     setTrainTimeChangeInsight(null);
     setElapsed(0); setSessionCompleted(false); setSessionOutcome(null); setLatencyDraft(""); setDistressTypeDraft(""); setPhase("running");
   };
@@ -1205,7 +1254,7 @@ export default function PawTimer() {
         </div>
 
         <div className={`tab-panel tab-panel--${tabMotionDirection}`} key={tab}>
-          {tab === "home" && <HomeScreen name={appData.name} sessions={canonicalSessions} recommendation={appData.recommendation} goalPct={appData.goalPct} goalSec={appData.goalSec} phase={phase} elapsed={elapsed} finalElapsed={finalElapsed} sessionCompleted={sessionCompleted} sessionOutcome={sessionOutcome} setSessionOutcome={setSessionOutcome} recordResult={recordResult} latencyDraft={latencyDraft} setLatencyDraft={setLatencyDraft} distressTypeDraft={distressTypeDraft} setDistressTypeDraft={setDistressTypeDraft} setPhase={setPhase} setElapsed={setElapsed} setFinalElapsed={setFinalElapsed} startSession={startSession} endSession={endSession} cancelSession={cancelSession} activeProto={appData.activeProto} daily={appData.daily} pattern={appData.pattern} walkPhase={walkPhase} startWalk={startWalk} cancelWalk={cancelWalk} walkElapsed={walkElapsed} endWalk={endWalk} walkPendingDuration={walkPendingDuration} saveWalkWithType={saveWalkWithType} patOpen={patOpen} setPatOpen={setPatOpen} patReminderText={appData.patReminderText} logPattern={logPattern} patLabels={patLabels} patterns={patterns} feedings={feedings} feedingOpen={feedingOpen} openFeedingForm={openFeedingForm} feedingDraft={feedingDraft} setFeedingDraft={setFeedingDraft} cancelFeedingForm={cancelFeedingForm} saveFeeding={saveFeeding} showTrainFirstRunHint={trainFirstRunHintVisible} dismissTrainFirstRunHint={completeTrainFirstRunHint} trainTimeChangeInsight={trainTimeChangeInsight} />}
+          {tab === "home" && <HomeScreen name={appData.name} sessions={canonicalSessions} recommendation={appData.recommendation} goalPct={appData.goalPct} goalSec={appData.goalSec} phase={phase} elapsed={elapsed} finalElapsed={finalElapsed} sessionCompleted={sessionCompleted} sessionOutcome={sessionOutcome} setSessionOutcome={setSessionOutcome} recordResult={recordResult} latencyDraft={latencyDraft} setLatencyDraft={setLatencyDraft} distressTypeDraft={distressTypeDraft} setDistressTypeDraft={setDistressTypeDraft} setPhase={setPhase} setElapsed={setElapsed} setFinalElapsed={setFinalElapsed} startSession={startSession} endSession={endSession} cancelSession={cancelSession} activeProto={appData.activeProto} daily={appData.daily} pattern={appData.pattern} walkPhase={walkPhase} startWalk={startWalk} cancelWalk={cancelWalk} walkElapsed={walkElapsed} endWalk={endWalk} walkPendingDuration={walkPendingDuration} saveWalkWithType={saveWalkWithType} patOpen={patOpen} setPatOpen={setPatOpen} patReminderText={appData.patReminderText} logPattern={logPattern} patLabels={patLabels} patterns={patterns} feedings={feedings} feedingOpen={feedingOpen} openFeedingForm={openFeedingForm} feedingDraft={feedingDraft} setFeedingDraft={setFeedingDraft} cancelFeedingForm={cancelFeedingForm} saveFeeding={saveFeeding} showTrainFirstRunHint={trainFirstRunHintVisible} dismissTrainFirstRunHint={completeTrainFirstRunHint} trainTimeChangeInsight={trainTimeChangeInsight} returningTrainNudge={returningTrainNudge} dismissReturningTrainNudge={acknowledgeReturningTrainNudge} openHistory={() => handleTabChange("history")} openProgress={() => handleTabChange("progress")} />}
           {tab === "history" && <HistoryScreen timeline={appData.timeline} sessions={canonicalSessions} name={appData.name} setTab={setTab} patLabels={patLabels} historyModal={historyModal} setHistoryModal={setHistoryModal} actions={historyActions} />}
           {tab === "progress" && <StatsScreen name={appData.name} totalCount={appData.totalCount} setTab={setTab} bestCalm={appData.bestCalm} recommendation={appData.recommendation} relapseTone={appData.relapseTone} chartData={appData.chartData} goalSec={appData.goalSec} CustomDot={CustomDot} distressLabel={appData.distressLabel} chartTrendLabel={appData.chartTrendLabel} aloneLastWeek={appData.aloneLastWeek} avgWalkDuration={appData.avgWalkDuration} avgSessionsPerDay={appData.avgSessionsPerDay} avgWalksPerDay={appData.avgWalksPerDay} headlineStatus={appData.headlineStatus} headlineStatusTone={appData.headlineStatusTone} contextualInsights={appData.contextualInsights} />}
           {tab === "settings" && <SettingsScreen name={appData.name} activeDogId={activeDogId} copyDogId={copyDogId} notifEnabled={notifEnabled} handleToggleNotif={handleToggleNotif} notifTime={notifTime} setNotifTime={setNotifTime} scheduleNotif={scheduleNotif} dogs={dogs} activeProto={appData.activeProto} pattern={appData.pattern} recommendation={appData.recommendation} setTrainingSettingsOpen={setTrainingSettingsOpen} patLabels={patLabels} editingPat={editingPat} setEditingPat={setEditingPat} setPatLabels={setPatLabels} settingsDisclosure={settingsDisclosure} setSettingsDisclosure={setSettingsDisclosure} syncDiagRunning={syncDiagRunning} runSyncDiagnostics={runSyncDiagnostics} SYNC_ENABLED={SYNC_ENABLED} SB_URL={SB_URL} SB_KEY={SB_KEY} SB_BASE_URL={SB_BASE_URL} syncDiagResult={syncDiagResult} syncSummary={syncSummary} syncDegradation={syncDegradation} trainingSettingsOpen={trainingSettingsOpen} setProtoWarnAck={setProtoWarnAck} protoWarnAck={protoWarnAck} protoOverride={protoOverride} setProtoOverride={setProtoOverride} setScreen={setScreen} setOnboardingState={setOnboardingState} dogsState={dogs} setDogs={setDogs} save={save} ACTIVE_DOG_KEY={ACTIVE_DOG_KEY} setActiveDogId={setActiveDogId} clearDogActivityState={clearDogActivityState} />}

--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -52,6 +52,10 @@ export default function HomeScreen(props) {
     showTrainFirstRunHint,
     dismissTrainFirstRunHint,
     trainTimeChangeInsight,
+    returningTrainNudge,
+    dismissReturningTrainNudge,
+    openHistory,
+    openProgress,
   } = props;
   const target = recommendation?.duration ?? 0;
   const recoveryMode = recommendation?.details?.recoveryMode;
@@ -119,6 +123,26 @@ export default function HomeScreen(props) {
           allowIdlePress={false}
           onIdlePress={toggleTrainExplain}
         />
+        {phase === "idle" && returningTrainNudge && (
+          <section className="train-returning-summary surface-card" role="status" aria-live="polite">
+            <div className="train-returning-summary__head">
+              <p className="train-returning-summary__eyebrow">Welcome back</p>
+              <button type="button" className="train-returning-summary__dismiss" onClick={dismissReturningTrainNudge} aria-label="Dismiss update">
+                Dismiss
+              </button>
+            </div>
+            <p className="train-returning-summary__title">
+              Target updated from <strong>{fmtClock(returningTrainNudge.previousTarget)}</strong> to <strong>{fmtClock(returningTrainNudge.currentTarget)}</strong>.
+            </p>
+            <p className="train-returning-summary__meta">
+              {returningTrainNudge.changedBy > 0 ? "You can try a slightly longer calm rep today." : "A shorter rep keeps confidence steady today."}
+            </p>
+            <div className="train-returning-summary__actions">
+              <button type="button" className="button-base button-ghost button--md button--pill" onClick={openHistory}>History</button>
+              <button type="button" className="button-base button-ghost button--md button--pill" onClick={openProgress}>Progress</button>
+            </div>
+          </section>
+        )}
         {phase === "idle" && (
           <div className="train-contextual-help">
             <button

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -560,6 +560,56 @@
     width:min(100%, 360px);
     margin:var(--space-density-compact-control-gap) auto 0;
   }
+  .train-returning-summary {
+    width:min(100%, 360px);
+    margin:var(--space-density-compact-control-gap) auto 0;
+    padding:var(--space-field-padding-default);
+    border-radius:var(--radius-md);
+    border:1px solid color-mix(in srgb, var(--primaryBlue) 28%, var(--border));
+    background:linear-gradient(180deg, color-mix(in srgb, var(--primaryBlue-weak) 48%, white), color-mix(in srgb, var(--surf) 95%, white));
+    text-align:left;
+    display:grid;
+    gap:var(--space-density-compact-control-gap);
+  }
+  .train-returning-summary__head {
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+    gap:var(--space-control-gap);
+  }
+  .train-returning-summary__eyebrow {
+    margin:0;
+    color:var(--primaryBlue);
+    text-transform:uppercase;
+    letter-spacing:var(--type-helper-text-track);
+    font-size:var(--type-helper-text-size);
+    font-weight:600;
+  }
+  .train-returning-summary__dismiss {
+    border:none;
+    background:none;
+    color:var(--text-muted);
+    font:inherit;
+    font-size:var(--type-helper-text-size);
+    cursor:pointer;
+    padding:0;
+  }
+  .train-returning-summary__title {
+    margin:0;
+    color:var(--brown);
+    font-size:var(--type-list-row-primary-size);
+    line-height:var(--type-list-row-primary-line);
+  }
+  .train-returning-summary__meta {
+    margin:0;
+    color:var(--text-muted);
+    font-size:var(--type-helper-text-size);
+    line-height:var(--type-helper-text-line);
+  }
+  .train-returning-summary__actions {
+    display:flex;
+    gap:var(--space-density-compact-control-gap);
+  }
   .train-contextual-help .train-inline-guidance {
     margin-top:0;
   }


### PR DESCRIPTION
### Motivation
- Improve the returning-user Train experience by surfacing target changes immediately on re-entry. 
- Make the change easy to understand with minimal, focused guidance and one-tap paths to deeper context. 
- Avoid persistent clutter by dismissing or clearing the hint once acknowledged or when a new rep starts.

### Description
- Added a returning-user nudge state in `src/App.jsx` (`returningTrainNudge`, `trainReturnSnapshotKey`) that snapshots the last-seen per-dog target and compares it to the current recommendation to detect target changes. 
- Persist the per-dog Train snapshot when users leave the Train tab and clear the nudge when the user starts a rep or explicitly dismisses it via `acknowledgeReturningTrainNudge`. 
- Exposed `returningTrainNudge`, `dismissReturningTrainNudge`, `openHistory`, and `openProgress` props to `HomeScreen` and added a compact, dismissible "Welcome back" summary card that states the previous vs current target and offers quick buttons to `History` and `Progress`. 
- Added CSS in `src/styles/app.css` for the returning summary card so it integrates with existing Train UI and remains compact and non-accumulating.

### Testing
- Ran unit tests with `npm test` (Vitest): all tests passed. 
- Built production assets with `npm run build`: build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14f02da38833282ba649ab1d8cfa8)