### PR TITLE
Standardize vertical and horizontal text centering in buttons

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1325,7 +1325,7 @@
   .walk-type-title { font-size:var(--type-panel-title-size); line-height:var(--type-panel-title-line); letter-spacing:var(--type-panel-title-track); font-weight:var(--type-panel-title-weight); color:var(--brown); margin-bottom:var(--space-card-row-gap); }
   .walk-type-sub { font-size:var(--type-helper-text-size); line-height:var(--type-helper-text-line); font-weight:var(--type-helper-text-weight); letter-spacing:var(--type-helper-text-track); color:var(--text-muted); margin-bottom:var(--space-control-gap); }
   .walk-type-grid { display:grid; gap:var(--space-card-row-gap); }
-  .walk-type-option { width:100%; min-height:44px; display:flex; align-items:center; text-align:left; border:1.5px solid var(--border); border-radius:var(--radius-sm); padding:var(--space-inline-control-padding); text-transform:capitalize; color:var(--brown); background:var(--surf); cursor:pointer; transition:transform var(--motion-press) var(--ease-out), color var(--motion-base) var(--ease-out), background var(--motion-base) var(--ease-out), border-color var(--motion-base) var(--ease-out); }
+  .walk-type-option { width:100%; min-height:44px; display:inline-flex; align-items:center; justify-content:center; text-align:center; border:1.5px solid var(--border); border-radius:var(--radius-sm); padding:var(--space-inline-control-padding); text-transform:capitalize; color:var(--brown); background:var(--surf); cursor:pointer; transition:transform var(--motion-press) var(--ease-out), color var(--motion-base) var(--ease-out), background var(--motion-base) var(--ease-out), border-color var(--motion-base) var(--ease-out); }
   .walk-type-option:hover { border-color:var(--mutedBlue); background:var(--softBlue); color:var(--primaryBlue); }
   .walk-type-actions { display:flex; justify-content:flex-end; gap:var(--space-control-gap); margin-top:var(--space-modal-footer-gap); }
   .walk-timer-left .walk-timer-elapsed { font-size:var(--type-metric-lg-size); font-weight:var(--type-metric-lg-weight); color:var(--green-dark); line-height:var(--type-metric-lg-line); letter-spacing:var(--type-metric-lg-track); font-variant-numeric:tabular-nums; }
@@ -2119,7 +2119,7 @@
 
   .share-steps { font-size:var(--type-body-size); color:var(--text-muted); line-height:var(--type-body-line); letter-spacing:var(--type-body-track); font-weight:var(--type-body-weight); padding-left:var(--space-card-padding); font-family:var(--font-prose); }
   .share-steps li { margin-bottom:var(--space-card-row-gap); }
-  .settings-btn { width:100%; justify-content:flex-start; text-align:left; white-space:normal; margin-bottom:0; transition:transform var(--motion-press) var(--ease-out), color var(--motion-base) var(--ease-out), background-color var(--motion-base) var(--ease-out), border-color var(--motion-base) var(--ease-out), box-shadow var(--motion-base) var(--ease-out); }
+  .settings-btn { width:100%; justify-content:center; text-align:center; white-space:normal; margin-bottom:0; transition:transform var(--motion-press) var(--ease-out), color var(--motion-base) var(--ease-out), background-color var(--motion-base) var(--ease-out), border-color var(--motion-base) var(--ease-out), box-shadow var(--motion-base) var(--ease-out); }
   .settings-btn + .settings-btn { margin-top:var(--space-control-gap); }
   .settings-btn--icon { gap:var(--space-control-gap); }
   .settings-btn__icon { display:inline-flex; align-items:center; justify-content:center; color:inherit; inline-size:18px; block-size:18px; }

--- a/src/styles/shared.css
+++ b/src/styles/shared.css
@@ -756,15 +756,26 @@
 .settings-btn {
   min-height: var(--control-touch-target-md);
   padding-block: 12px;
-  justify-content: flex-start;
-  text-align: left;
+  justify-content: center;
+  text-align: center;
   box-shadow: var(--shadow);
+}
+
+.settings-btn__label {
+  text-align: center;
 }
 
 .settings-btn.button-danger {
   box-shadow: var(--shadow);
 }
 
+
+:is(.walk-cancel-btn, .walk-end-btn, .button-base, .shared-button, .settings-inline-btn, .settings-btn, .copy-btn, .diag-run-btn, .pat-edit-btn, .settings-collapsible-toggle, .history-delete-confirm, .btn-save-outcome, .btn-result, .quick-action-btn, .walk-type-option, .btn-pat, .modal-close-btn, .ring-sub-btn, .tab-btn, .notif-toggle, .session-end-btn, .session-cancel-btn, .es-cta, .ds-join-btn, .ob-back-btn, .ob-btn-next, .ws-secondary, .ws-cta, .clear-btn) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
 
 :is(.walk-cancel-btn, .settings-inline-btn, .settings-btn, .copy-btn, .diag-run-btn, .pat-edit-btn, .settings-collapsible-toggle, .history-delete-confirm, .btn-save-outcome, .btn-result, .quick-action-btn, .walk-type-option, .btn-pat, .modal-close-btn, .ring-sub-btn, .tab-btn, .notif-toggle, .session-end-btn, .session-cancel-btn, .es-cta):active:not(:disabled) {
   transform: scale(0.96);


### PR DESCRIPTION
### Motivation
- Buttons and button-like controls were inconsistent: some used `display:flex` + left-aligned text or nested label offsets which caused visual mis-centering, especially for multi-line and icon+text cases.
- The goal is a single, reusable centering approach that guarantees vertical and horizontal centering without changing typography tokens, spacing, or overall layout.

### Description
- Applied a single centering rule to button families by adding `display: inline-flex; align-items: center; justify-content: center; text-align: center;` to a shared selector covering primary/secondary/ghost/modal/icon+text and other button-like classes.
- Updated specific components to follow the shared approach: replaced `.walk-type-option` `display:flex` + `text-align:left` with `display:inline-flex` and centered alignment, and changed `.settings-btn` from left-aligned to centered with an explicit `.settings-btn__label` `text-align: center` to avoid nested offset.
- Changed files: `src/styles/shared.css` and `src/styles/app.css` (centering selector and targeted button rules updated).
- Removed conflicting alignment overrides: replaced `justify-content: flex-start`/`text-align: left` and plain `display:flex` on button-like selectors so all buttons use the same inline-flex centering technique.

### Testing
- Ran the production build with `npm run build` (vite build) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9eeaaa94c83329f8269158fa24591)