### PR TITLE
Fix continuous journey curve rendering in Progress chart

### DIFF
--- a/src/features/stats/StatsComponents.jsx
+++ b/src/features/stats/StatsComponents.jsx
@@ -72,22 +72,57 @@ function normalizeContinuousChartData(chartData = []) {
   });
 }
 
-function buildSmoothPath(points = []) {
+function smoothChartValues(values = []) {
+  if (values.length <= 2) return values;
+
+  return values.map((value, index) => {
+    if (index === 0 || index === values.length - 1) return value;
+    const prev = values[index - 1];
+    const next = values[index + 1];
+    return ((prev * 0.2) + (value * 0.6) + (next * 0.2));
+  });
+}
+
+function buildMonotonePath(points = []) {
   if (!points.length) return "";
   if (points.length === 1) return `M ${points[0].x} ${points[0].y}`;
+  if (points.length === 2) return `M ${points[0].x} ${points[0].y} L ${points[1].x} ${points[1].y}`;
+
+  const slopes = [];
+  for (let i = 0; i < points.length - 1; i += 1) {
+    const dx = points[i + 1].x - points[i].x;
+    slopes.push(dx === 0 ? 0 : (points[i + 1].y - points[i].y) / dx);
+  }
+
+  const tangents = new Array(points.length).fill(0);
+  tangents[0] = slopes[0];
+  tangents[points.length - 1] = slopes.at(-1);
+
+  for (let i = 1; i < points.length - 1; i += 1) {
+    const previousSlope = slopes[i - 1];
+    const nextSlope = slopes[i];
+
+    if (previousSlope === 0 || nextSlope === 0 || previousSlope * nextSlope < 0) {
+      tangents[i] = 0;
+      continue;
+    }
+
+    const absPrev = Math.abs(previousSlope);
+    const absNext = Math.abs(nextSlope);
+    tangents[i] = ((Math.sign(previousSlope) + Math.sign(nextSlope))
+      * Math.min(absPrev, absNext, ((absPrev + absNext) / 2)));
+  }
 
   let path = `M ${points[0].x} ${points[0].y}`;
 
   for (let index = 0; index < points.length - 1; index += 1) {
-    const prev = points[index - 1] ?? points[index];
     const current = points[index];
     const next = points[index + 1];
-    const afterNext = points[index + 2] ?? next;
-
-    const c1x = current.x + ((next.x - prev.x) / 6);
-    const c1y = current.y + ((next.y - prev.y) / 6);
-    const c2x = next.x - ((afterNext.x - current.x) / 6);
-    const c2y = next.y - ((afterNext.y - current.y) / 6);
+    const dx = next.x - current.x;
+    const c1x = current.x + (dx / 3);
+    const c1y = current.y + ((tangents[index] * dx) / 3);
+    const c2x = next.x - (dx / 3);
+    const c2y = next.y - ((tangents[index + 1] * dx) / 3);
 
     path += ` C ${c1x} ${c1y}, ${c2x} ${c2y}, ${next.x} ${next.y}`;
   }
@@ -329,7 +364,8 @@ export function StatsChartSection({ chartData, goalSec, setTab, name, fmt, insig
   const hasGoal = Number.isFinite(goalSec) && goalSec > 0;
   const goalMinutes = hasGoal ? goalSec / 60 : null;
   const continuousChartData = normalizeContinuousChartData(chartData);
-  const values = continuousChartData.map((entry) => entry._continuousMinutes);
+  const rawValues = continuousChartData.map((entry) => entry._continuousMinutes);
+  const values = smoothChartValues(rawValues);
   const minY = Math.min(...values);
   const maxY = Math.max(...values);
   const range = Math.max(1, maxY - minY);
@@ -340,11 +376,11 @@ export function StatsChartSection({ chartData, goalSec, setTab, name, fmt, insig
   const points = continuousChartData.map((entry, index) => {
     const ratioX = continuousChartData.length === 1 ? 0 : index / (continuousChartData.length - 1);
     const x = WAVE_CHART_PADDING.left + (ratioX * chartWidth);
-    const y = chartBottom - ((entry._continuousMinutes - minY) / range) * (chartBottom - chartTop);
+    const y = chartBottom - ((values[index] - minY) / range) * (chartBottom - chartTop);
     return { x, y, entry, index };
   });
 
-  const wavePath = buildSmoothPath(points);
+  const wavePath = buildMonotonePath(points);
 
   const areaPath = `${wavePath} L ${points.at(-1).x} ${chartBottom} L ${points[0].x} ${chartBottom} Z`;
   const latestPoint = points.at(-1);

--- a/src/features/stats/StatsComponents.jsx
+++ b/src/features/stats/StatsComponents.jsx
@@ -11,6 +11,89 @@ export const METRIC_VARIANTS = Object.freeze({
 const WAVE_CHART_WIDTH = 720;
 const WAVE_CHART_HEIGHT = 220;
 const WAVE_CHART_PADDING = { top: 18, right: 20, bottom: 32, left: 20 };
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function toDayTimestamp(entry) {
+  const rawValue = entry?.dayKey ?? entry?.dateKey ?? entry?.date;
+  if (!rawValue) return null;
+  const parsed = new Date(rawValue);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate());
+}
+
+function normalizeContinuousChartData(chartData = []) {
+  if (!chartData.length) return [];
+
+  const normalized = chartData.map((entry, index) => ({
+    ...entry,
+    _sourceIndex: index,
+    _dayTs: toDayTimestamp(entry),
+  }));
+
+  const supportsDailyFill = normalized.every((entry) => Number.isFinite(entry._dayTs));
+  const baseSeries = (() => {
+    if (!supportsDailyFill) return normalized;
+
+    const byDay = new Map();
+    normalized.forEach((entry) => {
+      byDay.set(entry._dayTs, entry);
+    });
+
+    const startTs = normalized[0]._dayTs;
+    const endTs = normalized.at(-1)._dayTs;
+    const filled = [];
+    let carryEntry = normalized[0];
+
+    for (let dayTs = startTs; dayTs <= endTs; dayTs += DAY_MS) {
+      const directEntry = byDay.get(dayTs);
+      if (directEntry) {
+        carryEntry = directEntry;
+        filled.push(directEntry);
+      } else if (carryEntry) {
+        filled.push({
+          ...carryEntry,
+          _isInterpolated: true,
+          _dayTs: dayTs,
+        });
+      }
+    }
+
+    return filled;
+  })();
+
+  let lastKnownMinutes = null;
+  return baseSeries.map((entry) => {
+    const rawMinutes = Number(entry.durationMinutes);
+    const safeMinutes = Number.isFinite(rawMinutes)
+      ? rawMinutes
+      : (lastKnownMinutes ?? 0);
+    lastKnownMinutes = safeMinutes;
+    return { ...entry, _continuousMinutes: safeMinutes };
+  });
+}
+
+function buildSmoothPath(points = []) {
+  if (!points.length) return "";
+  if (points.length === 1) return `M ${points[0].x} ${points[0].y}`;
+
+  let path = `M ${points[0].x} ${points[0].y}`;
+
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const prev = points[index - 1] ?? points[index];
+    const current = points[index];
+    const next = points[index + 1];
+    const afterNext = points[index + 2] ?? next;
+
+    const c1x = current.x + ((next.x - prev.x) / 6);
+    const c1y = current.y + ((next.y - prev.y) / 6);
+    const c2x = next.x - ((afterNext.x - current.x) / 6);
+    const c2y = next.y - ((afterNext.y - current.y) / 6);
+
+    path += ` C ${c1x} ${c1y}, ${c2x} ${c2y}, ${next.x} ${next.y}`;
+  }
+
+  return path;
+}
 
 function useAnimatedValue(value, { duration = 180, round = false } = {}) {
   const [displayValue, setDisplayValue] = useState(value);
@@ -245,7 +328,8 @@ export function StatsChartSection({ chartData, goalSec, setTab, name, fmt, insig
   const areaGradientId = useId();
   const hasGoal = Number.isFinite(goalSec) && goalSec > 0;
   const goalMinutes = hasGoal ? goalSec / 60 : null;
-  const values = chartData.map((entry) => Number(entry.durationMinutes) || 0);
+  const continuousChartData = normalizeContinuousChartData(chartData);
+  const values = continuousChartData.map((entry) => entry._continuousMinutes);
   const minY = Math.min(...values);
   const maxY = Math.max(...values);
   const range = Math.max(1, maxY - minY);
@@ -253,19 +337,14 @@ export function StatsChartSection({ chartData, goalSec, setTab, name, fmt, insig
   const chartTop = WAVE_CHART_PADDING.top;
   const chartWidth = WAVE_CHART_WIDTH - WAVE_CHART_PADDING.left - WAVE_CHART_PADDING.right;
 
-  const points = chartData.map((entry, index) => {
-    const ratioX = chartData.length === 1 ? 0 : index / (chartData.length - 1);
+  const points = continuousChartData.map((entry, index) => {
+    const ratioX = continuousChartData.length === 1 ? 0 : index / (continuousChartData.length - 1);
     const x = WAVE_CHART_PADDING.left + (ratioX * chartWidth);
-    const y = chartBottom - (((Number(entry.durationMinutes) || 0) - minY) / range) * (chartBottom - chartTop);
+    const y = chartBottom - ((entry._continuousMinutes - minY) / range) * (chartBottom - chartTop);
     return { x, y, entry, index };
   });
 
-  const wavePath = points.reduce((acc, point, index) => {
-    if (index === 0) return `M ${point.x} ${point.y}`;
-    const previousPoint = points[index - 1];
-    const midX = (previousPoint.x + point.x) / 2;
-    return `${acc} Q ${previousPoint.x} ${previousPoint.y} ${midX} ${((previousPoint.y + point.y) / 2)} T ${point.x} ${point.y}`;
-  }, "");
+  const wavePath = buildSmoothPath(points);
 
   const areaPath = `${wavePath} L ${points.at(-1).x} ${chartBottom} L ${points[0].x} ${chartBottom} Z`;
   const latestPoint = points.at(-1);

--- a/src/features/stats/StatsComponents.jsx
+++ b/src/features/stats/StatsComponents.jsx
@@ -11,12 +11,27 @@ export const METRIC_VARIANTS = Object.freeze({
 const WAVE_CHART_WIDTH = 720;
 const WAVE_CHART_HEIGHT = 220;
 const WAVE_CHART_PADDING = { top: 18, right: 20, bottom: 32, left: 20 };
-function buildLinearPath(points = []) {
+function buildSmoothPathThroughPoints(points = [], tension = 0.18) {
   if (!points.length) return "";
   if (points.length === 1) return `M ${points[0].x} ${points[0].y}`;
-  return points.reduce((path, point, index) => (
-    index === 0 ? `M ${point.x} ${point.y}` : `${path} L ${point.x} ${point.y}`
-  ), "");
+
+  let path = `M ${points[0].x} ${points[0].y}`;
+
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const previous = points[index - 1] ?? points[index];
+    const current = points[index];
+    const next = points[index + 1];
+    const afterNext = points[index + 2] ?? next;
+
+    const c1x = current.x + ((next.x - previous.x) * tension);
+    const c1y = current.y + ((next.y - previous.y) * tension);
+    const c2x = next.x - ((afterNext.x - current.x) * tension);
+    const c2y = next.y - ((afterNext.y - current.y) * tension);
+
+    path += ` C ${c1x} ${c1y}, ${c2x} ${c2y}, ${next.x} ${next.y}`;
+  }
+
+  return path;
 }
 
 function useAnimatedValue(value, { duration = 180, round = false } = {}) {
@@ -248,7 +263,6 @@ export function StatsChartSection({ chartData, goalSec, setTab, name, fmt, insig
     );
   }
 
-  const gradientId = useId();
   const areaGradientId = useId();
   const hasGoal = Number.isFinite(goalSec) && goalSec > 0;
   const goalMinutes = hasGoal ? goalSec / 60 : null;
@@ -279,7 +293,7 @@ export function StatsChartSection({ chartData, goalSec, setTab, name, fmt, insig
     return { x, y, entry, index };
   });
 
-  const wavePath = buildLinearPath(points);
+  const wavePath = buildSmoothPathThroughPoints(points);
 
   const areaPath = `${wavePath} L ${points.at(-1).x} ${chartBottom} L ${points[0].x} ${chartBottom} Z`;
   const latestPoint = points.at(-1);
@@ -296,10 +310,6 @@ export function StatsChartSection({ chartData, goalSec, setTab, name, fmt, insig
       <div className="stats-progress-wave" role="img" aria-label={`${name}'s recent session durations`}>
         <svg viewBox={`0 0 ${WAVE_CHART_WIDTH} ${WAVE_CHART_HEIGHT}`} className="stats-progress-wave-svg" preserveAspectRatio="none">
           <defs>
-            <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="0%">
-              <stop offset="0%" stopColor="color-mix(in srgb, var(--brown) 82%, var(--green-dark))" />
-              <stop offset="100%" stopColor="var(--green-dark)" />
-            </linearGradient>
             <linearGradient id={areaGradientId} x1="0%" y1="0%" x2="0%" y2="100%">
               <stop offset="0%" stopColor="color-mix(in srgb, var(--green-light) 30%, transparent)" />
               <stop offset="100%" stopColor="transparent" />
@@ -323,16 +333,22 @@ export function StatsChartSection({ chartData, goalSec, setTab, name, fmt, insig
             />
           ) : null}
 
-          <path d={areaPath} fill={`url(#${areaGradientId})`} className="stats-progress-wave-area" />
-          <path d={wavePath} fill="none" stroke={`url(#${gradientId})`} className="stats-progress-wave-line" />
+          <path d={areaPath} fill={`url(#${areaGradientId})`} opacity="0.45" />
+          <path
+            d={wavePath}
+            fill="none"
+            stroke="var(--green-dark)"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
           {points.map((point) => (
             <circle
               key={`point-${point.index}`}
               cx={point.x}
               cy={point.y}
-              r="2.2"
+              r="2.4"
               fill="var(--green-dark)"
-              opacity="0.75"
             />
           ))}
 

--- a/src/features/stats/StatsComponents.jsx
+++ b/src/features/stats/StatsComponents.jsx
@@ -11,123 +11,12 @@ export const METRIC_VARIANTS = Object.freeze({
 const WAVE_CHART_WIDTH = 720;
 const WAVE_CHART_HEIGHT = 220;
 const WAVE_CHART_PADDING = { top: 18, right: 20, bottom: 32, left: 20 };
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-function toDayTimestamp(entry) {
-  const rawValue = entry?.dayKey ?? entry?.dateKey ?? entry?.date;
-  if (!rawValue) return null;
-  const parsed = new Date(rawValue);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate());
-}
-
-function normalizeContinuousChartData(chartData = []) {
-  if (!chartData.length) return [];
-
-  const normalized = chartData.map((entry, index) => ({
-    ...entry,
-    _sourceIndex: index,
-    _dayTs: toDayTimestamp(entry),
-  }));
-
-  const supportsDailyFill = normalized.every((entry) => Number.isFinite(entry._dayTs));
-  const baseSeries = (() => {
-    if (!supportsDailyFill) return normalized;
-
-    const byDay = new Map();
-    normalized.forEach((entry) => {
-      byDay.set(entry._dayTs, entry);
-    });
-
-    const startTs = normalized[0]._dayTs;
-    const endTs = normalized.at(-1)._dayTs;
-    const filled = [];
-    let carryEntry = normalized[0];
-
-    for (let dayTs = startTs; dayTs <= endTs; dayTs += DAY_MS) {
-      const directEntry = byDay.get(dayTs);
-      if (directEntry) {
-        carryEntry = directEntry;
-        filled.push(directEntry);
-      } else if (carryEntry) {
-        filled.push({
-          ...carryEntry,
-          _isInterpolated: true,
-          _dayTs: dayTs,
-        });
-      }
-    }
-
-    return filled;
-  })();
-
-  let lastKnownMinutes = null;
-  return baseSeries.map((entry) => {
-    const rawMinutes = Number(entry.durationMinutes);
-    const safeMinutes = Number.isFinite(rawMinutes)
-      ? rawMinutes
-      : (lastKnownMinutes ?? 0);
-    lastKnownMinutes = safeMinutes;
-    return { ...entry, _continuousMinutes: safeMinutes };
-  });
-}
-
-function smoothChartValues(values = []) {
-  if (values.length <= 2) return values;
-
-  return values.map((value, index) => {
-    if (index === 0 || index === values.length - 1) return value;
-    const prev = values[index - 1];
-    const next = values[index + 1];
-    return ((prev * 0.2) + (value * 0.6) + (next * 0.2));
-  });
-}
-
-function buildMonotonePath(points = []) {
+function buildLinearPath(points = []) {
   if (!points.length) return "";
   if (points.length === 1) return `M ${points[0].x} ${points[0].y}`;
-  if (points.length === 2) return `M ${points[0].x} ${points[0].y} L ${points[1].x} ${points[1].y}`;
-
-  const slopes = [];
-  for (let i = 0; i < points.length - 1; i += 1) {
-    const dx = points[i + 1].x - points[i].x;
-    slopes.push(dx === 0 ? 0 : (points[i + 1].y - points[i].y) / dx);
-  }
-
-  const tangents = new Array(points.length).fill(0);
-  tangents[0] = slopes[0];
-  tangents[points.length - 1] = slopes.at(-1);
-
-  for (let i = 1; i < points.length - 1; i += 1) {
-    const previousSlope = slopes[i - 1];
-    const nextSlope = slopes[i];
-
-    if (previousSlope === 0 || nextSlope === 0 || previousSlope * nextSlope < 0) {
-      tangents[i] = 0;
-      continue;
-    }
-
-    const absPrev = Math.abs(previousSlope);
-    const absNext = Math.abs(nextSlope);
-    tangents[i] = ((Math.sign(previousSlope) + Math.sign(nextSlope))
-      * Math.min(absPrev, absNext, ((absPrev + absNext) / 2)));
-  }
-
-  let path = `M ${points[0].x} ${points[0].y}`;
-
-  for (let index = 0; index < points.length - 1; index += 1) {
-    const current = points[index];
-    const next = points[index + 1];
-    const dx = next.x - current.x;
-    const c1x = current.x + (dx / 3);
-    const c1y = current.y + ((tangents[index] * dx) / 3);
-    const c2x = next.x - (dx / 3);
-    const c2y = next.y - ((tangents[index + 1] * dx) / 3);
-
-    path += ` C ${c1x} ${c1y}, ${c2x} ${c2y}, ${next.x} ${next.y}`;
-  }
-
-  return path;
+  return points.reduce((path, point, index) => (
+    index === 0 ? `M ${point.x} ${point.y}` : `${path} L ${point.x} ${point.y}`
+  ), "");
 }
 
 function useAnimatedValue(value, { duration = 180, round = false } = {}) {
@@ -363,9 +252,19 @@ export function StatsChartSection({ chartData, goalSec, setTab, name, fmt, insig
   const areaGradientId = useId();
   const hasGoal = Number.isFinite(goalSec) && goalSec > 0;
   const goalMinutes = hasGoal ? goalSec / 60 : null;
-  const continuousChartData = normalizeContinuousChartData(chartData);
-  const rawValues = continuousChartData.map((entry) => entry._continuousMinutes);
-  const values = smoothChartValues(rawValues);
+  const renderableChartData = chartData.filter((entry) => Number.isFinite(Number(entry.durationMinutes)));
+  if (renderableChartData.length <= 1) {
+    return (
+      <EmptyState
+        media={<TrendIcon />}
+        title="Almost there"
+        body={`Complete 2 more reps to see ${name}'s progress chart.`}
+        ctaLabel="Start training →"
+        onCta={() => setTab("home")}
+      />
+    );
+  }
+  const values = renderableChartData.map((entry) => Number(entry.durationMinutes));
   const minY = Math.min(...values);
   const maxY = Math.max(...values);
   const range = Math.max(1, maxY - minY);
@@ -373,14 +272,14 @@ export function StatsChartSection({ chartData, goalSec, setTab, name, fmt, insig
   const chartTop = WAVE_CHART_PADDING.top;
   const chartWidth = WAVE_CHART_WIDTH - WAVE_CHART_PADDING.left - WAVE_CHART_PADDING.right;
 
-  const points = continuousChartData.map((entry, index) => {
-    const ratioX = continuousChartData.length === 1 ? 0 : index / (continuousChartData.length - 1);
+  const points = renderableChartData.map((entry, index) => {
+    const ratioX = renderableChartData.length === 1 ? 0 : index / (renderableChartData.length - 1);
     const x = WAVE_CHART_PADDING.left + (ratioX * chartWidth);
     const y = chartBottom - ((values[index] - minY) / range) * (chartBottom - chartTop);
     return { x, y, entry, index };
   });
 
-  const wavePath = buildMonotonePath(points);
+  const wavePath = buildLinearPath(points);
 
   const areaPath = `${wavePath} L ${points.at(-1).x} ${chartBottom} L ${points[0].x} ${chartBottom} Z`;
   const latestPoint = points.at(-1);
@@ -426,6 +325,16 @@ export function StatsChartSection({ chartData, goalSec, setTab, name, fmt, insig
 
           <path d={areaPath} fill={`url(#${areaGradientId})`} className="stats-progress-wave-area" />
           <path d={wavePath} fill="none" stroke={`url(#${gradientId})`} className="stats-progress-wave-line" />
+          {points.map((point) => (
+            <circle
+              key={`point-${point.index}`}
+              cx={point.x}
+              cy={point.y}
+              r="2.2"
+              fill="var(--green-dark)"
+              opacity="0.75"
+            />
+          ))}
 
           {latestPoint ? (
             <g transform={`translate(${latestPoint.x} ${latestPoint.y})`} className="stats-progress-wave-latest">


### PR DESCRIPTION
### Motivation
- The Journey curve in the Progress screen rendered as disconnected segments when days or point values were missing, producing visual gaps instead of a continuous timeline.
- The UX requirement is a single continuous, smooth stroke connecting all data points and carrying forward the last known value for missing days without altering progress calculations.

### Description
- Added `normalizeContinuousChartData`, `toDayTimestamp`, and a daily carry-forward fill to produce a continuous plotting series when date metadata is available in `src/features/stats/StatsComponents.jsx`.
- Replaced the previous segmented quadratic path builder with `buildSmoothPath`, a single smooth cubic path generator, and wired the chart to use the normalized continuous series for plotting so the line is one continuous stroke.
- Kept all progression and data calculation logic unchanged and limited changes to rendering: the chart now interpolates missing days by carrying the last known value and only affects the SVG path generation.

### Testing
- Ran `npm run test -- tests/progressInsights.test.js` and the test file passed (2 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea69994d248332a53d04588f7e1836)