### PR TITLE
Polish premium training UX copy, spacing and motion hierarchy

### DIFF
--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -104,7 +104,7 @@ export default function HomeScreen(props) {
           <div className="train-identity-header__copy">
             <div className="train-identity-header__eyebrow">{name}'s calm practice</div>
             <h2 className="train-identity-header__name">Train with {name}</h2>
-            <p className="train-identity-header__mood">Short, gentle reps to help {name} feel safer during real departures.</p>
+            <p className="train-identity-header__mood">Short, calm reps that build {name}&apos;s confidence when you leave.</p>
           </div>
         </header>
 
@@ -152,22 +152,22 @@ export default function HomeScreen(props) {
               aria-expanded={trainExplainOpen}
             >
               <span className="train-inline-guidance__label">What this means</span>
-              <span className="train-inline-guidance__copy">How the circle supports separation training</span>
+              <span className="train-inline-guidance__copy">See what the circle is coaching right now</span>
             </button>
             {trainExplainOpen && (
               <div className="train-inline-explain" role="note" aria-live="polite">
-                <p><strong>Circle:</strong> this is {name}&apos;s target for one rep. The ring fills as calm alone time is completed.</p>
-                <p><strong>Target ({fmtClock(target)}):</strong> your current safe step. End while {name} is still relaxed.</p>
-                <p><strong>Session flow:</strong> start, observe calm body language, then end and rate what you saw.</p>
+                <p><strong>Circle:</strong> one calm rep for {name}. The ring fills as relaxed time passes.</p>
+                <p><strong>Target ({fmtClock(target)}):</strong> today&apos;s safe step. End while {name} still looks settled.</p>
+                <p><strong>Flow:</strong> start, quietly observe, end early, then log what you noticed.</p>
               </div>
             )}
           </div>
         )}
         <section className="train-context-block surface-card">
-          <p className="train-context-block__title">Today&apos;s target</p>
-          <p className="train-context-block__value">{fmtClock(target)} calm for {name}</p>
+          <p className="train-context-block__title">Today&apos;s focus</p>
+          <p className="train-context-block__value">{fmtClock(target)} calm-alone rep for {name}</p>
           <p className="train-context-block__meta">
-            Reps today: <strong>{daily.count}</strong> · Longer-term goal: <strong>{fmt(goalSec)}</strong>
+            Reps logged: <strong>{daily.count}</strong> · Longer-term goal: <strong>{fmt(goalSec)}</strong>
           </p>
           {!daily.canAdd && (
             <p className="status-msg status-msg--warning">
@@ -176,12 +176,12 @@ export default function HomeScreen(props) {
           )}
           {phase === "idle" && showTrainFirstRunHint && (
             <div className="train-inline-tip" role="note">
-              <span className="train-inline-tip__label">Targets adapt to your dog</span>
-              <span className="train-inline-tip__copy">Calm reps nudge targets up. Stress signs nudge them down.</span>
+              <span className="train-inline-tip__label">Targets adapt to {name}</span>
+              <span className="train-inline-tip__copy">Calm reps nudge up. Stress signs gently step back.</span>
               <ol className="train-inline-tip__steps">
-                <li>Press <strong>Start rep</strong> when the space is calm.</li>
-                <li>Watch quietly, then end before stress builds.</li>
-                <li>Rate what you saw so tomorrow&apos;s target fits better.</li>
+                <li>Press <strong>Start rep</strong> when the home feels calm.</li>
+                <li>Watch quietly and end before stress builds.</li>
+                <li>Rate the rep so tomorrow&apos;s step stays right-sized.</li>
               </ol>
               <button
                 type="button"
@@ -237,8 +237,8 @@ export default function HomeScreen(props) {
             onClick={() => setTodayOpen((prev) => !prev)}
           >
             <div>
-              <div className="section-title section-title--flush">Today&apos;s training + care log</div>
-              <div className="t-helper">{todaySessions.length} calm-alone reps · support logs</div>
+              <div className="section-title section-title--flush">Today&apos;s care log</div>
+              <div className="t-helper">{todaySessions.length} calm reps · walks, breaks, feeding</div>
             </div>
             <span className="settings-collapsible-arrow" aria-hidden="true">{todayOpen ? "−" : "+"}</span>
           </button>

--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -90,10 +90,10 @@ export function SessionControl({
           : `${name}'s calm hold for this rep`
         : `Next target for ${name}`;
   const helperCaption = displayState === "active"
-    ? (isPastTarget ? `+${fmt(overTargetSeconds)} calm hold` : `${fmt(elapsed)} completed this rep · keep departures quiet and predictable`)
+    ? (isPastTarget ? `+${fmt(overTargetSeconds)} calm hold` : `${fmt(elapsed)} complete · keep departures quiet and predictable`)
     : displayState === "warning"
       ? "Come back tomorrow for the next rep"
-      : "Short reps build comfort with alone time";
+      : "Small, steady reps build comfort with alone time";
 
   const startWithFeedback = () => {
     if (!onStart || !canStart) return;
@@ -151,7 +151,7 @@ export function SessionControl({
               <div className="sc-caption">{innerCaption}</div>
               <div className="sc-support">{helperCaption}</div>
               <div className={`sc-state-chip ${isRunning ? "is-running" : ""}`}>
-                {isRunning ? `Rep live · ${fmt(elapsed)} elapsed` : "Ready for the next rep"}
+                {isRunning ? `Rep live · ${fmt(elapsed)} elapsed` : "Ready · calm rep"}
               </div>
             </div>
           </div>
@@ -212,20 +212,20 @@ export function SessionRatingPanel({
         <div className="rating-sheet-grabber" aria-hidden="true" />
         <div className="rating-title" id="session-rating-title">How did {name} do?</div>
         <div className="rating-sub" id="session-rating-sub">
-          {fmt(finalElapsed)} rep with {name}. Your choice gently adjusts the next target.
+          {fmt(finalElapsed)} with {name}. Your rating tunes the next step.
         </div>
         <div className="result-grid">
           <button className="btn-result btn-none" onClick={() => recordResult("none")}>
             <Img src="result-calm.png" size={36} alt="No stress"/>
-            <div><div>Calm</div><div className="result-desc">Relaxed the whole rep</div></div>
+            <div><div>Calm</div><div className="result-desc">Relaxed throughout</div></div>
           </button>
           <button className="btn-result btn-mild" onClick={() => recordResult("subtle")}>
             <Img src="result-mild.png" size={36} alt="Slight stress"/>
-            <div><div>Some stress</div><div className="result-desc">Mild signs, still settled</div></div>
+            <div><div>Some stress</div><div className="result-desc">Mild signs, recovered</div></div>
           </button>
           <button className="btn-result btn-strong" onClick={() => recordResult("active")}>
             <Img src="result-strong.png" size={36} alt="Strong stress"/>
-            <div><div>High stress</div><div className="result-desc">Clear stress signs; next step should be easier</div></div>
+            <div><div>High stress</div><div className="result-desc">Clear stress signs; next rep should be easier</div></div>
           </button>
         </div>
         <p className="rating-adapt-note" role="status">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2270,7 +2270,7 @@
 
 .train-main {
   width: min(100%, 484px);
-  gap: var(--space-3);
+  gap: clamp(16px, 2.8vh, 24px);
 }
 
 .tool-group-card {
@@ -2359,6 +2359,66 @@
 }
 .tab-btn:active {
   transform: translateY(0) scale(0.986);
+}
+
+.train-identity-header,
+.train-context-block,
+.train-returning-summary,
+.train-inline-guidance,
+.train-inline-explain,
+.train-inline-tip,
+.train-time-change-insight {
+  box-shadow: 0 8px 22px color-mix(in srgb, var(--surface-overlay-soft) 9%, transparent);
+}
+
+.train-identity-header {
+  border-radius: 20px;
+  padding: 16px;
+}
+
+.train-identity-header__mood {
+  margin-top: 6px;
+  max-width: 36ch;
+}
+
+.session-control {
+  width: clamp(238px, 70vw, 300px);
+}
+
+.sc-state-chip {
+  letter-spacing: 0.01em;
+}
+
+.session-actions {
+  margin-top: 6px;
+  gap: 10px;
+}
+
+.session-primary-btn,
+.session-cancel-btn {
+  width: min(100%, 296px);
+}
+
+.train-inline-guidance {
+  align-items: flex-start;
+}
+
+.train-inline-guidance__copy {
+  max-width: 24ch;
+  text-wrap: balance;
+}
+
+.train-inline-explain {
+  border-radius: 14px;
+}
+
+.train-context-block__value {
+  text-wrap: balance;
+}
+
+.train-returning-summary__title,
+.train-time-change-insight__copy {
+  text-wrap: pretty;
 }
 
 :where(


### PR DESCRIPTION
### Motivation
- Raise the Train/Home experience to feature-quality by tightening copy, clarifying contextual guidance, and reducing visual clutter while preserving existing flows and behavior. 
- Emphasize a calm, dog-focused identity and smoother motion/spacing to improve emotional clarity and ease of use.

### Description
- Updated hero and guidance copy in `src/features/home/HomeScreen.jsx` to be calmer, more concise, and dog-centered (hero mood, “What this means”, first-run hint steps, and care-log wording). 
- Refined session microcopy in `src/features/train/TrainComponents.jsx` to make the timer, helper line, and rating language feel more supportive and minimal (helper wording when active/past target, idle chip, and rating descriptions). 
- Applied visual and motion polish in `src/styles/app.css`, including improved vertical rhythm (clamped gaps), unified soft card shadows, tuned session-control sizing, refined action row sizing, and text wrapping improvements for guidance cards. 
- No new features or interaction changes were introduced; all edits are copy/spacing/motion/style refinements only.

### Testing
- Ran unit tests with `npm run test` and all tests passed (`236 tests passed`). 
- Built a production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1502c3be083328be997378c4002b0)