### PR TITLE
Redesign stress rating modal to minimal list-style (Variant 1)

### DIFF
--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -147,7 +147,7 @@ export function SessionRatingPanel({
           </div>
           <div className="result-list" role="radiogroup" aria-label="Stress rating">
             <button
-              className={`result-option ${sessionOutcome === "none" ? "is-selected" : ""}`.trim()}
+              className={`result-option result-option--none ${sessionOutcome === "none" ? "is-selected" : ""}`.trim()}
               onClick={() => { setSessionOutcome("none"); recordResult("none"); }}
               role="radio"
               aria-checked={sessionOutcome === "none"}
@@ -159,7 +159,7 @@ export function SessionRatingPanel({
               </span>
             </button>
             <button
-              className={`result-option ${sessionOutcome === "subtle" ? "is-selected" : ""}`.trim()}
+              className={`result-option result-option--subtle ${sessionOutcome === "subtle" ? "is-selected" : ""}`.trim()}
               onClick={() => setSessionOutcome("subtle")}
               role="radio"
               aria-checked={sessionOutcome === "subtle"}
@@ -171,7 +171,7 @@ export function SessionRatingPanel({
               </span>
             </button>
             <button
-              className={`result-option ${sessionOutcome === "active" ? "is-selected" : ""}`.trim()}
+              className={`result-option result-option--active ${sessionOutcome === "active" ? "is-selected" : ""}`.trim()}
               onClick={() => setSessionOutcome("active")}
               role="radio"
               aria-checked={sessionOutcome === "active"}
@@ -183,7 +183,7 @@ export function SessionRatingPanel({
               </span>
             </button>
             <button
-              className={`result-option ${sessionOutcome === "severe" ? "is-selected" : ""}`.trim()}
+              className={`result-option result-option--severe ${sessionOutcome === "severe" ? "is-selected" : ""}`.trim()}
               onClick={() => setSessionOutcome("severe")}
               role="radio"
               aria-checked={sessionOutcome === "severe"}

--- a/src/features/train/TrainComponents.jsx
+++ b/src/features/train/TrainComponents.jsx
@@ -133,7 +133,6 @@ export function SessionRatingPanel({
   setDistressTypeDraft,
   onCancel,
   fmt,
-  Img,
   distressTypes,
 }) {
   if (phase !== "rating") return null;
@@ -146,25 +145,57 @@ export function SessionRatingPanel({
           <div className="rating-sub">
             {fmt(finalElapsed)} session — how did {name} handle it?
           </div>
-          <div className="result-grid">
-            <button className="btn-result btn-none" onClick={() => { setSessionOutcome("none"); recordResult("none"); }}>
-              <Img src="result-calm.png" size={36} alt="No distress"/>
-              <div><div>No distress</div><div className="result-desc">{name} was completely calm</div></div>
+          <div className="result-list" role="radiogroup" aria-label="Stress rating">
+            <button
+              className={`result-option ${sessionOutcome === "none" ? "is-selected" : ""}`.trim()}
+              onClick={() => { setSessionOutcome("none"); recordResult("none"); }}
+              role="radio"
+              aria-checked={sessionOutcome === "none"}
+            >
+              <span className="result-option__radio" aria-hidden="true">{sessionOutcome === "none" ? "✓" : ""}</span>
+              <span className="result-option__text">
+                <span className="result-option__title">No distress</span>
+                <span className="result-option__subtitle">{name} was completely calm</span>
+              </span>
             </button>
-            <button className="btn-result btn-mild" onClick={() => setSessionOutcome("subtle")}>
-              <Img src="result-mild.png" size={36} alt="Subtle stress"/>
-              <div><div>Subtle stress</div><div className="result-desc">Mild/passive signs (restless, lip licking, etc.)</div></div>
+            <button
+              className={`result-option ${sessionOutcome === "subtle" ? "is-selected" : ""}`.trim()}
+              onClick={() => setSessionOutcome("subtle")}
+              role="radio"
+              aria-checked={sessionOutcome === "subtle"}
+            >
+              <span className="result-option__radio" aria-hidden="true">{sessionOutcome === "subtle" ? "✓" : ""}</span>
+              <span className="result-option__text">
+                <span className="result-option__title">Subtle stress</span>
+                <span className="result-option__subtitle">Mild/passive signs (restless, lip licking, etc.)</span>
+              </span>
             </button>
-            <button className="btn-result btn-strong" onClick={() => setSessionOutcome("active")}>
-              <Img src="result-strong.png" size={36} alt="Active distress"/>
-              <div><div>Active distress</div><div className="result-desc">Barking, pacing, unable to settle</div></div>
+            <button
+              className={`result-option ${sessionOutcome === "active" ? "is-selected" : ""}`.trim()}
+              onClick={() => setSessionOutcome("active")}
+              role="radio"
+              aria-checked={sessionOutcome === "active"}
+            >
+              <span className="result-option__radio" aria-hidden="true">{sessionOutcome === "active" ? "✓" : ""}</span>
+              <span className="result-option__text">
+                <span className="result-option__title">Active distress</span>
+                <span className="result-option__subtitle">Barking, pacing, unable to settle</span>
+              </span>
             </button>
-            <button className="btn-result btn-severe" onClick={() => setSessionOutcome("severe")}>
-              <Img src="result-strong.png" size={36} alt="Severe distress"/>
-              <div><div>Severe distress</div><div className="result-desc">Panic, escape attempt, major breakdown</div></div>
+            <button
+              className={`result-option ${sessionOutcome === "severe" ? "is-selected" : ""}`.trim()}
+              onClick={() => setSessionOutcome("severe")}
+              role="radio"
+              aria-checked={sessionOutcome === "severe"}
+            >
+              <span className="result-option__radio" aria-hidden="true">{sessionOutcome === "severe" ? "✓" : ""}</span>
+              <span className="result-option__text">
+                <span className="result-option__title">Severe distress</span>
+                <span className="result-option__subtitle">Panic, escape attempt, major breakdown</span>
+              </span>
             </button>
           </div>
-          <button className="button-base button-ghost button--md button--block rating-inline-cancel" onClick={onCancel}>
+          <button className="button-base button-ghost button--md rating-inline-cancel" onClick={onCancel}>
             Cancel
           </button>
           {sessionOutcome && sessionOutcome !== "none" && (

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1376,6 +1376,11 @@
   .rating-sub   { font-size:var(--type-body-size); color:var(--text-muted); text-align:center; margin-bottom:var(--space-2); line-height:var(--type-body-line); letter-spacing:var(--type-body-track); font-weight:var(--type-body-weight); }
   .result-list { display:flex; flex-direction:column; gap:14px; margin-bottom:var(--space-1); }
   .result-option {
+    --result-accent: 60, 140, 100;
+    --result-accent-solid: var(--green-dark);
+    --result-selected-tint: 0.08;
+    --result-title-tint: 56%;
+    --result-border-opacity: 0.28;
     width:100%;
     padding:10px 12px;
     border:0;
@@ -1394,8 +1399,8 @@
     width:18px;
     height:18px;
     border-radius:999px;
-    border:1.5px solid color-mix(in srgb, var(--text-muted) 65%, var(--border));
-    color:var(--green-dark);
+    border:1.5px solid rgba(var(--result-accent), var(--result-border-opacity));
+    color:var(--result-accent-solid);
     font-size:11px;
     font-weight:700;
     line-height:1;
@@ -1416,7 +1421,7 @@
     line-height:var(--type-body-line);
     letter-spacing:var(--type-body-track);
     font-weight:var(--type-button-weight);
-    color:var(--brown);
+    color:color-mix(in srgb, rgb(var(--result-accent)) var(--result-title-tint), var(--brown));
   }
   .result-option__subtitle {
     font-size:var(--type-helper-text-size);
@@ -1426,22 +1431,50 @@
     color:var(--text-muted);
   }
   .result-option.is-selected {
-    background:rgba(60, 140, 100, 0.08);
-    box-shadow:inset 0 0 0 1px rgba(60, 140, 100, 0.2);
+    background:rgba(var(--result-accent), var(--result-selected-tint));
+    box-shadow:inset 0 0 0 1px rgba(var(--result-accent), 0.24);
   }
   .result-option.is-selected .result-option__radio {
-    border-color:var(--green-dark);
-    background:var(--green-dark);
+    border-color:var(--result-accent-solid);
+    background:var(--result-accent-solid);
     color:#fff;
   }
   .result-option.is-selected .result-option__title {
-    color:color-mix(in srgb, var(--green-dark) 78%, var(--brown));
+    color:color-mix(in srgb, rgb(var(--result-accent)) 72%, var(--brown));
   }
   .result-option:hover {
     background:rgba(0, 0, 0, 0.03);
   }
   .result-option.is-selected:hover {
-    background:rgba(60, 140, 100, 0.1);
+    background:rgba(var(--result-accent), calc(var(--result-selected-tint) + 0.02));
+  }
+  .result-option--none {
+    --result-accent: 60, 140, 100;
+    --result-accent-solid: rgb(60, 140, 100);
+    --result-selected-tint: 0.1;
+    --result-title-tint: 62%;
+    --result-border-opacity: 0.34;
+  }
+  .result-option--subtle {
+    --result-accent: 170, 142, 78;
+    --result-accent-solid: rgb(170, 142, 78);
+    --result-selected-tint: 0.06;
+    --result-title-tint: 32%;
+    --result-border-opacity: 0.2;
+  }
+  .result-option--active {
+    --result-accent: 181, 124, 76;
+    --result-accent-solid: rgb(181, 124, 76);
+    --result-selected-tint: 0.08;
+    --result-title-tint: 46%;
+    --result-border-opacity: 0.24;
+  }
+  .result-option--severe {
+    --result-accent: 163, 92, 92;
+    --result-accent-solid: rgb(163, 92, 92);
+    --result-selected-tint: 0.07;
+    --result-title-tint: 42%;
+    --result-border-opacity: 0.22;
   }
   .rating-inline-cancel {
     margin:var(--space-1) auto 0;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1383,11 +1383,12 @@
     background:transparent;
     color:var(--brown);
     cursor:pointer;
-    transition:background-color var(--motion-base) var(--ease-out);
+    transition:background-color var(--motion-base) var(--ease-out), box-shadow var(--motion-base) var(--ease-out);
     display:flex;
     align-items:flex-start;
     gap:12px;
     text-align:left;
+    box-shadow:inset 0 -1px 0 color-mix(in srgb, var(--border) 52%, transparent);
   }
   .result-option__radio {
     width:18px;
@@ -1404,6 +1405,7 @@
     flex:0 0 auto;
     margin-top:2px;
     background:transparent;
+    transition:background-color var(--motion-base) var(--ease-out), border-color var(--motion-base) var(--ease-out), color var(--motion-base) var(--ease-out);
   }
   .result-option__text {
     display:grid;
@@ -1424,14 +1426,22 @@
     color:var(--text-muted);
   }
   .result-option.is-selected {
-    background:color-mix(in srgb, var(--green-dark) 8%, transparent);
+    background:rgba(60, 140, 100, 0.08);
+    box-shadow:inset 0 0 0 1px rgba(60, 140, 100, 0.2);
   }
   .result-option.is-selected .result-option__radio {
-    border-color:color-mix(in srgb, var(--green-dark) 48%, var(--border));
-    background:color-mix(in srgb, var(--green-dark) 14%, var(--surf));
+    border-color:var(--green-dark);
+    background:var(--green-dark);
+    color:#fff;
+  }
+  .result-option.is-selected .result-option__title {
+    color:color-mix(in srgb, var(--green-dark) 78%, var(--brown));
   }
   .result-option:hover {
-    background:color-mix(in srgb, var(--surf) 85%, transparent);
+    background:rgba(0, 0, 0, 0.03);
+  }
+  .result-option.is-selected:hover {
+    background:rgba(60, 140, 100, 0.1);
   }
   .rating-inline-cancel {
     margin:var(--space-1) auto 0;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1378,14 +1378,16 @@
   .result-option {
     --result-accent: 60, 140, 100;
     --result-accent-solid: var(--green-dark);
-    --result-selected-tint: 0.08;
-    --result-title-tint: 56%;
-    --result-border-opacity: 0.28;
+    --result-unselected-tint: 0.05;
+    --result-selected-tint: 0.1;
+    --result-title-tint: 64%;
+    --result-border-opacity: 0.55;
+    --result-ring-opacity: 0.18;
     width:100%;
     padding:10px 12px;
     border:0;
     border-radius:var(--radius-sm);
-    background:transparent;
+    background:rgba(var(--result-accent), var(--result-unselected-tint));
     color:var(--brown);
     cursor:pointer;
     transition:background-color var(--motion-base) var(--ease-out), box-shadow var(--motion-base) var(--ease-out);
@@ -1393,7 +1395,7 @@
     align-items:flex-start;
     gap:12px;
     text-align:left;
-    box-shadow:inset 0 -1px 0 color-mix(in srgb, var(--border) 52%, transparent);
+    box-shadow:inset 0 0 0 1px rgba(var(--result-accent), var(--result-ring-opacity));
   }
   .result-option__radio {
     width:18px;
@@ -1432,7 +1434,7 @@
   }
   .result-option.is-selected {
     background:rgba(var(--result-accent), var(--result-selected-tint));
-    box-shadow:inset 0 0 0 1px rgba(var(--result-accent), 0.24);
+    box-shadow:inset 0 0 0 1px rgba(var(--result-accent), 0.38);
   }
   .result-option.is-selected .result-option__radio {
     border-color:var(--result-accent-solid);
@@ -1443,7 +1445,7 @@
     color:color-mix(in srgb, rgb(var(--result-accent)) 72%, var(--brown));
   }
   .result-option:hover {
-    background:rgba(0, 0, 0, 0.03);
+    background:rgba(var(--result-accent), calc(var(--result-unselected-tint) + 0.02));
   }
   .result-option.is-selected:hover {
     background:rgba(var(--result-accent), calc(var(--result-selected-tint) + 0.02));
@@ -1451,30 +1453,38 @@
   .result-option--none {
     --result-accent: 60, 140, 100;
     --result-accent-solid: rgb(60, 140, 100);
-    --result-selected-tint: 0.1;
-    --result-title-tint: 62%;
-    --result-border-opacity: 0.34;
+    --result-unselected-tint: 0.08;
+    --result-selected-tint: 0.14;
+    --result-title-tint: 76%;
+    --result-border-opacity: 0.6;
+    --result-ring-opacity: 0.2;
   }
   .result-option--subtle {
     --result-accent: 170, 142, 78;
     --result-accent-solid: rgb(170, 142, 78);
-    --result-selected-tint: 0.06;
-    --result-title-tint: 32%;
-    --result-border-opacity: 0.2;
+    --result-unselected-tint: 0.055;
+    --result-selected-tint: 0.095;
+    --result-title-tint: 58%;
+    --result-border-opacity: 0.48;
+    --result-ring-opacity: 0.17;
   }
   .result-option--active {
     --result-accent: 181, 124, 76;
     --result-accent-solid: rgb(181, 124, 76);
-    --result-selected-tint: 0.08;
-    --result-title-tint: 46%;
-    --result-border-opacity: 0.24;
+    --result-unselected-tint: 0.06;
+    --result-selected-tint: 0.11;
+    --result-title-tint: 62%;
+    --result-border-opacity: 0.52;
+    --result-ring-opacity: 0.18;
   }
   .result-option--severe {
     --result-accent: 163, 92, 92;
     --result-accent-solid: rgb(163, 92, 92);
-    --result-selected-tint: 0.07;
-    --result-title-tint: 42%;
-    --result-border-opacity: 0.22;
+    --result-unselected-tint: 0.055;
+    --result-selected-tint: 0.1;
+    --result-title-tint: 60%;
+    --result-border-opacity: 0.5;
+    --result-ring-opacity: 0.17;
   }
   .rating-inline-cancel {
     margin:var(--space-1) auto 0;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1374,21 +1374,74 @@
   }
   .rating-title { font-size:var(--type-section-heading-size); font-weight:var(--type-section-heading-weight); line-height:var(--type-section-heading-line); letter-spacing:var(--type-section-heading-track); color:var(--brown); text-align:center; margin-bottom:4px; }
   .rating-sub   { font-size:var(--type-body-size); color:var(--text-muted); text-align:center; margin-bottom:var(--space-2); line-height:var(--type-body-line); letter-spacing:var(--type-body-track); font-weight:var(--type-body-weight); }
-  .result-grid { display:flex; flex-direction:column; gap:var(--space-control-gap); margin-bottom:var(--space-1); }
-  .btn-result { width:100%; padding:var(--space-field-padding-default); border:1px solid transparent; border-radius:var(--radius-sm); font-size:var(--type-button-size); font-weight:var(--type-button-weight); line-height:var(--type-button-line); cursor:pointer; transition:transform 0.15s, border-color var(--motion-base) var(--ease-out), background-color var(--motion-base) var(--ease-out); display:flex; align-items:center; gap:var(--space-2); text-align:left; letter-spacing:var(--type-button-track); }
-  .btn-result .result-desc { font-size:var(--type-helper-text-size); line-height:var(--type-helper-text-line); font-weight:var(--type-helper-text-weight); letter-spacing:var(--type-helper-text-track); opacity:0.82; margin-top:2px; }
-  .btn-none   { background:var(--status-success-bg); color:var(--green-dark); border-color:color-mix(in srgb, var(--green-dark) 22%, var(--border)); }
-  .btn-mild   { background:var(--status-warning-bg); color:var(--amber); border-color:color-mix(in srgb, var(--amber) 24%, var(--border)); }
-  .btn-strong { background:var(--status-attention-bg); color:var(--status-attention-fg); border-color:color-mix(in srgb, var(--status-attention-fg) 24%, var(--border)); }
-  .btn-severe { background:var(--status-danger-bg); color:var(--status-danger-fg); border-color:color-mix(in srgb, var(--status-danger-fg) 24%, var(--border)); }
-  .btn-result:hover { transform:translateY(-2px); }
-  .rating-inline-cancel {
-    margin-top:var(--space-1);
-    min-height:44px;
+  .result-list { display:flex; flex-direction:column; gap:14px; margin-bottom:var(--space-1); }
+  .result-option {
     width:100%;
-    border-color:color-mix(in srgb, var(--border) 96%, var(--surf));
+    padding:10px 12px;
+    border:0;
+    border-radius:var(--radius-sm);
+    background:transparent;
     color:var(--brown);
-    background:color-mix(in srgb, var(--surf) 92%, transparent);
+    cursor:pointer;
+    transition:background-color var(--motion-base) var(--ease-out);
+    display:flex;
+    align-items:flex-start;
+    gap:12px;
+    text-align:left;
+  }
+  .result-option__radio {
+    width:18px;
+    height:18px;
+    border-radius:999px;
+    border:1.5px solid color-mix(in srgb, var(--text-muted) 65%, var(--border));
+    color:var(--green-dark);
+    font-size:11px;
+    font-weight:700;
+    line-height:1;
+    display:inline-flex;
+    align-items:center;
+    justify-content:center;
+    flex:0 0 auto;
+    margin-top:2px;
+    background:transparent;
+  }
+  .result-option__text {
+    display:grid;
+    gap:2px;
+  }
+  .result-option__title {
+    font-size:var(--type-body-size);
+    line-height:var(--type-body-line);
+    letter-spacing:var(--type-body-track);
+    font-weight:var(--type-button-weight);
+    color:var(--brown);
+  }
+  .result-option__subtitle {
+    font-size:var(--type-helper-text-size);
+    line-height:var(--type-helper-text-line);
+    font-weight:var(--type-helper-text-weight);
+    letter-spacing:var(--type-helper-text-track);
+    color:var(--text-muted);
+  }
+  .result-option.is-selected {
+    background:color-mix(in srgb, var(--green-dark) 8%, transparent);
+  }
+  .result-option.is-selected .result-option__radio {
+    border-color:color-mix(in srgb, var(--green-dark) 48%, var(--border));
+    background:color-mix(in srgb, var(--green-dark) 14%, var(--surf));
+  }
+  .result-option:hover {
+    background:color-mix(in srgb, var(--surf) 85%, transparent);
+  }
+  .rating-inline-cancel {
+    margin:var(--space-1) auto 0;
+    min-height:32px;
+    width:auto;
+    border:0;
+    color:var(--text-muted);
+    background:transparent;
+    padding:4px 10px;
+    font-size:var(--type-secondary-size);
   }
   .rating-adapt-note {
     margin:var(--space-control-gap) 0 var(--space-1);
@@ -1416,12 +1469,12 @@
     .rating-sub {
       margin-bottom:var(--space-1);
     }
-    .result-grid {
+    .result-list {
       gap:var(--space-density-compact-control-gap);
       margin-bottom:0;
     }
-    .btn-result {
-      padding:var(--space-field-padding-compact);
+    .result-option {
+      padding:8px 10px;
     }
   }
   .field-label { font-size:var(--type-secondary-size); color:var(--brown); font-weight:var(--type-secondary-weight); line-height:var(--type-secondary-line); }


### PR DESCRIPTION
### Motivation
- Replace the current colored card-style stress rating options with a clean, minimal list that reads as a natural extension of the Train screen design language. 
- Remove heavy icons and colored cards while preserving existing selection behavior and accessibility semantics. 

### Description
- Replaced the card grid with a vertical `radiogroup` list in `SessionRatingPanel` and removed the large option `Img` usage, rendering each option as a `.result-option` row with a small circular selector and text block. 
- Added new styles in `src/styles/app.css` for `.result-list`, `.result-option`, `.result-option__radio`, `.result-option__text`, `.result-option__title`, `.result-option__subtitle` and a subtle selected state using a low-opacity green tint. 
- Switched the cancel control from a full-width rounded ghost button to a centered low-emphasis text button (`.rating-inline-cancel`) to match the minimal treatment. 
- Preserved all existing behavior and logic (including immediate `recordResult("none")` for No distress and the existing outcome-details/save flow for stressed outcomes). 

### Testing
- Built the production bundle with `npm run build` and the build completed successfully. 
- Ran the inline-style hygiene check with `npm run check:inline-styles` which reported failing inline-style usages that are pre-existing elsewhere in the codebase (unrelated to this modal change). 
- No unit tests were changed; manual verification of modal JSX and styles was performed locally via the build output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb852ce5b48332ae6dee3a6813672e)