### PR TITLE
Simplify History screen hierarchy and timeline layout

### DIFF
--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -3,7 +3,7 @@ import EmptyState from "../../components/EmptyState";
 import { InlineBanner } from "../../components/primitives";
 import { buildEditedActivityIso, sortByDateAsc, toDateInputValue, toTimeInputValue } from "../../lib/activityDateTime";
 import { normalizeDistressLevel } from "../../lib/protocol";
-import { PATTERN_TYPES, fmt, fmtDate, parseDurationInput, sessionDetailBadges, walkTypeLabel } from "../app/helpers";
+import { PATTERN_TYPES, fmt, fmtDate, parseDurationInput, walkTypeLabel } from "../app/helpers";
 import { ClockIcon, DeleteIcon, EditIcon, ModalCloseButton, TrendIcon } from "../app/ui";
 import { logSyncDebug, mergeSessionWithDerivedFields, normalizeSession } from "../app/storage";
 
@@ -35,15 +35,6 @@ function HistoryDetailGroup({ label, children }) {
     <div className="h-detail-group">
       <div className="h-detail-label">{label}</div>
       <div className="h-detail-body">{children}</div>
-    </div>
-  );
-}
-
-function HistoryChipList({ items }) {
-  if (!items?.length) return <div className="h-detail-empty">No extra notes logged yet.</div>;
-  return (
-    <div className="h-chip-list">
-      {items.map((item) => <span className="h-chip" key={item}>{item}</span>)}
     </div>
   );
 }
@@ -332,8 +323,7 @@ const renderSyncBadge = (entry) => {
 };
 
 export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, historyModal, setHistoryModal, actions }) {
-  const [expandedItemKey, setExpandedItemKey] = useState(null);
-  const [sessionDetail, setSessionDetail] = useState(null);
+  const [activityDetail, setActivityDetail] = useState(null);
   const [clearSessionsConfirmOpen, setClearSessionsConfirmOpen] = useState(false);
   const parsedDuration = historyModal?.mode === "duration" ? parseDurationInput(historyModal.value) : null;
   const requiresPositiveDuration = historyModal?.kind === "session";
@@ -341,10 +331,6 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
   const durationIsValid = historyModal?.mode === "duration"
     ? Number.isFinite(parsedDuration) && (requiresPositiveDuration ? parsedDuration > 0 : parsedDuration >= 0)
     : true;
-  const sessionCount = timeline.filter((item) => item.kind === "session").length;
-  const careCount = timeline.filter((item) => item.kind !== "session").length;
-  const lastSession = timeline.find((item) => item.kind === "session");
-  const lastSessionLabel = lastSession ? fmtDate(lastSession.date) : "—";
   const timelineByDay = timeline.reduce((acc, item) => {
     const isoDate = item?.date;
     if (!isoDate) return acc;
@@ -364,170 +350,50 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
       bucketDate.setDate(bucketDate.getDate() - offset);
       const dayKey = bucketDate.toISOString().slice(0, 10);
       const daySessions = timelineByDay[dayKey]?.filter((item) => item.kind === "session") ?? [];
-      const calmSessions = daySessions.filter((item) => normalizeDistressLevel(item?.data?.distressLevel) === "none").length;
       buckets.push({
         dayKey,
         count: daySessions.length,
-        calmCount: calmSessions,
         label: bucketDate.toLocaleDateString(undefined, { weekday: "short" }),
       });
     }
     return buckets;
   })();
-  const historyInsights = (() => {
-    const sessionItems = timeline
-      .filter((item) => item.kind === "session")
-      .map((item) => item.data)
-      .filter((session) => session?.date)
-      .sort((a, b) => (a.date > b.date ? 1 : -1));
-    if (sessionItems.length < 2) return [];
-
-    const scoreDistress = (session) => {
-      const level = normalizeDistressLevel(
-        session?.distressLevel
-        ?? (session?.result === "success" ? "none" : (session?.result === "distress" ? "strong" : null)),
-      );
-      if (level === "none") return 0;
-      if (level === "subtle") return 1;
-      if (level === "active") return 2;
-      return 3;
-    };
-
-    const average = (values) => values.reduce((sum, value) => sum + value, 0) / values.length;
-    const latestSessions = sessionItems.slice(-6);
-    const latestThree = latestSessions.slice(-3);
-    const previousThree = latestSessions.slice(0, 3);
-    const insightPool = [];
-
-    if (latestThree.length === 3 && previousThree.length === 3) {
-      const recentDistress = average(latestThree.map(scoreDistress));
-      const priorDistress = average(previousThree.map(scoreDistress));
-      if (recentDistress + 0.35 < priorDistress) {
-        insightPool.push("Improving over recent sessions.");
-      }
-    }
-
-    const todayKey = new Date().toISOString().slice(0, 10);
-    const todaySessions = sessionItems.filter((session) => session.date.slice(0, 10) === todayKey);
-    if (todaySessions.length >= 2) {
-      const todayDurations = todaySessions
-        .map((session) => (Number.isFinite(session.actualDuration) ? session.actualDuration : 0))
-        .filter((duration) => duration > 0);
-      const todayDistressAvg = average(todaySessions.map(scoreDistress));
-      if (todayDurations.length >= 2 && todayDistressAvg <= 1) {
-        const spread = Math.max(...todayDurations) - Math.min(...todayDurations);
-        if (spread <= 120) insightPool.push("More stable today.");
-      }
-    }
-
-    const distressScores = sessionItems.map(scoreDistress);
-    const mostRecentStressIndex = distressScores.reduce((latestIndex, score, index) => (score >= 2 ? index : latestIndex), -1);
-    if (mostRecentStressIndex >= 0 && mostRecentStressIndex + 2 < sessionItems.length) {
-      const preStressDuration = sessionItems
-        .slice(Math.max(0, mostRecentStressIndex - 2), mostRecentStressIndex)
-        .map((session) => session.actualDuration)
-        .filter((duration) => Number.isFinite(duration) && duration > 0);
-      const postStressDuration = sessionItems
-        .slice(mostRecentStressIndex + 1, mostRecentStressIndex + 3)
-        .map((session) => session.actualDuration)
-        .filter((duration) => Number.isFinite(duration) && duration > 0);
-      if (preStressDuration.length && postStressDuration.length) {
-        if (average(postStressDuration) <= average(preStressDuration) * 0.82) {
-          insightPool.push("Shorter sessions after a stress event.");
-        }
-      }
-    }
-
-    if (sessionItems.length >= 4) {
-      const lastTwoScores = sessionItems.slice(-2).map(scoreDistress);
-      const priorScores = sessionItems.slice(-6, -2).map(scoreDistress);
-      const hadStressBefore = priorScores.some((score) => score >= 2);
-      const nowCalm = lastTwoScores.every((score) => score <= 1);
-      if (hadStressBefore && nowCalm) {
-        insightPool.push("Back on track.");
-      }
-    }
-
-    if (!insightPool.length) {
-      return ["Steady rhythm this week."];
-    }
-    return insightPool.slice(0, 2);
-  })();
-  const trendMax = Math.max(1, ...recentTrend.map((day) => day.count));
-  const trendLevel = (count) => {
-    if (count <= 0) return 0;
-    const ratio = count / trendMax;
-    if (ratio >= 0.8) return 4;
-    if (ratio >= 0.6) return 3;
-    if (ratio >= 0.35) return 2;
-    if (ratio >= 0.15) return 1;
-    return 0;
-  };
-
-  const toggleExpandedItem = (itemKey) => {
-    setExpandedItemKey((prev) => (prev === itemKey ? null : itemKey));
-  };
+  const weeklyRhythmLabel = recentTrend.some((day) => day.count > 0) ? "Weekly rhythm" : "No sessions this week";
 
   useEffect(() => {
-    if (!sessionDetail) return;
+    if (!activityDetail) return;
     const closeOnEscape = (event) => {
-      if (event.key === "Escape") setSessionDetail(null);
+      if (event.key === "Escape") setActivityDetail(null);
     };
     window.addEventListener("keydown", closeOnEscape);
     return () => window.removeEventListener("keydown", closeOnEscape);
-  }, [sessionDetail]);
+  }, [activityDetail]);
 
-  const renderHistoryCard = ({ itemKey, title, date, value, badge, syncBadge, expandedContent, kindLabel, onActivate }) => {
-    const isExpanded = expandedItemKey === itemKey;
-    const detailsId = `history-details-${itemKey}`;
-    const isInteractiveCard = typeof onActivate === "function" || Boolean(expandedContent);
-    const cardClassName = `h-item ${isExpanded ? "is-expanded" : ""} ${typeof onActivate === "function" ? "is-tap-card" : ""}`.trim();
-
-    const handleActivate = () => {
-      if (typeof onActivate === "function") {
-        onActivate();
-        return;
-      }
-      if (expandedContent) toggleExpandedItem(itemKey);
-    };
-
+  const renderHistoryCard = ({ itemKey, title, date, duration, status, onActivate }) => {
     return (
       <div
-        className={cardClassName}
+        className="h-item is-tap-card"
         key={itemKey}
-        role={isInteractiveCard ? "button" : undefined}
-        tabIndex={isInteractiveCard ? 0 : undefined}
-        aria-expanded={expandedContent ? isExpanded : undefined}
-        aria-controls={expandedContent ? detailsId : undefined}
-        onClick={isInteractiveCard ? handleActivate : undefined}
+        role="button"
+        tabIndex={0}
+        onClick={onActivate}
         onKeyDown={(event) => {
-          if (!isInteractiveCard) return;
           if (event.key !== "Enter" && event.key !== " ") return;
           event.preventDefault();
-          handleActivate();
+          onActivate();
         }}
       >
+        <div className="h-rail" aria-hidden="true">
+          <div className="h-marker" />
+        </div>
         <div className="h-body">
-          <div className="h-content">
-            <div className="h-marker" aria-hidden="true" />
-            <div className="h-info">
-              <div className="h-kind">{kindLabel}</div>
-              <div className="h-main">{title}</div>
-              <div className="h-meta-line">
-                <span className="h-date">{date}</span>
-                {syncBadge}
-              </div>
-            </div>
-            <div className="h-side">
-              {value ? <div className="h-value">{value}</div> : null}
-              {badge}
-            </div>
+          <div className="h-main">{title}</div>
+          <div className="h-meta-line">
+            <span className="h-duration">{duration}</span>
+            <span className="h-meta-divider" aria-hidden="true">•</span>
+            <span className="h-date">{date}</span>
           </div>
-          {isExpanded ? (
-            <div className="h-expand" id={detailsId}>
-              {expandedContent}
-            </div>
-          ) : null}
+          <div className="h-status-row">{status}</div>
         </div>
       </div>
     );
@@ -540,7 +406,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
           <div className="history-section-head">
             <div>
               <div className="section-title">History</div>
-              <div className="t-helper">A timeline of {name}&rsquo;s calm-alone reps and support routine.</div>
+              <div className="t-helper">Weekly rhythm and activity timeline.</div>
             </div>
             {sessions.length > 0 && <button className="clear-btn surface-text-button secondary-control secondary-control--inline-text" onClick={() => setClearSessionsConfirmOpen((prev) => !prev)}>{clearSessionsConfirmOpen ? "Cancel" : "Clear sessions"}</button>}
           </div>
@@ -569,45 +435,19 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
           ) : null}
           {timeline.length > 0 && (
             <div className="history-summary-surface">
-              <div className="history-summary-grid">
-                <div className="history-summary-item">
-                  <div className="history-summary-value">{sessionCount}</div>
-                  <div className="history-summary-label">Calm-alone reps</div>
-                </div>
-                <div className="history-summary-item">
-                  <div className="history-summary-value">{careCount}</div>
-                  <div className="history-summary-label">Support routine logs</div>
-                </div>
-                <div className="history-summary-item">
-                  <div className="history-summary-value">{lastSessionLabel}</div>
-                  <div className="history-summary-label">Latest calm-alone rep</div>
-                </div>
-              </div>
               <div className="history-mini-trend" aria-label="Last seven days of training sessions">
                 <div className="history-mini-trend-head">
-                  <span>7-day calm-alone rhythm</span>
-                  <span>{recentTrend.reduce((sum, day) => sum + day.count, 0)} reps</span>
+                  <span>{weeklyRhythmLabel}</span>
                 </div>
-                <div className="history-mini-trend-bars" role="img" aria-label="Each bar shows number of sessions completed each day">
+                <div className="history-mini-trend-dots" role="img" aria-label="Each dot shows whether a session was completed on that day">
                   {recentTrend.map((day) => (
-                    <div className="history-mini-trend-day" key={day.dayKey}>
-                      <div
-                        className={`history-mini-trend-bar history-mini-trend-bar--level-${trendLevel(day.count)}`}
-                        title={`${day.dayKey}: ${day.count} session${day.count === 1 ? "" : "s"}, ${day.calmCount} calm`}
-                      />
+                    <div className="history-mini-trend-dot-wrap" key={day.dayKey}>
+                      <div className={`history-mini-trend-dot ${day.count > 0 ? "is-active" : ""}`} title={`${day.dayKey}: ${day.count > 0 ? "session logged" : "no session"}`} />
                       <span>{day.label.slice(0, 1)}</span>
                     </div>
                   ))}
                 </div>
               </div>
-              {historyInsights.length > 0 ? (
-                <div className="history-insights" aria-label="History summary insights">
-                  {historyInsights.map((insight) => (
-                    <span className="history-insight-pill" key={insight}>{insight}</span>
-                  ))}
-                </div>
-              ) : null}
-              {lastSession ? <div className="history-summary-note">Use recent detail cards below to edit or clean up timeline entries.</div> : null}
             </div>
           )}
 
@@ -628,11 +468,14 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                 itemKey: `s-${s.id}`,
                 title: "Calm-alone training rep",
                 date: fmtDate(s.date),
-                value: fmt(s.actualDuration),
-                kindLabel: "Calm-alone",
-                onActivate: () => setSessionDetail(s),
-                badge: <span className={`h-badge badge-${lv}`}>{lv === "none" ? "No distress" : lv === "subtle" ? "Subtle stress" : lv === "active" ? "Active distress" : "Severe distress"}</span>,
-                syncBadge: renderSyncBadge(s),
+                duration: fmt(s.actualDuration),
+                onActivate: () => setActivityDetail({ kind: "session", item: s, title: "Calm-alone training rep", duration: fmt(s.actualDuration), status: lv === "none" ? "No distress" : lv === "subtle" ? "Subtle stress" : lv === "active" ? "Active distress" : "Severe distress" }),
+                status: (
+                  <>
+                    <span className={`h-badge badge-${lv}`}>{lv === "none" ? "No distress" : lv === "subtle" ? "Subtle stress" : lv === "active" ? "Active distress" : "Severe distress"}</span>
+                    {renderSyncBadge(s)}
+                  </>
+                ),
               });
             }
             if (item.kind === "walk") {
@@ -641,28 +484,14 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                 itemKey: `w-${w.id}`,
                 title: `${walkTypeLabel(w.type)} with ${name}`,
                 date: fmtDate(w.date),
-                value: w.duration ? fmt(w.duration) : "—",
-                kindLabel: "Support",
-                badge: <span className="h-side-label">Duration</span>,
-                syncBadge: renderSyncBadge(w),
-                expandedContent: <>
-                  <div className="h-expand-grid">
-                    <HistoryDetailGroup label="Walk details">
-                      <HistoryChipList items={["Walk logged for decompression support", `Type: ${walkTypeLabel(w.type)}`]} />
-                    </HistoryDetailGroup>
-                  </div>
-                  <div className="h-expand-footer">
-                    <HistoryDetailGroup label="Actions">
-                      <HistoryActionGroup
-                        actions={[
-                          { key: "time", className: "h-edit", label: "Edit walk time", icon: <ClockIcon />, onClick: () => actions.editWalkTime(w.id, setHistoryModal) },
-                          { key: "duration", className: "h-edit", label: "Edit walk duration", icon: <EditIcon />, onClick: () => actions.editWalkDuration(w.id, setHistoryModal) },
-                          { key: "delete", className: "h-del", label: "Delete walk", icon: <DeleteIcon />, onClick: () => actions.requestHistoryDelete("walk", w, setHistoryModal) },
-                        ]}
-                      />
-                    </HistoryDetailGroup>
-                  </div>
-                </>,
+                duration: w.duration ? fmt(w.duration) : "No duration",
+                onActivate: () => setActivityDetail({ kind: "walk", item: w, title: `${walkTypeLabel(w.type)} with ${name}`, duration: w.duration ? fmt(w.duration) : "No duration", status: "Logged" }),
+                status: (
+                  <>
+                    <span className="h-badge badge-pat">Logged</span>
+                    {renderSyncBadge(w)}
+                  </>
+                ),
               });
             }
             if (item.kind === "pat") {
@@ -672,25 +501,14 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                 itemKey: `p-${p.id}`,
                 title: patLabels[pt.type] || pt.label,
                 date: fmtDate(p.date),
-                kindLabel: "Support",
-                badge: <span className="h-badge badge-pat">Pattern break</span>,
-                syncBadge: renderSyncBadge(p),
-                expandedContent: <>
-                  <div className="h-expand-grid">
-                    <HistoryDetailGroup label="Pattern details">
-                      <HistoryChipList items={["Departure-cue support item", pt.desc]} />
-                    </HistoryDetailGroup>
-                  </div>
-                  <div className="h-expand-footer">
-                    <HistoryDetailGroup label="Actions">
-                      <HistoryActionGroup
-                        actions={[
-                          { key: "delete", className: "h-del", label: "Delete pattern break", icon: <DeleteIcon />, onClick: () => actions.requestHistoryDelete("pattern", p, setHistoryModal) },
-                        ]}
-                      />
-                    </HistoryDetailGroup>
-                  </div>
-                </>,
+                duration: "—",
+                onActivate: () => setActivityDetail({ kind: "pattern", item: p, title: patLabels[pt.type] || pt.label, duration: "—", status: "Pattern break" }),
+                status: (
+                  <>
+                    <span className="h-badge badge-pat">Pattern break</span>
+                    {renderSyncBadge(p)}
+                  </>
+                ),
               });
             }
             if (item.kind === "feeding") {
@@ -699,26 +517,14 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                 itemKey: `f-${f.id}`,
                 title: <span className="history-food-type">{f.foodType}</span>,
                 date: fmtDate(f.date),
-                value: f.amount,
-                kindLabel: "Support",
-                badge: <span className="h-badge badge-feed">Feeding</span>,
-                syncBadge: renderSyncBadge(f),
-                expandedContent: <>
-                  <div className="h-expand-grid">
-                    <HistoryDetailGroup label="Meal details">
-                      <HistoryChipList items={["Meal recorded for routine consistency", `Amount: ${f.amount}`, `Type: ${f.foodType}`]} />
-                    </HistoryDetailGroup>
-                  </div>
-                  <div className="h-expand-footer">
-                    <HistoryDetailGroup label="Actions">
-                      <HistoryActionGroup
-                        actions={[
-                          { key: "delete", className: "h-del", label: "Delete feeding", icon: <DeleteIcon />, onClick: () => actions.requestHistoryDelete("feeding", f, setHistoryModal) },
-                        ]}
-                      />
-                    </HistoryDetailGroup>
-                  </div>
-                </>,
+                duration: f.amount,
+                onActivate: () => setActivityDetail({ kind: "feeding", item: f, title: f.foodType, duration: f.amount, status: "Feeding" }),
+                status: (
+                  <>
+                    <span className="h-badge badge-feed">Feeding</span>
+                    {renderSyncBadge(f)}
+                  </>
+                ),
               });
             }
             return null;
@@ -785,38 +591,36 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
         </div>
       )}
 
-      {sessionDetail && (
+      {activityDetail && (
         <div
           className="history-session-sheet-overlay"
           role="dialog"
           aria-modal="true"
           aria-labelledby="history-session-sheet-title"
-          onClick={() => setSessionDetail(null)}
+          onClick={() => setActivityDetail(null)}
         >
-          <div className="history-session-sheet modal-card modal-card--dialog-md" onClick={(event) => event.stopPropagation()}>
+          <div className="history-session-sheet modal-card modal-card--dialog-md modal-card--sheet" onClick={(event) => event.stopPropagation()}>
             <div className="history-session-sheet-grabber" aria-hidden="true" />
             <div className="quick-modal-head">
-              <div className="section-title section-title--flush" id="history-session-sheet-title">Calm-alone rep details</div>
-              <ModalCloseButton onClick={() => setSessionDetail(null)} />
+              <div className="section-title section-title--flush" id="history-session-sheet-title">Activity details</div>
+              <ModalCloseButton onClick={() => setActivityDetail(null)} />
             </div>
             <div className="history-session-sheet-meta">
-              <div className="history-session-sheet-value">{fmt(sessionDetail.actualDuration)}</div>
-              <div className="history-session-sheet-date">{fmtDate(sessionDetail.date)}</div>
+              <div className="history-session-sheet-value">{activityDetail.title}</div>
+              <div className="history-session-sheet-date">{activityDetail.duration} · {fmtDate(activityDetail.item.date)}</div>
             </div>
-            <HistoryDetailGroup label="Details">
-              <HistoryChipList items={sessionDetailBadges(sessionDetail)} />
-            </HistoryDetailGroup>
+            <HistoryDetailGroup label="Status">{activityDetail.status}</HistoryDetailGroup>
             <HistoryDetailGroup label="Actions">
               <HistoryActionGroup
-                actions={[
+                actions={activityDetail.kind === "session" ? [
                   {
                     key: "time",
                     className: "h-edit",
                     label: "Edit session time",
                     icon: <ClockIcon />,
                     onClick: () => {
-                      actions.editSessionTime(sessionDetail.id, setHistoryModal);
-                      setSessionDetail(null);
+                      actions.editSessionTime(activityDetail.item.id, setHistoryModal);
+                      setActivityDetail(null);
                     },
                   },
                   {
@@ -825,8 +629,8 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                     label: "Edit session duration",
                     icon: <EditIcon />,
                     onClick: () => {
-                      actions.editSessionDuration(sessionDetail.id, setHistoryModal);
-                      setSessionDetail(null);
+                      actions.editSessionDuration(activityDetail.item.id, setHistoryModal);
+                      setActivityDetail(null);
                     },
                   },
                   {
@@ -835,10 +639,18 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
                     label: "Delete session",
                     icon: <DeleteIcon />,
                     onClick: () => {
-                      actions.requestHistoryDelete("session", sessionDetail, setHistoryModal);
-                      setSessionDetail(null);
+                      actions.requestHistoryDelete("session", activityDetail.item, setHistoryModal);
+                      setActivityDetail(null);
                     },
                   },
+                ] : activityDetail.kind === "walk" ? [
+                  { key: "time", className: "h-edit", label: "Edit walk time", icon: <ClockIcon />, onClick: () => { actions.editWalkTime(activityDetail.item.id, setHistoryModal); setActivityDetail(null); } },
+                  { key: "duration", className: "h-edit", label: "Edit walk duration", icon: <EditIcon />, onClick: () => { actions.editWalkDuration(activityDetail.item.id, setHistoryModal); setActivityDetail(null); } },
+                  { key: "delete", className: "h-del", label: "Delete walk", icon: <DeleteIcon />, onClick: () => { actions.requestHistoryDelete("walk", activityDetail.item, setHistoryModal); setActivityDetail(null); } },
+                ] : activityDetail.kind === "pattern" ? [
+                  { key: "delete", className: "h-del", label: "Delete pattern break", icon: <DeleteIcon />, onClick: () => { actions.requestHistoryDelete("pattern", activityDetail.item, setHistoryModal); setActivityDetail(null); } },
+                ] : [
+                  { key: "delete", className: "h-del", label: "Delete feeding", icon: <DeleteIcon />, onClick: () => { actions.requestHistoryDelete("feeding", activityDetail.item, setHistoryModal); setActivityDetail(null); } },
                 ]}
               />
             </HistoryDetailGroup>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1334,29 +1334,18 @@
   .history-section-head { display:flex; justify-content:space-between; align-items:baseline; margin-bottom:var(--space-3); }
   .history-clear-banner { margin:0 0 var(--space-section-gap); animation:surfaceEnter var(--motion-enter) var(--ease-out); }
   .history-clear-banner-actions { display:flex; gap:var(--space-control-gap); justify-content:flex-end; flex-wrap:wrap; }
-  .history-summary-surface { margin:0 0 var(--space-section-gap); padding:var(--space-card-padding); border-radius:var(--radius-sm); border:1px solid color-mix(in srgb, var(--mutedBlue) 16%, var(--border)); background:color-mix(in srgb, var(--surface-muted) 80%, white); display:grid; gap:var(--space-control-gap); }
-  .history-summary-grid { display:grid; grid-template-columns:repeat(3, minmax(0, 1fr)); gap:var(--space-control-gap); }
-  .history-summary-item { display:grid; gap:2px; min-width:0; }
-  .history-summary-value { font-size:var(--type-field-value-size); font-weight:var(--type-field-value-weight); line-height:var(--type-field-value-line); letter-spacing:var(--type-field-value-track); color:var(--brown); font-variant-numeric:tabular-nums; }
-  .history-summary-label { font-size:var(--type-helper-text-size); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); color:var(--text-muted); }
-  .history-summary-note { font-size:var(--type-helper-text-size); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); color:var(--brown-muted); }
+  .history-summary-surface { margin:0 0 var(--space-section-gap); padding:var(--space-card-padding); border-radius:var(--radius-sm); border:1px solid color-mix(in srgb, var(--mutedBlue) 16%, var(--border)); background:color-mix(in srgb, var(--surface-muted) 80%, white); display:grid; gap:var(--space-density-compact-control-gap); }
   .history-mini-trend { display:grid; gap:var(--space-density-compact-control-gap); }
-  .history-mini-trend-head { display:flex; justify-content:space-between; align-items:center; gap:var(--space-control-gap); font-size:var(--type-helper-text-size); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); color:var(--text-muted); }
-  .history-mini-trend-bars { height:56px; display:grid; grid-template-columns:repeat(7, minmax(0, 1fr)); gap:8px; align-items:end; }
-  .history-mini-trend-day { height:100%; display:grid; grid-template-rows:1fr auto; gap:4px; justify-items:center; align-items:end; min-width:0; }
-  .history-mini-trend-bar { width:100%; border-radius:999px; background:linear-gradient(180deg, color-mix(in srgb, var(--primaryBlue) 58%, white), color-mix(in srgb, var(--mutedBlue) 72%, var(--surface-muted))); min-height:12px; }
-  .history-mini-trend-bar--level-0 { height:12%; }
-  .history-mini-trend-bar--level-1 { height:30%; }
-  .history-mini-trend-bar--level-2 { height:50%; }
-  .history-mini-trend-bar--level-3 { height:74%; }
-  .history-mini-trend-bar--level-4 { height:100%; }
-  .history-mini-trend-day span { font-size:var(--type-micro-text-size); line-height:var(--type-micro-text-line); letter-spacing:var(--type-micro-text-track); color:var(--text-muted); text-transform:uppercase; }
-  .history-insights { display:flex; flex-wrap:wrap; gap:8px; }
-  .history-insight-pill { display:inline-flex; align-items:center; min-height:28px; padding:6px 10px; border-radius:999px; font-size:var(--type-helper-text-size); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); color:var(--brown-muted); background:color-mix(in srgb, var(--surface-muted) 90%, white); border:1px solid color-mix(in srgb, var(--mutedBlue) 18%, var(--border)); animation:softLiftIn var(--motion-slow) var(--ease-premium); }
+  .history-mini-trend-head { display:flex; align-items:center; gap:var(--space-control-gap); font-size:var(--type-helper-text-size); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); color:var(--text-muted); }
+  .history-mini-trend-dots { display:grid; grid-template-columns:repeat(7, minmax(0, 1fr)); gap:8px; }
+  .history-mini-trend-dot-wrap { display:grid; justify-items:center; gap:4px; }
+  .history-mini-trend-dot { width:10px; height:10px; border-radius:50%; background:color-mix(in srgb, var(--border) 90%, transparent); }
+  .history-mini-trend-dot.is-active { background:color-mix(in srgb, var(--mutedBlue) 72%, var(--primaryBlue)); }
+  .history-mini-trend-dot-wrap span { font-size:var(--type-micro-text-size); line-height:var(--type-micro-text-line); letter-spacing:var(--type-micro-text-track); color:var(--text-muted); text-transform:uppercase; }
   .history-day-group { display:grid; gap:var(--space-control-gap); margin-bottom:var(--space-section-gap); }
   .history-day-label { font-size:var(--type-overline-size); line-height:var(--type-overline-line); letter-spacing:var(--type-overline-track); font-weight:var(--type-overline-weight); text-transform:uppercase; color:var(--text-muted); }
   .history-day-track { position:relative; display:grid; gap:var(--space-density-compact-control-gap); }
-  .history-day-track::before { content:""; position:absolute; left:11px; top:2px; bottom:2px; width:2px; border-radius:999px; background:color-mix(in srgb, var(--border) 88%, transparent); }
+  .history-day-track::before { content:""; position:absolute; left:13px; top:4px; bottom:4px; width:2px; border-radius:999px; background:color-mix(in srgb, var(--border) 88%, transparent); }
   .section-title { font-size:var(--type-section-heading-size); font-weight:var(--type-section-heading-weight); color:var(--text); line-height:var(--type-section-heading-line); letter-spacing:var(--type-section-heading-track); margin:0; min-height:calc(var(--type-section-heading-line) * 1em); display:flex; align-items:baseline; }
   .section-title--flush { margin-bottom:0; }
   .empty-state { text-align:center; padding:var(--space-5) 28px; color:var(--text-muted); }
@@ -1485,33 +1474,25 @@
   .pat-edit-actions { display:flex; align-items:center; gap:var(--space-control-gap); flex-shrink:0; }
   .pat-edit-btn { border:none; background:none; cursor:pointer; color:var(--primaryBlue); text-decoration:underline; }
   .pat-edit-btn:hover { color:var(--blue-darker); }
-  .h-item { position:relative; margin:0; align-items:flex-start; animation:surfaceEnter var(--motion-enter) var(--ease-out); border:1px solid transparent; border-radius:var(--radius-sm); padding:10px 10px 10px 0; transition:background var(--motion-base) var(--ease-out), border-color var(--motion-base) var(--ease-out); }
+  .h-item { position:relative; margin:0; display:grid; grid-template-columns:28px minmax(0, 1fr); align-items:flex-start; animation:surfaceEnter var(--motion-enter) var(--ease-out); border:1px solid transparent; border-radius:var(--radius-sm); padding:10px 10px 10px 0; transition:background var(--motion-base) var(--ease-out), border-color var(--motion-base) var(--ease-out); }
   .h-item:hover { background:color-mix(in srgb, var(--surface-muted) 64%, white); }
   .h-item.is-tap-card { cursor:pointer; }
   .h-item:focus-visible { outline:none; border-color:color-mix(in srgb, var(--mutedBlue) 40%, var(--border)); background:color-mix(in srgb, var(--surface-muted) 70%, white); }
   .h-item.is-expanded { border-color:color-mix(in srgb, var(--mutedBlue) 24%, var(--border)); background:color-mix(in srgb, var(--surface-muted) 70%, white); }
-  .h-body { flex:1; min-width:0; display:flex; flex-direction:column; gap:var(--space-control-gap); }
-  .h-content { display:flex; align-items:flex-start; justify-content:space-between; gap:var(--space-control-gap); min-width:0; }
-  .h-marker { width:10px; height:10px; margin:8px 0 0 7px; border-radius:50%; background:color-mix(in srgb, var(--mutedBlue) 65%, white); box-shadow:0 0 0 3px color-mix(in srgb, var(--surface-muted) 86%, white); flex:0 0 auto; }
-  .h-info { flex:1; min-width:0; display:flex; flex-direction:column; gap:var(--row-gap-dense); padding-top:1px; }
-  .h-kind { font-size:var(--type-micro-text-size); font-weight:var(--type-overline-weight); line-height:var(--type-micro-text-line); letter-spacing:var(--type-overline-track); color:var(--text-muted); text-transform:uppercase; }
+  .h-rail { display:flex; justify-content:center; padding-top:8px; }
+  .h-body { min-width:0; display:flex; flex-direction:column; gap:6px; }
+  .h-marker { width:10px; height:10px; border-radius:50%; background:color-mix(in srgb, var(--mutedBlue) 65%, white); box-shadow:0 0 0 3px color-mix(in srgb, var(--surface-muted) 86%, white); }
   .h-main { font-size:var(--type-list-row-title-size); font-weight:var(--type-list-row-title-weight); line-height:var(--type-list-row-title-line); letter-spacing:var(--type-list-row-title-track); color:var(--brown); }
-  .h-meta-line { display:flex; flex-wrap:wrap; align-items:center; gap:8px; min-width:0; }
+  .h-meta-line { display:flex; flex-wrap:wrap; align-items:center; gap:6px; min-width:0; }
+  .h-duration, .h-meta-divider { font-size:var(--type-helper-text-size); font-weight:var(--type-helper-text-weight); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); color:var(--brown-muted); }
   .h-date { font-size:var(--type-helper-text-size); font-weight:var(--type-helper-text-weight); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); color:var(--text-muted); min-width:0; }
+  .h-status-row { display:flex; flex-wrap:wrap; align-items:center; gap:8px; }
   .h-sync-meta { display:inline-flex; align-items:center; gap:6px; font-size:var(--type-helper-text-size); font-weight:var(--type-helper-text-weight); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); color:var(--text-muted); }
   .h-sync-dot { width:6px; height:6px; border-radius:50%; background:currentColor; opacity:0.88; }
   .h-sync-local { color:var(--status-sync-local-fg); }
   .h-sync-syncing { color:var(--primaryBlue); }
   .h-sync-error { color:var(--red); }
-  .h-side { display:flex; flex-direction:column; align-items:flex-end; gap:var(--row-gap-dense); text-align:right; flex-shrink:0; min-width:fit-content; }
-  .h-value { font-size:var(--type-field-value-size); font-weight:var(--type-field-value-weight); line-height:var(--type-field-value-line); letter-spacing:var(--type-field-value-track); color:var(--brown); text-align:right; white-space:nowrap; font-variant-numeric:tabular-nums; }
-  .h-side-label,
-  .h-secondary { font-size:var(--type-helper-text-size); font-weight:var(--type-helper-text-weight); line-height:var(--type-helper-text-line); letter-spacing:var(--type-helper-text-track); color:var(--text-muted); }
-  .h-secondary { min-width:0; }
   .h-badge { font-size:var(--type-status-text-size); font-weight:var(--type-status-text-weight); line-height:var(--type-status-text-line); padding:var(--space-pill-padding-small); border-radius:99px; letter-spacing:var(--type-status-text-track); white-space:nowrap; flex-shrink:0; text-transform:uppercase; }
-  .h-expand { display:grid; gap:var(--space-control-gap); margin-top:var(--space-density-compact-control-gap); margin-left:24px; padding-top:var(--space-control-gap); border-top:1px solid var(--border); }
-  .h-expand-grid { display:grid; gap:var(--space-control-gap); }
-  .h-expand-footer { padding-top:2px; }
   .h-detail-group { display:grid; gap:var(--row-gap-default); }
   .h-detail-label { font-size:var(--type-overline-size); font-weight:var(--type-overline-weight); line-height:var(--type-overline-line); letter-spacing:var(--type-overline-track); text-transform:uppercase; color:var(--text-muted); }
   .h-detail-body { display:grid; gap:var(--row-gap-default); }
@@ -1531,10 +1512,6 @@
   .badge-feed   { background:var(--status-warning-bg); color:color-mix(in srgb, var(--warning) 72%, var(--brown)); }
   .badge-pat    { background:var(--status-neutral-bg); color:var(--brown-mid); }
   @media (max-width: 560px) {
-    .history-summary-grid { grid-template-columns:1fr; gap:var(--space-density-compact-control-gap); }
-    .h-content { flex-direction:column; align-items:flex-start; }
-    .h-marker { margin-left:8px; }
-    .h-side { align-items:flex-start; text-align:left; }
     .h-actions { justify-content:flex-start; }
   }
 


### PR DESCRIPTION
### Motivation
- Make the History screen minimal and more scannable by removing duplicate headers, numeric stats, and long insight blocks and keeping only a simple weekly rhythm and activity list.  
- Prevent the timeline vertical line from overlapping text by moving markers into a fixed left column and tightening the visual hierarchy.  
- Replace multiple per-item popups/expands with a single consistent bottom-sheet activity detail to simplify interactions and spacing.  

### Description
- Reworked `HistoryFeature.jsx` to remove numeric summary cards and insight generation and replace them with a minimal weekly rhythm label + 7-day dot strip.  
- Simplified timeline item rendering by introducing a compact `renderHistoryCard` signature that only shows `title`, `duration`, `date`, and `status`, and by replacing the previous expand-in-place behavior with a single `activityDetail` bottom-sheet state.  
- Moved timeline marker into a left rail (added `h-rail` markup) so the timeline vertical rule (`.history-day-track::before`) no longer overlaps text and each item has a dedicated left column.  
- Preserved edit/delete flows by routing actions through the existing editing helpers (`actions.*`) from the new bottom-sheet detail UI.  
- Removed unused chip/insight helpers from the active render path (deleted `HistoryChipList` usage and insight computation) to keep the screen minimal.  
- Updated styles in `src/styles/app.css` to support the new compact grid layout for `.h-item`, the left marker rail, the dot-based mini trend (`.history-mini-trend-dots` / `.history-mini-trend-dot`), and adjusted track offsets so the vertical rule is visually separated from text.  
- Files changed: `src/features/history/HistoryFeature.jsx`, `src/styles/app.css`.  

### Testing
- Built production assets with `npm run build`, which completed successfully.  
- Ran targeted tests with `npm run test -- tests/historyDurationEditing.test.js tests/sessionEditing.test.js` and all tests passed: 2 test files, 12 tests total (✅ passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e261772bb483329f081009b52ec67a)