### PR TITLE
Simplify Progress screen to a clear 3-block status view

### DIFF
--- a/src/features/stats/StatsScreen.jsx
+++ b/src/features/stats/StatsScreen.jsx
@@ -1,98 +1,47 @@
 import EmptyState from "../../components/EmptyState";
-import { METRIC_VARIANTS, ProgressHero, StatsChartSection, StatsInsightCard, StatsMetricCard, StatsSection, StatsSupportRow } from "./StatsComponents";
+import { StatsSection } from "./StatsComponents";
 import { fmt } from "../app/helpers";
 import { SproutIcon } from "../app/ui";
 
 export default function StatsScreen({ name, totalCount, setTab, bestCalm, recommendation, relapseTone, chartData, goalSec, chartTrendLabel, aloneLastWeek, avgWalkDuration, avgSessionsPerDay, avgWalksPerDay, headlineStatus, headlineStatusTone, contextualInsights = [] }) {
   const target = recommendation?.duration ?? 0;
-  const standardMetricVariant = METRIC_VARIANTS.STANDARD;
-  const ringMetricVariant = METRIC_VARIANTS.RING;
   const headlineSurfaceState = headlineStatusTone?.surfaceState || "today";
-  const riskSurfaceState = relapseTone?.surfaceState || "today";
-
-  const emotionalMomentum = chartTrendLabel || `${name} is building confidence, one rep at a time.`;
-  const progressDelta = Math.max(0, target - bestCalm);
-  const nextTargetLabel = progressDelta > 0
-    ? `Next step (+${fmt(progressDelta)})`
-    : "Step reached — hold this rhythm";
-  const heroHeadline = progressDelta <= 0
-    ? `${name} reached this milestone.`
-    : progressDelta <= 60
-      ? `${name} is one calm stretch from the next step.`
-      : `${name} is building calm confidence.`;
-  const cadenceLabel = avgSessionsPerDay != null
-    ? avgSessionsPerDay >= 1
-      ? `Strong cadence: ${avgSessionsPerDay.toFixed(1)} reps/day.`
-      : `Steady cadence: ${avgSessionsPerDay.toFixed(1)} reps/day.`
-    : "Cadence appears after a few reps.";
-  const walkSupportLabel = avgWalkDuration != null
-    ? `Walks average ${fmt(avgWalkDuration, { hoursMinutesOnly: true })}, supporting decompression between reps.`
-    : "Add decompression walks to support recovery between reps.";
+  const independenceGoalSeconds = goalSec > 0 ? goalSec : (target > 0 ? target : 40 * 60);
+  const progressPct = Math.max(0, Math.min(100, Math.round((bestCalm / independenceGoalSeconds) * 100)));
+  const nextSessionSeconds = target > 0 ? target : bestCalm;
 
   return (
-    <div className="tab-content stats-tab-content" data-ring-metric-variant={ringMetricVariant}>
+    <div className="tab-content stats-tab-content">
       <div className="section">
         {totalCount === 0 ? (
           <EmptyState media={<SproutIcon />} title="Progress starts here" body={`Log your first rep and ${name}&apos;s trend will appear here.`} ctaLabel="Go to Train →" onCta={() => setTab("home")} />
         ) : <>
           <StatsSection className="stats-section-hero stats-section-priority">
-            <ProgressHero
-              name={name}
-              headlineStatus={headlineStatus}
-              headline={heroHeadline}
-              headlineSurfaceState={headlineSurfaceState}
-              currentValue={fmt(bestCalm)}
-              currentLabel="Current calm-alone window"
-              currentSeconds={bestCalm}
-              targetValue={fmt(target)}
-              targetLabel={nextTargetLabel}
-              targetSeconds={target}
-              insight={emotionalMomentum}
-            />
-          </StatsSection>
-
-          <StatsSection title="What is shaping today&apos;s training" className="stats-section-signals">
-            <div className="stats-row stats-row-core stats-row-core-calm">
-              <StatsMetricCard
-                value={fmt(bestCalm)}
-                label="Best calm-alone window"
-                detail="Longest calm rep so far"
-                className="stat-card--key-metric"
-                variant={standardMetricVariant}
-              />
-              <StatsMetricCard
-                value={relapseTone.label}
-                label="Recovery pressure"
-                detail="How gently to pace the next rep"
-                className={`stat-card--key-metric stat-card-risk surface-state--${riskSurfaceState}`}
-                variant={standardMetricVariant}
-              />
+            <div
+              className={`stats-simple-hero metric-surface metric-surface--headline surface-state--${headlineSurfaceState}`.trim()}
+              aria-label="Current calm-alone progress"
+            >
+              <span className="stats-simple-status">{headlineStatus}</span>
+              <div className="stats-simple-duration">{fmt(bestCalm)}</div>
+              <div className="stats-simple-label">Current calm-alone duration</div>
             </div>
           </StatsSection>
 
-          <StatsSection title="Progress over time" className="stats-section-journey">
-            <StatsChartSection chartData={chartData} goalSec={goalSec} setTab={setTab} name={name} fmt={fmt} insightLabel={chartTrendLabel} />
+          <StatsSection title="Progress toward independence" className="stats-section-minimal">
+            <div className="stats-goal-progress metric-surface metric-surface--standard" aria-label={`${progressPct}% toward independence goal`}>
+              <div className="stats-goal-progress-topline">
+                <span>{progressPct}% to independence</span>
+                <span>{fmt(independenceGoalSeconds)} goal</span>
+              </div>
+              <div className="stats-goal-progress-track" aria-hidden="true">
+                <span className="stats-goal-progress-fill" style={{ width: `${Math.max(progressPct, 4)}%` }} />
+              </div>
+            </div>
           </StatsSection>
 
-          <StatsSection title="Context for your dog&apos;s progress" className="stats-section-supporting">
-            {contextualInsights.length > 0 ? (
-              <div className="stats-insight-stack" role="list" aria-label="Progress movement insights">
-                {contextualInsights.map((insight, index) => (
-                  <StatsInsightCard
-                    key={insight.id || `${insight.message}-${index}`}
-                    message={insight.message}
-                    detail={insight.detail}
-                    tone={insight.tone}
-                    index={index}
-                  />
-                ))}
-              </div>
-            ) : null}
-            <div className="stats-support-list stats-support-list--insights">
-              <StatsSupportRow label="Weekly practice time" value={fmt(aloneLastWeek)} />
-              <StatsSupportRow label="Session cadence" value={cadenceLabel} />
-              <StatsSupportRow label="Walk support" value={walkSupportLabel} />
-              <StatsSupportRow label="Daily walks" value={avgWalksPerDay != null ? `${avgWalksPerDay.toFixed(1)} walks/day` : "Tracking after more walk logs"} />
+          <StatsSection className="stats-section-minimal stats-section-next-step">
+            <div className="stats-next-step metric-surface metric-surface--standard" aria-live="polite">
+              Next session: {fmt(nextSessionSeconds)}
             </div>
           </StatsSection>
         </>}

--- a/src/features/stats/StatsScreen.jsx
+++ b/src/features/stats/StatsScreen.jsx
@@ -9,6 +9,21 @@ export default function StatsScreen({ name, totalCount, setTab, bestCalm, recomm
   const independenceGoalSeconds = goalSec > 0 ? goalSec : (target > 0 ? target : 40 * 60);
   const progressPct = Math.max(0, Math.min(100, Math.round((bestCalm / independenceGoalSeconds) * 100)));
   const nextSessionSeconds = target > 0 ? target : bestCalm;
+  const progressMessage = progressPct >= 100
+    ? "You reached your goal"
+    : progressPct >= 75
+      ? "You’re getting very close"
+      : progressPct >= 50
+        ? "You’re over halfway there"
+        : progressPct >= 25
+          ? "You’re building momentum"
+          : "You’ve started the path";
+  const insightLine = chartTrendLabel
+    || (progressPct >= 100
+      ? "Stable streak — your dog is learning consistency"
+      : progressPct >= 50
+        ? "Your sessions are getting longer"
+        : "Small calm wins are building confidence");
 
   return (
     <div className="tab-content stats-tab-content">
@@ -21,27 +36,30 @@ export default function StatsScreen({ name, totalCount, setTab, bestCalm, recomm
               className={`stats-simple-hero metric-surface metric-surface--headline surface-state--${headlineSurfaceState}`.trim()}
               aria-label="Current calm-alone progress"
             >
-              <span className="stats-simple-status">{headlineStatus}</span>
               <div className="stats-simple-duration">{fmt(bestCalm)}</div>
-              <div className="stats-simple-label">Current calm-alone duration</div>
+              <div className="stats-simple-label">Your dog can stay calm alone</div>
+              <span className="stats-simple-status">{headlineStatus}</span>
             </div>
           </StatsSection>
 
           <StatsSection title="Progress toward independence" className="stats-section-minimal">
             <div className="stats-goal-progress metric-surface metric-surface--standard" aria-label={`${progressPct}% toward independence goal`}>
               <div className="stats-goal-progress-topline">
-                <span>{progressPct}% to independence</span>
-                <span>{fmt(independenceGoalSeconds)} goal</span>
+                <span>{progressMessage}</span>
+                <span>{progressPct}%</span>
               </div>
               <div className="stats-goal-progress-track" aria-hidden="true">
                 <span className="stats-goal-progress-fill" style={{ width: `${Math.max(progressPct, 4)}%` }} />
               </div>
+              <div className="stats-goal-progress-meta">{fmt(bestCalm)} → {fmt(independenceGoalSeconds)} goal</div>
+              <div className="stats-goal-progress-insight">{insightLine}</div>
             </div>
           </StatsSection>
 
           <StatsSection className="stats-section-minimal stats-section-next-step">
             <div className="stats-next-step metric-surface metric-surface--standard" aria-live="polite">
-              Next session: {fmt(nextSessionSeconds)}
+              <span>Next session: {fmt(nextSessionSeconds)}</span>
+              <span className="stats-next-step-hint">Keep it slightly below your best</span>
             </div>
           </StatsSection>
         </>}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1899,6 +1899,7 @@
     font-weight:var(--type-helper-text-weight);
     color:var(--metric-surface-accent);
     text-transform:uppercase;
+    opacity:0.86;
   }
   .stats-simple-duration {
     font-family:var(--font-ui);
@@ -1918,7 +1919,7 @@
   }
   .stats-goal-progress {
     display:grid;
-    gap:10px;
+    gap:8px;
     padding:var(--space-inline-control-padding);
   }
   .stats-goal-progress-topline {
@@ -1930,6 +1931,20 @@
     line-height:var(--type-secondary-line);
     letter-spacing:var(--type-secondary-track);
     font-weight:var(--type-secondary-weight);
+    color:var(--text-muted);
+  }
+  .stats-goal-progress-meta {
+    font-size:var(--type-secondary-size);
+    line-height:var(--type-secondary-line);
+    letter-spacing:var(--type-secondary-track);
+    font-weight:var(--type-secondary-weight);
+    color:color-mix(in srgb, var(--text) 84%, var(--text-muted));
+  }
+  .stats-goal-progress-insight {
+    font-size:var(--type-helper-text-size);
+    line-height:var(--type-helper-text-line);
+    letter-spacing:var(--type-helper-text-track);
+    font-weight:var(--type-helper-text-weight);
     color:var(--text-muted);
   }
   .stats-goal-progress-track {
@@ -1948,12 +1963,21 @@
     background:color-mix(in srgb, var(--green-dark) 86%, var(--brown));
   }
   .stats-next-step {
+    display:grid;
+    gap:4px;
     padding:var(--space-inline-control-padding);
     font-size:var(--type-body-lg-size);
     line-height:var(--type-body-lg-line);
     letter-spacing:var(--type-body-lg-track);
     font-weight:var(--type-body-lg-weight);
     color:var(--brown);
+  }
+  .stats-next-step-hint {
+    font-size:var(--type-helper-text-size);
+    line-height:var(--type-helper-text-line);
+    letter-spacing:var(--type-helper-text-track);
+    font-weight:var(--type-helper-text-weight);
+    color:var(--text-muted);
   }
   .train-screen { padding-top:var(--space-3); }
   .train-screen .train-main { gap:var(--space-section-gap); }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1885,6 +1885,76 @@
   .tab-panel--forward { animation-name: tabSlideForward; }
   .tab-panel--backward { animation-name: tabSlideBackward; }
   .stats-tab-content { position:relative; }
+  .stats-section-minimal .stats-section-title { margin-bottom:10px; }
+  .stats-simple-hero {
+    display:grid;
+    gap:8px;
+    padding:clamp(16px, 3.5vw, 22px);
+  }
+  .stats-simple-status {
+    justify-self:start;
+    font-size:var(--type-helper-text-size);
+    line-height:var(--type-helper-text-line);
+    letter-spacing:var(--type-helper-text-track);
+    font-weight:var(--type-helper-text-weight);
+    color:var(--metric-surface-accent);
+    text-transform:uppercase;
+  }
+  .stats-simple-duration {
+    font-family:var(--font-ui);
+    font-size:var(--type-metric-headline-size);
+    line-height:var(--type-metric-headline-line);
+    letter-spacing:var(--type-metric-headline-track);
+    font-weight:var(--type-metric-headline-weight);
+    color:var(--brown);
+    font-variant-numeric:tabular-nums;
+  }
+  .stats-simple-label {
+    font-size:var(--type-metric-label-size);
+    line-height:var(--type-metric-label-line);
+    letter-spacing:var(--type-metric-label-track);
+    font-weight:var(--type-metric-label-weight);
+    color:var(--text-muted);
+  }
+  .stats-goal-progress {
+    display:grid;
+    gap:10px;
+    padding:var(--space-inline-control-padding);
+  }
+  .stats-goal-progress-topline {
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+    gap:var(--space-control-gap);
+    font-size:var(--type-secondary-size);
+    line-height:var(--type-secondary-line);
+    letter-spacing:var(--type-secondary-track);
+    font-weight:var(--type-secondary-weight);
+    color:var(--text-muted);
+  }
+  .stats-goal-progress-track {
+    position:relative;
+    width:100%;
+    height:10px;
+    border-radius:999px;
+    overflow:hidden;
+    background:color-mix(in srgb, var(--green-light) 20%, var(--surf));
+    border:1px solid color-mix(in srgb, var(--green-dark) 14%, transparent);
+  }
+  .stats-goal-progress-fill {
+    display:block;
+    height:100%;
+    border-radius:inherit;
+    background:color-mix(in srgb, var(--green-dark) 86%, var(--brown));
+  }
+  .stats-next-step {
+    padding:var(--space-inline-control-padding);
+    font-size:var(--type-body-lg-size);
+    line-height:var(--type-body-lg-line);
+    letter-spacing:var(--type-body-lg-track);
+    font-weight:var(--type-body-lg-weight);
+    color:var(--brown);
+  }
   .train-screen { padding-top:var(--space-3); }
   .train-screen .train-main { gap:var(--space-section-gap); }
   .train-screen .prog-section,


### PR DESCRIPTION
### Motivation
- The Progress screen was functioning like an analytics dashboard and created noise instead of answering the single question: “Am I getting closer to the goal of leaving my dog alone calmly?”.
- The intent of this change is to radically simplify the UI to a calm, emotional status screen that communicates progress in under three seconds.
- Non-essential metrics, explanation cards, multi-card blocks, and repeated trend labels were removed to reduce cognitive load and keep focus on a single decision.

### Description
- Reworked `src/features/stats/StatsScreen.jsx` to render only three core blocks: a dominant hero showing status and `Current calm-alone duration`, a single percent-based progress-to-goal bar, and one-line `Next session: X` text. 
- Removed rendering of the previous dashboard elements including the `ProgressHero` layout, chart section, `StatsInsightCard` stack, metric cards, and support rows by deleting their render paths and unused variables. 
- Introduced simple progress calculation with `independenceGoalSeconds` and `progressPct` and a `nextSessionSeconds` fallback to keep existing logic but present it minimally. 
- Added lightweight styles in `src/styles/app.css` for `.stats-simple-hero`, `.stats-goal-progress`, and `.stats-next-step` to keep the presentation calm, dominant, and uncluttered.

### Testing
- Built the production bundle with `npm run build` which completed successfully (Vite build completed and service worker assets generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2766cad548332870de51938cb5ba7)