### PR TITLE
Simplify Train screen to focus on core session action

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1237,22 +1237,6 @@ export default function PawTimer() {
         </div>
       )}
       <div className="app">
-        <div className="header">
-          <div className="header-top">
-            <div className="identity-zone">
-              <label className="dog-photo-btn" title="Tap to change photo">
-                <input type="file" accept="image/*" className="sr-only" onChange={handlePhotoUpload} />
-                {dogPhoto ? <img src={dogPhoto} className="dog-photo-img" alt={appData.name} /> : <div className="dog-photo-placeholder"><PawIcon size={28} /></div>}
-                <div className="dog-photo-overlay"><CameraIcon /></div>
-              </label>
-              <div className="identity-copy">
-                <div className="app-title">{appData.name}</div>
-                <div className="app-subtitle">Calm-alone plan for real departures</div>
-              </div>
-            </div>
-          </div>
-        </div>
-
         <div className={`tab-panel tab-panel--${tabMotionDirection}`} key={tab}>
           {tab === "home" && <HomeScreen name={appData.name} sessions={canonicalSessions} recommendation={appData.recommendation} goalPct={appData.goalPct} goalSec={appData.goalSec} phase={phase} elapsed={elapsed} finalElapsed={finalElapsed} sessionCompleted={sessionCompleted} sessionOutcome={sessionOutcome} setSessionOutcome={setSessionOutcome} recordResult={recordResult} latencyDraft={latencyDraft} setLatencyDraft={setLatencyDraft} distressTypeDraft={distressTypeDraft} setDistressTypeDraft={setDistressTypeDraft} setPhase={setPhase} setElapsed={setElapsed} setFinalElapsed={setFinalElapsed} startSession={startSession} endSession={endSession} cancelSession={cancelSession} activeProto={appData.activeProto} daily={appData.daily} pattern={appData.pattern} walkPhase={walkPhase} startWalk={startWalk} cancelWalk={cancelWalk} walkElapsed={walkElapsed} endWalk={endWalk} walkPendingDuration={walkPendingDuration} saveWalkWithType={saveWalkWithType} patOpen={patOpen} setPatOpen={setPatOpen} patReminderText={appData.patReminderText} logPattern={logPattern} patLabels={patLabels} patterns={patterns} feedings={feedings} feedingOpen={feedingOpen} openFeedingForm={openFeedingForm} feedingDraft={feedingDraft} setFeedingDraft={setFeedingDraft} cancelFeedingForm={cancelFeedingForm} saveFeeding={saveFeeding} showTrainFirstRunHint={trainFirstRunHintVisible} dismissTrainFirstRunHint={completeTrainFirstRunHint} trainTimeChangeInsight={trainTimeChangeInsight} returningTrainNudge={returningTrainNudge} dismissReturningTrainNudge={acknowledgeReturningTrainNudge} openHistory={() => handleTabChange("history")} openProgress={() => handleTabChange("progress")} />}
           {tab === "history" && <HistoryScreen timeline={appData.timeline} sessions={canonicalSessions} name={appData.name} setTab={setTab} patLabels={patLabels} historyModal={historyModal} setHistoryModal={setHistoryModal} actions={historyActions} />}

--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -65,6 +65,19 @@ export default function HomeScreen(props) {
   return (
     <div className="tab-content train-screen">
       <div className="train-main">
+        <header className="train-identity-header surface-card">
+          <div className="train-identity-header__badge" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="22" height="22" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M7 10.5 5.6 6.8a1.2 1.2 0 0 1 2-.9L10 8.8h4l2.4-2.9a1.2 1.2 0 0 1 2 .9L17 10.5a6.2 6.2 0 0 1 .7 2.8c0 3.2-2.6 5.7-5.7 5.7s-5.7-2.5-5.7-5.7c0-1 .2-2 .7-2.8Z" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"/>
+              <path d="M9.4 13.1c.2 0 .4-.2.4-.4s-.2-.4-.4-.4-.4.2-.4.4.2.4.4.4Zm5.2 0c.2 0 .4-.2.4-.4s-.2-.4-.4-.4-.4.2-.4.4.2.4.4.4Z" fill="currentColor"/>
+              <path d="M10.3 15.3c.5.5 1 .7 1.7.7s1.2-.2 1.7-.7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+            </svg>
+          </div>
+          <div className="train-identity-header__copy">
+            <h2 className="train-identity-header__name">Train with {name}</h2>
+          </div>
+        </header>
+
         <SessionControl
           phase={phase}
           elapsed={elapsed}

--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -65,20 +65,10 @@ export default function HomeScreen(props) {
   return (
     <div className="tab-content train-screen">
       <div className="train-main">
-        <header className="train-identity-header surface-card">
-          <div className="train-identity-header__badge" aria-hidden="true">
-            <span role="img" aria-label="Dog">🐕</span>
-          </div>
-          <div className="train-identity-header__copy">
-            <h2 className="train-identity-header__name">Train with {name}</h2>
-          </div>
-        </header>
-
         <SessionControl
           phase={phase}
           elapsed={elapsed}
           target={target}
-          name={name}
           onStart={startSession}
           onEnd={endSession}
           onCancel={cancelSession}

--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -1,14 +1,13 @@
 import { SessionControl, SessionRatingPanel } from "../train/TrainComponents";
 import { DISTRESS_TYPES, PATTERN_TYPES, WALK_TYPE_OPTIONS, fmt, fmtClock, isToday, walkTypeLabel } from "../app/helpers";
 import { Img, ModalCloseButton } from "../app/ui";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export default function HomeScreen(props) {
   const {
     name,
     sessions,
     recommendation,
-    goalSec,
     phase,
     elapsed,
     finalElapsed,
@@ -49,28 +48,10 @@ export default function HomeScreen(props) {
     setFeedingDraft,
     cancelFeedingForm,
     saveFeeding,
-    showTrainFirstRunHint,
     dismissTrainFirstRunHint,
-    trainTimeChangeInsight,
-    returningTrainNudge,
-    dismissReturningTrainNudge,
-    openHistory,
-    openProgress,
   } = props;
   const target = recommendation?.duration ?? 0;
-  const recoveryMode = recommendation?.details?.recoveryMode;
-  const recommendationType = recommendation?.details?.recommendationType;
-  const recoveryModalTitle = (() => {
-    if (!recoveryMode?.active) return "Recovery plan";
-    if (recommendationType === "recovery_mode_active") return "Recovery reset sessions";
-    return "Recovery sessions active";
-  })();
-  const recoveryModalCopy = recoveryMode?.planCopy
-    || recommendation?.details?.summary
-    || recommendation?.explanation
-    || "We temporarily adjusted session targets to rebuild calm confidence before progression resumes.";
   const [todayOpen, setTodayOpen] = useState(false);
-  const [trainExplainOpen, setTrainExplainOpen] = useState(false);
   const todaySessions = sessions.filter((s) => isToday(s.date));
   const todayFeedingCount = feedings.filter((f) => isToday(f.date)).length;
   const latestSession = [...todaySessions]
@@ -81,30 +62,15 @@ export default function HomeScreen(props) {
     : daily.blockReason === "max_sessions"
       ? `Daily session max reached (${daily.maxCount}). Try again tomorrow.`
       : "";
-  const toggleTrainExplain = () => {
-    setTrainExplainOpen((prev) => !prev);
-    if (showTrainFirstRunHint) dismissTrainFirstRunHint();
-  };
-
-  useEffect(() => {
-    if (phase !== "idle") {
-      setTrainExplainOpen(false);
-      return;
-    }
-    if (showTrainFirstRunHint) setTrainExplainOpen(true);
-  }, [phase, showTrainFirstRunHint]);
-
   return (
     <div className="tab-content train-screen">
       <div className="train-main">
         <header className="train-identity-header surface-card">
           <div className="train-identity-header__badge" aria-hidden="true">
-            <Img src="hero-dog.png" size={44} alt="" />
+            <span role="img" aria-label="Dog">🐕</span>
           </div>
           <div className="train-identity-header__copy">
-            <div className="train-identity-header__eyebrow">{name}'s calm practice</div>
             <h2 className="train-identity-header__name">Train with {name}</h2>
-            <p className="train-identity-header__mood">Short, calm reps that build {name}&apos;s confidence when you leave.</p>
           </div>
         </header>
 
@@ -121,90 +87,8 @@ export default function HomeScreen(props) {
           canStart={daily.canAdd}
           startBlockedMessage={sessionBlockedMessage}
           allowIdlePress={false}
-          onIdlePress={toggleTrainExplain}
+          onIdlePress={dismissTrainFirstRunHint}
         />
-        {phase === "idle" && returningTrainNudge && (
-          <section className="train-returning-summary surface-card" role="status" aria-live="polite">
-            <div className="train-returning-summary__head">
-              <p className="train-returning-summary__eyebrow">Welcome back</p>
-              <button type="button" className="train-returning-summary__dismiss" onClick={dismissReturningTrainNudge} aria-label="Dismiss update">
-                Dismiss
-              </button>
-            </div>
-            <p className="train-returning-summary__title">
-              Target updated from <strong>{fmtClock(returningTrainNudge.previousTarget)}</strong> to <strong>{fmtClock(returningTrainNudge.currentTarget)}</strong>.
-            </p>
-            <p className="train-returning-summary__meta">
-              {returningTrainNudge.changedBy > 0 ? "You can try a slightly longer calm rep today." : "A shorter rep keeps confidence steady today."}
-            </p>
-            <div className="train-returning-summary__actions">
-              <button type="button" className="button-base button-ghost button--md button--pill" onClick={openHistory}>History</button>
-              <button type="button" className="button-base button-ghost button--md button--pill" onClick={openProgress}>Progress</button>
-            </div>
-          </section>
-        )}
-        {phase === "idle" && (
-          <div className="train-contextual-help">
-            <button
-              type="button"
-              className={`train-inline-guidance ${showTrainFirstRunHint ? "is-first-run" : ""}`}
-              onClick={toggleTrainExplain}
-              aria-expanded={trainExplainOpen}
-            >
-              <span className="train-inline-guidance__label">What this means</span>
-              <span className="train-inline-guidance__copy">See what the circle is coaching right now</span>
-            </button>
-            {trainExplainOpen && (
-              <div className="train-inline-explain" role="note" aria-live="polite">
-                <p><strong>Circle:</strong> one calm rep for {name}. The ring fills as relaxed time passes.</p>
-                <p><strong>Target ({fmtClock(target)}):</strong> today&apos;s safe step. End while {name} still looks settled.</p>
-                <p><strong>Flow:</strong> start, quietly observe, end early, then log what you noticed.</p>
-              </div>
-            )}
-          </div>
-        )}
-        <section className="train-context-block surface-card">
-          <p className="train-context-block__title">Today&apos;s focus</p>
-          <p className="train-context-block__value">{fmtClock(target)} calm-alone rep for {name}</p>
-          <p className="train-context-block__meta">
-            Reps logged: <strong>{daily.count}</strong> · Longer-term goal: <strong>{fmt(goalSec)}</strong>
-          </p>
-          {!daily.canAdd && (
-            <p className="status-msg status-msg--warning">
-              {sessionBlockedMessage}
-            </p>
-          )}
-          {phase === "idle" && showTrainFirstRunHint && (
-            <div className="train-inline-tip" role="note">
-              <span className="train-inline-tip__label">Targets adapt to {name}</span>
-              <span className="train-inline-tip__copy">Calm reps nudge up. Stress signs gently step back.</span>
-              <ol className="train-inline-tip__steps">
-                <li>Press <strong>Start rep</strong> when the home feels calm.</li>
-                <li>Watch quietly and end before stress builds.</li>
-                <li>Rate the rep so tomorrow&apos;s step stays right-sized.</li>
-              </ol>
-              <button
-                type="button"
-                className="train-inline-tip__dismiss"
-                onClick={dismissTrainFirstRunHint}
-              >
-                Got it
-              </button>
-            </div>
-          )}
-          {phase === "idle" && recoveryMode?.active && (
-            <div className="train-recovery-inline" role="note" aria-live="polite">
-              <p className="train-recovery-inline__title">{recoveryModalTitle}</p>
-              <p className="train-recovery-inline__copy">{recoveryModalCopy}</p>
-            </div>
-          )}
-          {phase === "idle" && trainTimeChangeInsight && (
-            <div className={`train-time-change-insight is-${trainTimeChangeInsight.tone || "neutral"}`} role="status" aria-live="polite">
-              <p className="train-time-change-insight__title">{trainTimeChangeInsight.title}</p>
-              <p className="train-time-change-insight__copy">{trainTimeChangeInsight.body}</p>
-            </div>
-          )}
-        </section>
 
         <SessionRatingPanel
           phase={phase}
@@ -222,6 +106,12 @@ export default function HomeScreen(props) {
           Img={Img}
           distressTypes={DISTRESS_TYPES}
         />
+
+        {!daily.canAdd && (
+          <p className="status-msg status-msg--warning">
+            {sessionBlockedMessage}
+          </p>
+        )}
 
         {daily.canAdd && daily.count >= Math.max(1, activeProto.sessionsPerDayMax - (pattern.normalizedLeaves >= 7 ? 1 : 0)) && (
           <p className="status-msg status-msg--warning">

--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -51,7 +51,6 @@ export function SessionControl({
   phase,
   elapsed,
   target,
-  name = "your dog",
   onStart,
   onEnd,
   onCancel,

--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -30,7 +30,7 @@ function SessionActionRow({
         onClick={handlePrimary}
         disabled={!isRunning && !canRunStart && !canExplain}
       >
-        {isRunning ? "End and save" : "Start rep"}
+        {isRunning ? "End and save" : "Start session"}
       </button>
       <button
         className="session-cancel-btn button-base button-ghost button--md button--pill"
@@ -81,19 +81,12 @@ export function SessionControl({
         ? "active"
         : "idle";
   const innerCaption = displayState === "warning"
-    ? "Practice is paused for today"
+    ? "Paused"
     : displayState === "success"
-      ? `${name} hit this calm target`
+      ? "Complete"
       : displayState === "active"
-        ? isPastTarget
-          ? `Past target — end while ${name} is still settled`
-          : `${name}'s calm hold for this rep`
-        : `Next target for ${name}`;
-  const helperCaption = displayState === "active"
-    ? (isPastTarget ? `+${fmt(overTargetSeconds)} calm hold` : `${fmt(elapsed)} complete · keep departures quiet and predictable`)
-    : displayState === "warning"
-      ? "Come back tomorrow for the next rep"
-      : "Small, steady reps build comfort with alone time";
+        ? "In session"
+        : "Ready";
 
   const startWithFeedback = () => {
     if (!onStart || !canStart) return;
@@ -149,10 +142,6 @@ export function SessionControl({
             <div className="sc-time">
               <div className="sc-time-value">{fmt(timerValue)}</div>
               <div className="sc-caption">{innerCaption}</div>
-              <div className="sc-support">{helperCaption}</div>
-              <div className={`sc-state-chip ${isRunning ? "is-running" : ""}`}>
-                {isRunning ? `Rep live · ${fmt(elapsed)} elapsed` : "Ready · calm rep"}
-              </div>
             </div>
           </div>
         </button>


### PR DESCRIPTION
### Motivation

- Reduce clutter on the Train surface so the single, primary training action is the user's focus. 
- Remove duplicated identity/hero details and long explanatory copy that compete with the session control. 
- Keep necessary active-session affordances (clear primary CTA and visible cancel) while simplifying presentation.

### Description

- Aggressively removed contextual and explanatory blocks from the main Train surface by trimming the content in `src/features/home/HomeScreen.jsx` and eliminating first-run/returning nudge UI and recovery copy. 
- Kept a single identity header and replaced the hero image placeholder with a minimal icon by swapping `Img src="hero-dog.png"` for a simple emoji span in `src/features/home/HomeScreen.jsx`. 
- Simplified the hero-circle copy inside `SessionControl` (`src/features/train/TrainComponents.jsx`) to only show the timer value and a short state label (`"Ready"`, `"In session"`, `"Complete"`, `"Paused"`) and removed the long helper/support text and state chip. 
- Renamed the primary action label from `Start rep` to `Start session` in `SessionActionRow` while preserving the active-session cancel affordance `Cancel (don't save)` so users can abort without saving. 
- Removed now-unused props and related logic from the Home screen component to match the simplified UI surface without adding any new elements.

### Testing

- Built the production bundle with `npm run build`, which completed successfully. 
- Ran the full test suite with `npm test` (Vitest), with all tests passing (`236 tests, 236 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1599927bc8332b3f8999c568c2c52)