### PR TITLE
Center all app modals in viewport via shared portal

### DIFF
--- a/src/features/app/ui.jsx
+++ b/src/features/app/ui.jsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { createPortal } from "react-dom";
 
 // ─── Embedded icon data URIs (base64, 64×64px, rounded corners) ─────────────
 export const ICONS = {
@@ -30,6 +31,48 @@ export const ModalCloseButton = ({ onClick, label = "Close dialog" }) => (
     <span aria-hidden="true">×</span>
   </button>
 );
+
+export const ViewportModal = ({
+  open = false,
+  onClose,
+  overlayClassName = "",
+  panelClassName = "",
+  role = "dialog",
+  ariaModal = true,
+  labelledBy,
+  describedBy,
+  children,
+}) => {
+  useEffect(() => {
+    if (!open) return undefined;
+    const onEscape = (event) => {
+      if (event.key === "Escape") onClose?.();
+    };
+    window.addEventListener("keydown", onEscape);
+    return () => window.removeEventListener("keydown", onEscape);
+  }, [open, onClose]);
+
+  if (!open || typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      className={`quick-modal-overlay viewport-modal-overlay ${overlayClassName}`.trim()}
+      role={role}
+      aria-modal={ariaModal}
+      aria-labelledby={labelledBy}
+      aria-describedby={describedBy}
+      onClick={() => onClose?.()}
+    >
+      <div
+        className={`viewport-modal-panel ${panelClassName}`.trim()}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+};
 const SvgIcon = ({ children, strokeWidth = 1.9, className = "" }) => (
   <svg
     className={className}

--- a/src/features/history/HistoryFeature.jsx
+++ b/src/features/history/HistoryFeature.jsx
@@ -4,7 +4,7 @@ import { InlineBanner } from "../../components/primitives";
 import { buildEditedActivityIso, sortByDateAsc, toDateInputValue, toTimeInputValue } from "../../lib/activityDateTime";
 import { normalizeDistressLevel } from "../../lib/protocol";
 import { PATTERN_TYPES, fmt, fmtDate, parseDurationInput, walkTypeLabel } from "../app/helpers";
-import { ClockIcon, DeleteIcon, EditIcon, ModalCloseButton, TrendIcon } from "../app/ui";
+import { ClockIcon, DeleteIcon, EditIcon, ModalCloseButton, TrendIcon, ViewportModal } from "../app/ui";
 import { logSyncDebug, mergeSessionWithDerivedFields, normalizeSession } from "../app/storage";
 
 function HistoryActionGroup({ actions }) {
@@ -548,8 +548,8 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
       </div>
 
       {historyModal && (
-        <div className="activity-time-overlay quick-modal-overlay--sheet" role="dialog" aria-modal="true" aria-labelledby="history-modal-title" onClick={() => setHistoryModal(null)}>
-          <div className="activity-time-card history-modal-card modal-card modal-card--dialog-sm modal-card--sheet" onClick={(e) => e.stopPropagation()}>
+        <ViewportModal open onClose={() => setHistoryModal(null)} overlayClassName="activity-time-overlay" labelledBy="history-modal-title">
+          <div className="activity-time-card history-modal-card modal-card modal-card--dialog-sm modal-card--sheet">
             <div className="history-session-sheet-grabber" aria-hidden="true" />
             <div className="quick-modal-head">
               <div className="section-title section-title--flush" id="history-modal-title">
@@ -602,18 +602,17 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
               </div>
             </>}
           </div>
-        </div>
+        </ViewportModal>
       )}
 
       {activityDetail && (
-        <div
-          className="history-session-sheet-overlay"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="history-session-sheet-title"
-          onClick={() => setActivityDetail(null)}
+        <ViewportModal
+          open
+          onClose={() => setActivityDetail(null)}
+          overlayClassName="history-session-sheet-overlay"
+          labelledBy="history-session-sheet-title"
         >
-          <div className="history-session-sheet modal-card modal-card--dialog-md modal-card--sheet" onClick={(event) => event.stopPropagation()}>
+          <div className="history-session-sheet modal-card modal-card--dialog-md modal-card--sheet">
             <div className="history-session-sheet-grabber" aria-hidden="true" />
             <div className="quick-modal-head">
               <div className="section-title section-title--flush" id="history-session-sheet-title">Activity details</div>
@@ -669,7 +668,7 @@ export function HistoryScreen({ timeline, sessions, name, setTab, patLabels, his
               />
             </HistoryDetailGroup>
           </div>
-        </div>
+        </ViewportModal>
       )}
     </>
   );

--- a/src/features/home/HomeScreen.jsx
+++ b/src/features/home/HomeScreen.jsx
@@ -1,6 +1,6 @@
 import { SessionControl, SessionRatingPanel } from "../train/TrainComponents";
 import { DISTRESS_TYPES, PATTERN_TYPES, WALK_TYPE_OPTIONS, fmt, fmtClock, isToday, walkTypeLabel } from "../app/helpers";
-import { Img, ModalCloseButton } from "../app/ui";
+import { Img, ModalCloseButton, ViewportModal } from "../app/ui";
 import { useState } from "react";
 
 export default function HomeScreen(props) {
@@ -161,8 +161,8 @@ export default function HomeScreen(props) {
         </section>
 
         {(walkPhase !== "idle" || patOpen) && (
-          <div className="quick-modal-overlay quick-modal-overlay--sheet" role="dialog" aria-modal="true" onClick={() => { if (walkPhase !== "idle") cancelWalk(); if (patOpen) setPatOpen(false); }}>
-            <div className="quick-modal-card modal-card modal-card--dialog-md modal-card--sheet quick-modal-card--sheet" onClick={(e) => e.stopPropagation()}>
+          <ViewportModal open onClose={() => { if (walkPhase !== "idle") cancelWalk(); if (patOpen) setPatOpen(false); }}>
+            <div className="quick-modal-card modal-card modal-card--dialog-md modal-card--sheet quick-modal-card--sheet">
               <div className="history-session-sheet-grabber" aria-hidden="true" />
               <div className="quick-modal-head">
                 <div className="quick-modal-title">{walkPhase !== "idle" ? "Log walk" : "Log pattern break"}</div>
@@ -215,12 +215,12 @@ export default function HomeScreen(props) {
                 </div>
               )}
             </div>
-          </div>
+          </ViewportModal>
         )}
 
         {feedingOpen && (
-          <div className="feeding-overlay quick-modal-overlay--sheet" role="dialog" aria-modal="true" aria-labelledby="feeding-title" onClick={cancelFeedingForm}>
-            <div className="feeding-card modal-card modal-card--dialog-sm modal-card--sheet quick-modal-card--sheet quick-modal-card--sheet-compact" onClick={(e) => e.stopPropagation()}>
+          <ViewportModal open onClose={cancelFeedingForm} overlayClassName="feeding-overlay" labelledBy="feeding-title">
+            <div className="feeding-card modal-card modal-card--dialog-sm modal-card--sheet quick-modal-card--sheet quick-modal-card--sheet-compact">
               <div className="history-session-sheet-grabber" aria-hidden="true" />
               <div className="quick-modal-head">
                 <div className="section-title section-title--flush" id="feeding-title">Log feeding</div>
@@ -254,7 +254,7 @@ export default function HomeScreen(props) {
                 <button className="walk-end-btn button-base button-primary button--md button--pill" type="button" onClick={saveFeeding}>Save</button>
               </div>
             </div>
-          </div>
+          </ViewportModal>
         )}
       </div>
     </div>

--- a/src/features/settings/SettingsScreen.jsx
+++ b/src/features/settings/SettingsScreen.jsx
@@ -1,5 +1,5 @@
 import { PATTERN_TYPES } from "../app/helpers";
-import { DeleteIcon, ModalCloseButton } from "../app/ui";
+import { DeleteIcon, ModalCloseButton, ViewportModal } from "../app/ui";
 import { useState } from "react";
 
 const SETTINGS_PANEL = {
@@ -121,8 +121,8 @@ export default function SettingsScreen(props) {
       </div>
 
       {activePanel === SETTINGS_PANEL.PROFILE && (
-        <div className="quick-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="settings-profile-title" onClick={() => setActivePanel(null)}>
-          <div className="quick-modal-card modal-card modal-card--dialog-md" onClick={(e) => e.stopPropagation()}>
+        <ViewportModal open onClose={() => setActivePanel(null)} labelledBy="settings-profile-title">
+          <div className="quick-modal-card modal-card modal-card--dialog-md">
             <div className="quick-modal-head">
               <div className="quick-modal-title" id="settings-profile-title">Dog profile</div>
               <ModalCloseButton onClick={() => setActivePanel(null)} />
@@ -144,12 +144,12 @@ export default function SettingsScreen(props) {
               </div>
             </div>
           </div>
-        </div>
+        </ViewportModal>
       )}
 
       {activePanel === SETTINGS_PANEL.REMINDERS && (
-        <div className="quick-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="settings-reminders-title" onClick={() => setActivePanel(null)}>
-          <div className="quick-modal-card modal-card modal-card--dialog-md" onClick={(e) => e.stopPropagation()}>
+        <ViewportModal open onClose={() => setActivePanel(null)} labelledBy="settings-reminders-title">
+          <div className="quick-modal-card modal-card modal-card--dialog-md">
             <div className="quick-modal-head">
               <div className="quick-modal-title" id="settings-reminders-title">Reminders</div>
               <ModalCloseButton onClick={() => setActivePanel(null)} />
@@ -182,12 +182,12 @@ export default function SettingsScreen(props) {
               )}
             </div>
           </div>
-        </div>
+        </ViewportModal>
       )}
 
       {activePanel === SETTINGS_PANEL.LABELS && (
-        <div className="quick-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="settings-labels-title" onClick={() => setActivePanel(null)}>
-          <div className="quick-modal-card modal-card modal-card--dialog-md" onClick={(e) => e.stopPropagation()}>
+        <ViewportModal open onClose={() => setActivePanel(null)} labelledBy="settings-labels-title">
+          <div className="quick-modal-card modal-card modal-card--dialog-md">
             <div className="quick-modal-head">
               <div className="quick-modal-title" id="settings-labels-title">Custom labels</div>
               <ModalCloseButton onClick={() => setActivePanel(null)} />
@@ -208,12 +208,12 @@ export default function SettingsScreen(props) {
               ))}
             </div>
           </div>
-        </div>
+        </ViewportModal>
       )}
 
       {activePanel === SETTINGS_PANEL.HELP && (
-        <div className="quick-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="settings-help-title" onClick={() => setActivePanel(null)}>
-          <div className="quick-modal-card modal-card modal-card--dialog-md" onClick={(e) => e.stopPropagation()}>
+        <ViewportModal open onClose={() => setActivePanel(null)} labelledBy="settings-help-title">
+          <div className="quick-modal-card modal-card modal-card--dialog-md">
             <div className="quick-modal-head">
               <div className="quick-modal-title" id="settings-help-title">Help</div>
               <ModalCloseButton onClick={() => setActivePanel(null)} />
@@ -227,12 +227,12 @@ export default function SettingsScreen(props) {
               <div className="proto-section"><div className="proto-title">Daily rhythm</div><div className="proto-row">Aim for up to {activeProto.sessionsPerDayMax} sessions, {activeProto.maxDailyAloneMinutes} min/day, and {pattern.recMin}–{pattern.recMax} pattern breaks.</div></div>
             </div>
           </div>
-        </div>
+        </ViewportModal>
       )}
 
       {activePanel === SETTINGS_PANEL.ADVANCED && (
-        <div className="quick-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="settings-advanced-title" onClick={() => setActivePanel(null)}>
-          <div className="quick-modal-card modal-card modal-card--dialog-md" onClick={(e) => e.stopPropagation()}>
+        <ViewportModal open onClose={() => setActivePanel(null)} labelledBy="settings-advanced-title">
+          <div className="quick-modal-card modal-card modal-card--dialog-md">
             <div className="quick-modal-head">
               <div className="quick-modal-title" id="settings-advanced-title">Advanced</div>
               <ModalCloseButton onClick={() => setActivePanel(null)} />
@@ -280,12 +280,12 @@ export default function SettingsScreen(props) {
               {diagDetailsOpen && syncDiagResult && <div className="settings-advanced-group settings-advanced-group--technical"><div className={`diag-summary ${syncDiagResult.checks?.summary?.ok ? "ok" : "err"}`}>{syncDiagResult.checks?.summary?.ok ? "All checks passed" : "Some checks failed"}</div><pre className="diag-json">{JSON.stringify(syncDiagResult, null, 2)}</pre></div>}
             </div>
           </div>
-        </div>
+        </ViewportModal>
       )}
 
       {activePanel === SETTINGS_PANEL.ACCOUNT && (
-        <div className="quick-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="settings-account-title" onClick={() => setActivePanel(null)}>
-          <div className="quick-modal-card modal-card modal-card--dialog-md" onClick={(e) => e.stopPropagation()}>
+        <ViewportModal open onClose={() => setActivePanel(null)} labelledBy="settings-account-title">
+          <div className="quick-modal-card modal-card modal-card--dialog-md">
             <div className="quick-modal-head">
               <div className="quick-modal-title" id="settings-account-title">Account</div>
               <ModalCloseButton onClick={() => setActivePanel(null)} />
@@ -307,12 +307,12 @@ export default function SettingsScreen(props) {
               </button>
             </div>
           </div>
-        </div>
+        </ViewportModal>
       )}
 
       {trainingSettingsOpen && (
-        <div className="quick-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="training-settings-title" onClick={() => setTrainingSettingsOpen(false)}>
-          <div className="quick-modal-card modal-card modal-card--dialog-md" onClick={(e) => e.stopPropagation()}>
+        <ViewportModal open onClose={() => setTrainingSettingsOpen(false)} labelledBy="training-settings-title">
+          <div className="quick-modal-card modal-card modal-card--dialog-md">
             <div className="quick-modal-head">
               <div className="quick-modal-title" id="training-settings-title">Edit training plan</div>
               <ModalCloseButton onClick={() => setTrainingSettingsOpen(false)} />
@@ -345,7 +345,7 @@ export default function SettingsScreen(props) {
               </div>
             )}
           </div>
-        </div>
+        </ViewportModal>
       )}
     </>
   );

--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { ViewportModal } from "../app/ui";
 
 function SessionActionRow({ onEnd, onCancel }) {
   return (
@@ -132,8 +133,8 @@ export function SessionRatingPanel({
   if (phase !== "rating") return null;
 
   return (
-    <div className="rating-overlay" role="presentation">
-      <div className="rating-screen session-feedback modal-card modal-card--dialog-md" role="dialog" aria-modal="true" aria-labelledby="session-rating-title">
+    <ViewportModal open onClose={onCancel} overlayClassName="rating-overlay" labelledBy="session-rating-title">
+      <div className="rating-screen session-feedback modal-card modal-card--dialog-md">
         <div className="rating-scroll-body">
           <div className="rating-title" id="session-rating-title">Was there any stress?</div>
           <div className="rating-sub">
@@ -198,6 +199,6 @@ export function SessionRatingPanel({
           )}
         </div>
       </div>
-    </div>
+    </ViewportModal>
   );
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1154,6 +1154,26 @@
   .tool-expand { background:var(--surface-muted); padding:var(--space-inline-control-padding); border-top:1px solid var(--border); }
   .tool-expand--modal { border-top:none; border-radius:12px; }
   .quick-modal-overlay { position:fixed; inset:0; background:var(--surface-overlay-strong); display:flex; align-items:center; justify-content:center; z-index:80; backdrop-filter:blur(8px); padding:var(--space-card-padding); animation:overlayFadeIn var(--motion-sheet-enter) var(--ease-standard); }
+  .viewport-modal-overlay {
+    position:fixed;
+    inset:0;
+    width:100vw;
+    height:100vh;
+    height:100dvh;
+    z-index:260;
+  }
+  .viewport-modal-panel {
+    position:fixed;
+    top:50%;
+    left:50%;
+    transform:translate(-50%, -50%);
+    width:min(100%, calc(100vw - 32px));
+    max-width:calc(100vw - 32px);
+    max-height:calc(100vh - 32px);
+    max-height:calc(100dvh - 32px);
+    overflow:auto;
+    overscroll-behavior:contain;
+  }
   .quick-modal-card { --modal-card-max-width:min(430px, calc(100vw - (2 * var(--space-card-padding)))); --modal-card-max-height:min(82vh, 760px); }
   .quick-modal-overlay--sheet { align-items:flex-end; }
   .quick-modal-card--sheet {


### PR DESCRIPTION
### Motivation
- Fix incorrect popup/modal positioning caused by rendering panels inside scrollable/translated containers so dialogs appear centered in the visible viewport and are not clipped or anchored to cards or charts. 
- Provide a single, reusable modal/backdrop pattern to ensure consistent behavior across History, Progress/Train, Settings, and other info popups. 

### Description
- Add a shared `ViewportModal` portal component that renders into `document.body`, traps Escape-to-close, and delegates backdrop clicks to `onClose` in `src/features/app/ui.jsx`. 
- Replace container-bound overlays with the portal wrapper in `src/features/settings/SettingsScreen.jsx`, `src/features/home/HomeScreen.jsx`, `src/features/history/HistoryFeature.jsx`, and `src/features/train/TrainComponents.jsx` so popups are no longer positioned relative to local layout. 
- Add viewport-fixed CSS rules (`.viewport-modal-overlay` and `.viewport-modal-panel`) to `src/styles/app.css` implementing the required `position: fixed` backdrop and centered panel with `top:50%/left:50%` and `transform: translate(-50%,-50%)`, viewport max sizes, and scroll containment. 
- Keep visual styling and component logic unchanged except for backdrop/panel rendering and click/escape handling via the new portal. 

### Testing
- Built the production bundle with `npm run build`, which completed successfully. 
- Ran the unit test suite with `npm test` (Vitest): 236 tests executed, 235 passed and 1 failed, with the single failure in `tests/historyProgressEditRuntime.test.js` (an existing assertion about `aloneLastWeek` that appears unrelated to modal positioning). 
- Verified the codebase compiles after the JSX changes and CSS update and no runtime build errors remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa0a3d6988332bd293d39d7026625)