### PR TITLE
Cool down global surface palette to warm-neutral greige tokens

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -20,12 +20,12 @@
   --surface-diagnostics-bg: #1f1f1f;
   --text-diagnostics: #e7e7e7;
 
-  --chart-grid-stroke: rgba(74,60,45,0.12);
+  --chart-grid-stroke: rgba(86,95,84,0.12);
   --chart-tooltip-bg: #111827;
   --chart-tooltip-border: rgba(255,255,255,0.08);
   --chart-tooltip-shadow: 0 16px 30px rgba(15,23,42,0.20);
 
-  --progress-track-bg: linear-gradient(90deg, rgba(47,122,87,0.11), rgba(90,71,53,0.08));
+  --progress-track-bg: linear-gradient(90deg, rgba(47,122,87,0.11), rgba(95,104,92,0.08));
   --progress-fill-bg: linear-gradient(90deg, var(--green-dark), var(--green));
   --progress-thumb-bg: radial-gradient(circle at 32% 28%, var(--surf) 0 30%, var(--green-light) 52%, color-mix(in srgb, var(--green) 72%, var(--green-dark)) 100%);
   --progress-thumb-shadow: 0 5px 13px rgba(61,140,96,0.28), 0 0 0 2px rgba(255,255,255,0.92), 0 0 0 4px rgba(61,140,96,0.22);
@@ -35,7 +35,7 @@
   --session-control-idle-shadow: 0 14px 34px rgba(61,140,96,0.34), inset 0 1px 0 rgba(255,255,255,0.34);
   --session-control-running-shadow: 0 16px 36px rgba(61,140,96,0.28), inset 0 1px 0 rgba(255,255,255,0.30);
   --session-control-ring-border: rgba(184,224,199,0.22);
-  --session-control-track-stroke: rgba(74,60,45,0.12);
+  --session-control-track-stroke: rgba(86,95,84,0.12);
   --session-control-content-shade: radial-gradient(circle, rgba(0,0,0,0.30) 0%, rgba(0,0,0,0.14) 45%, rgba(0,0,0,0) 72%);
   --session-control-content-active-bg: var(--surf);
   --session-control-idle-fg: rgba(255,255,255,0.99);
@@ -46,7 +46,7 @@
   --surface-streak-bg: linear-gradient(135deg, var(--green-dark) 0%, var(--green) 100%);
   --surface-streak-shadow: 0 4px 20px rgba(61,140,96,0.30);
   --surface-avatar-accent-shadow: 0 2px 8px rgba(61,140,96,0.16);
-  --surface-ring-inner-bg: radial-gradient(circle at 32% 28%, rgba(255,255,255,0.96) 0%, rgba(253,247,239,0.98) 46%, var(--blue-wash) 100%);
+  --surface-ring-inner-bg: radial-gradient(circle at 32% 28%, rgba(255,255,255,0.96) 0%, rgba(247,248,245,0.98) 46%, var(--blue-wash) 100%);
   --surface-ring-inner-highlight: inset 0 1px 0 rgba(255,255,255,0.9);
 
   --surface-state-bg-default: linear-gradient(180deg, var(--surf) 0%, var(--surface-tint) 100%);

--- a/src/styles/tokens/color.tokens.css
+++ b/src/styles/tokens/color.tokens.css
@@ -1,16 +1,16 @@
 :root {
   /* 2026 Warm Minimalism — primitive palette */
-  --color-bg: #F6F4EE;
-  --color-bg-subtle: #FBF8F3;
-  --color-surface: #FFFCF8;
-  --color-surface-soft: #EFEAE2;
-  --color-surface-raised: #FFFDF9;
-  --color-border: #DCD3C6;
-  --color-border-strong: #C8BCAA;
+  --color-bg: #F4F5F3;
+  --color-bg-subtle: #F7F7F5;
+  --color-surface: #FAFAF8;
+  --color-surface-soft: #ECEDE9;
+  --color-surface-raised: #FDFDFB;
+  --color-border: #DFE1DA;
+  --color-border-strong: #C9CDC3;
 
-  --color-text: #2E2720;
-  --color-text-muted: #6E6255;
-  --color-text-subtle: #938678;
+  --color-text: #2C2C29;
+  --color-text-muted: #666861;
+  --color-text-subtle: #8A8D85;
 
   --color-primary-700: #2F7A57;
   --color-primary-600: #3D8C67;
@@ -18,14 +18,14 @@
 
   --color-info-500: #5B78B4;
   --color-info-600: #4D6AA5;
-  --color-info-50: #F4F1EA;
-  --color-info-100: #E9E1D4;
-  --color-info-200: #DACDBB;
+  --color-info-50: #F1F2EF;
+  --color-info-100: #E6E8E2;
+  --color-info-200: #D8DBD3;
 
   --color-success-600: #2F7A57;
   --color-warning-600: #B87B3E;
   --color-error-600: #C24138;
 
-  --color-warm-accent: #E4D2B8;
-  --color-warm-accent-strong: #D1AA7A;
+  --color-warm-accent: #DED3C1;
+  --color-warm-accent-strong: #C8B299;
 }

--- a/src/styles/tokens/radius-shadow-motion.tokens.css
+++ b/src/styles/tokens/radius-shadow-motion.tokens.css
@@ -13,10 +13,10 @@
   --control-touch-target-lg: 52px;
 
   /* soft depth */
-  --shadow: 0 10px 24px rgba(47,33,20,0.07);
-  --shadow-lg: 0 20px 44px rgba(47,33,20,0.12);
-  --surface-focus-shadow-soft: 0 10px 24px rgba(47,33,20,0.06);
-  --surface-dock-shadow: 0 -10px 30px rgba(47,33,20,0.06);
+  --shadow: 0 10px 24px rgba(33,39,32,0.07);
+  --shadow-lg: 0 20px 44px rgba(33,39,32,0.12);
+  --surface-focus-shadow-soft: 0 10px 24px rgba(33,39,32,0.06);
+  --surface-dock-shadow: 0 -10px 30px rgba(33,39,32,0.06);
   --surface-toast-shadow: 0 8px 32px rgba(36,27,19,0.24);
   --surface-metric-radius: var(--radius-md);
   --surface-metric-shadow: 0 10px 24px rgba(15,23,42,0.05);

--- a/src/styles/tokens/semantic.tokens.css
+++ b/src/styles/tokens/semantic.tokens.css
@@ -17,7 +17,7 @@
   --softBlue: var(--color-info-50);
   --softBlueHover: var(--color-info-100);
   --softBlueBorder: var(--color-info-200);
-  --mutedBlue: #8C7A67;
+  --mutedBlue: #7C8178;
 
   --green: var(--color-primary-200);
   --green-light: #D7E8D2;
@@ -28,7 +28,7 @@
   --blue-dark: var(--primaryBlue);
   --blue-darker: var(--color-info-600);
   --blue-muted: var(--mutedBlue);
-  --blue-wash: rgba(124,103,81,0.08);
+  --blue-wash: rgba(114,123,112,0.08);
 
   --brown: var(--text);
   --brown-mid: var(--text-muted);
@@ -43,13 +43,13 @@
   --warning: var(--amber);
   --info: var(--primaryBlue);
 
-  --surface-muted: #F6F1E8;
-  --surface-tint: #F8F3EB;
+  --surface-muted: #F3F4F0;
+  --surface-tint: #F6F7F3;
   --surface-hero-top: var(--color-bg-subtle);
-  --surface-hero-mid: #F7F0E5;
-  --surface-overlay: rgba(36,27,19,0.30);
-  --surface-overlay-strong: rgba(36,27,19,0.38);
-  --surface-frost: rgba(255,249,241,0.94);
+  --surface-hero-mid: #F1F3EE;
+  --surface-overlay: rgba(30,34,30,0.28);
+  --surface-overlay-strong: rgba(30,34,30,0.36);
+  --surface-frost: rgba(250,251,248,0.94);
 
   --surface-gradient-soft: linear-gradient(180deg, var(--surf) 0%, var(--surface-tint) 100%);
   --surface-gradient-raised: linear-gradient(180deg, var(--surf) 0%, var(--color-surface-raised) 100%);
@@ -73,6 +73,6 @@
   --status-danger-fg: var(--danger);
   --status-attention-bg: rgba(200,120,78,0.12);
   --status-attention-fg: color-mix(in srgb, var(--orange) 56%, var(--danger));
-  --status-neutral-bg: rgba(90,71,53,0.08);
+  --status-neutral-bg: rgba(95,101,92,0.08);
   --status-sync-local-fg: #9a6a19;
 }


### PR DESCRIPTION
### Motivation
- The app background and card palette felt too warm/cream and needed to shift toward a softer, cooler warm-neutral (light greige/stone) while remaining slightly warm and avoiding a cold blue/gray look.  
- Make the change at the global theme/token level so all screens (Train, History, Progress, Settings, modals, bottom nav) inherit a cohesive, modern tone while keeping the green accent untouched.

### Description
- Updated primitive color tokens in `src/styles/tokens/color.tokens.css` to cooler warm-neutral values, including `--color-bg`, `--color-bg-subtle`, `--color-surface`, `--color-surface-soft`, `--color-surface-raised`, `--color-border`, `--color-border-strong`, `--color-text`, `--color-text-muted`, `--color-text-subtle`, `--color-info-50`, `--color-info-100`, `--color-info-200`, `--color-warm-accent`, and `--color-warm-accent-strong`.  
- Tuned semantic surface tokens in `src/styles/tokens/semantic.tokens.css` such as `--mutedBlue`, `--blue-wash`, `--surface-muted`, `--surface-tint`, `--surface-hero-mid`, `--surface-overlay`, `--surface-overlay-strong`, `--surface-frost`, and `--status-neutral-bg` so card/modal/background usages render consistently.  
- Adjusted a few theme aliases and shadow neutrals in `src/styles/theme.css` and `src/styles/tokens/radius-shadow-motion.tokens.css` (e.g. `--chart-grid-stroke`, `--progress-track-bg`, `--session-control-track-stroke`, `--surface-ring-inner-bg`, `--shadow`/`--shadow-lg`) so progress/session visuals and depth match the refreshed base palette.  
- No layout, spacing, component structure, or session/business logic was modified; this PR is styling/token-only and preserves the existing green accent family.

### Testing
- Ran `npm run build` and the production build completed successfully.  
- Ran `npm run test` where the suite reported `235 passed` and `1 failed` (failing test: `tests/historyProgressEditRuntime.test.js` — assertion expected `97` but received `0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb745bc82c83329702c70c2058f6a7)